### PR TITLE
use external value if available, otherwise use same

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/KeycloakConfigController.java
+++ b/webapp/src/main/java/io/github/microcks/web/KeycloakConfigController.java
@@ -40,10 +40,10 @@ public class KeycloakConfigController {
    private static Logger log = LoggerFactory.getLogger(KeycloakConfigController.class);
 
 
-   @Value("${keycloak.auth-server-url}")
+   @Value("${external_url}")
    private final String keycloakServerUrl = null;
 
-   @Value("${keycloak.realm}")
+   @Value("${external_realm}")
    private final String keycloakRealmName = null;
 
    @RequestMapping(value = "/config", method = RequestMethod.GET)

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -22,6 +22,9 @@ keycloak.use-resource-role-mappings=true
 keycloak.bearer-only=true
 keycloak.ssl-required=external
 
+external_url=${KEYCLOAK_EXTERNAL_URL:${keycloak.auth-server-url}}
+external_realm=${KEYCLOAK_EXTERNAL_REALM:${keycloak.realm}}
+
 keycloak.security-constraints[0].authRoles[0]=admin
 keycloak.security-constraints[0].authRoles[1]=manager
 keycloak.security-constraints[0].authRoles[2]=user


### PR DESCRIPTION
should fix #119 

Change the `/api/keycloak` service to use the `external_url` configuration instead of the main keycloak if `KEYCLOAL_EXTERNAL_URL` is set. If not, then fallback to the same config as the backend services.