### PR TITLE
Remove the OpenAPI version check at importer instantiation time

### DIFF
--- a/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -71,7 +71,7 @@ public class OpenAPIImporter implements MockRepositoryImporter {
                isYaml = false;
                break;
             }
-            else if (line.startsWith("---") || line.startsWith("openapi: 3")) {
+            else if (line.startsWith("---") || line.matches("(openapi: ["']?3.*))") {
                isYaml = true;
                break;
             }

--- a/src/test/resources/io/github/microcks/util/openapi/cars-openapi-with-json.yaml
+++ b/src/test/resources/io/github/microcks/util/openapi/cars-openapi-with-json.yaml
@@ -85,4 +85,4 @@ components:
       value: laurent
 tags:
 - name: car
-  description:
+  description: Car Ownership


### PR DESCRIPTION
Resolves #132 

The OpenAPI version is checked before the OpenAPIImporter is instantiated, so it is known to be valid. Additionally, the presence of quotations in the spec causes uploads to report successfully despite the absence of a mocked server. It looks like this is probably due to a file pointer overrun where isYaml remains null, though this has not been verified.