### PR TITLE
Handle empty bodies in postman collection + default status code

### DIFF
--- a/src/main/java/io/github/microcks/util/postman/PostmanCollectionImporter.java
+++ b/src/main/java/io/github/microcks/util/postman/PostmanCollectionImporter.java
@@ -253,9 +253,9 @@ public class PostmanCollectionImporter implements MockRepositoryImporter {
       response.setName(responseNode.path("name").asText());
 
       if (isV2Collection) {
-         response.setStatus(responseNode.path("code").asText());
+         response.setStatus(responseNode.path("code").asText("200"));
          response.setHeaders(buildHeaders(responseNode.path("header")));
-         response.setContent(responseNode.path("body").asText());
+         response.setContent(responseNode.path("body").asText(""));
       } else {
          response.setStatus(responseNode.path("responseCode").path("code").asText());
          response.setHeaders(buildHeaders(responseNode.path("headers")));


### PR DESCRIPTION
This PR fixes two things:
- #147: Postman examples with empty response body generates a mock that returns null
- Postman examples without http status (the author implied "200 OK" ?) generate a deficient mock

## Postman examples with empty response body

Before:

```raw
$ curl -D - -XPOST http://localhost:8080/rest/Test/1.0/test
HTTP/1.1 200 
X-Application-Context: application
Content-Type: text/plain;charset=UTF-8
Content-Length: 4
Date: Wed, 08 May 2019 11:08:12 GMT

null
```

After:
```raw
$ curl -D - -XPOST http://localhost:8080/rest/Test/1.0/test
HTTP/1.1 200 
X-Application-Context: application
Content-Type: text/plain;charset=UTF-8
Content-Length: 4
Date: Wed, 08 May 2019 11:08:12 GMT

```

## Postman examples without http status

Before:

```raw
$ curl -D - http://localhost:8080/rest/Test/1.0/test
HTTP/1.1 500 
X-Application-Context: application
Content-Type: application/json;charset=UTF-8
Transfer-Encoding: chunked
Date: Wed, 08 May 2019 16:42:10 GMT
Connection: close

{"timestamp":1557333730902,"status":500,"error":"Internal Server Error","exception":"java.lang.NumberFormatException","message":"For input string: \"\"","path":"/rest/AirFrance+Connect/1.0/test"}
```

After:

```
curl -D - http://localhost:8080/rest/Test/1.0/test
HTTP/1.1 200 
X-Application-Context: application
Content-Type: text/plain;charset=UTF-8
Content-Length: 14
Date: Wed, 08 May 2019 16:39:56 GMT

This is a test
```