### PR TITLE
Spec body should also use UTF8 encoding

### DIFF
--- a/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -81,7 +81,7 @@ public class OpenAPIImporter implements MockRepositoryImporter {
 
          // Read spec bytes.
          byte[] bytes = Files.readAllBytes(Paths.get(specificationFilePath));
-         specContent = new String(bytes);
+         specContent = new String(bytes, Charset.forName("UTF-8"));
          // Convert them to Node using Jackson object mapper.
          ObjectMapper mapper = null;
          if (isYaml) {


### PR DESCRIPTION
Currently, when saving spec body, no encoding was specified. So the spec may be saved in wrong encoding.