### PR TITLE
Update psql openshift IS to postgresql:9.6

### DIFF
--- a/install/openshift/openshift-ephemeral-full-template.yml
+++ b/install/openshift/openshift-ephemeral-full-template.yml
@@ -882,7 +882,7 @@ objects:
         - keycloak-postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:9.6
           namespace: "${NAMESPACE}"
     - type: ConfigChange
     replicas: 1

--- a/install/openshift/openshift-persistent-full-template-https.yml
+++ b/install/openshift/openshift-persistent-full-template-https.yml
@@ -909,7 +909,7 @@ objects:
         - keycloak-postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:9.6
           namespace: "${NAMESPACE}"
     - type: ConfigChange
     replicas: 1

--- a/install/openshift/openshift-persistent-full-template.yml
+++ b/install/openshift/openshift-persistent-full-template.yml
@@ -900,7 +900,7 @@ objects:
         - keycloak-postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: postgresql:9.6
           namespace: "${NAMESPACE}"
     - type: ConfigChange
     replicas: 1


### PR DESCRIPTION
This due to change in support, for info see:
https://github.com/sclorg/postgresql-container

Related to #169 