### PR TITLE
Initial support for running Microcks with Podman

### DIFF
--- a/install/podman-compose/.gitignore
+++ b/install/podman-compose/.gitignore
@@ -1,0 +1,2 @@
+microcks-data
+microcks.yml

--- a/install/podman-compose/config
+++ b/install/podman-compose/config
@@ -1,0 +1,1 @@
+../docker-compose/config

--- a/install/podman-compose/keycloak-realm/microcks-realm-sample.json
+++ b/install/podman-compose/keycloak-realm/microcks-realm-sample.json
@@ -1,0 +1,128 @@
+{
+  "id": "microcks",
+  "realm": "microcks",
+  "displayName": "Microcks",
+  "notBefore": 0,
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "offlineSessionIdleTimeout": 2592000,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": false,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "users" : [
+    {
+      "username" : "admin",
+      "enabled": true,
+      "credentials" : [
+        { "type" : "password",
+          "value" : "123" }
+      ],
+      "requiredActions": [
+        "UPDATE_PASSWORD"
+      ],
+      "realmRoles": [],
+      "applicationRoles": {
+        "realm-management": [ "realm-admin" ],
+        "account": [ "manage-account" ],
+        "microcks-app": [ "admin "]
+      }
+    }
+  ],
+  "roles": {
+    "realm": [],
+    "client": {
+      "microcks-app": [
+        {
+          "name": "user",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "microcks"
+        },
+        {
+          "name": "admin",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "microcks"
+        },
+        {
+          "name": "manager",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "microcks"
+        }
+      ]
+    }
+  },
+  "defaultRoles": [],
+  "requiredCredentials": [ "password" ],
+  "scopeMappings": [],
+  "clientScopeMappings": {
+    "microcks-app": [
+      {
+        "client": "microcks-app-js",
+        "roles": [
+          "manager",
+          "admin",
+          "user"
+        ]
+      }
+    ]
+  },
+  "applications": [
+    {
+      "name": "microcks-app",
+      "enabled": true,
+      "bearerOnly": true,
+      "defaultRoles": [
+        "user"
+      ]
+    },
+    {
+      "name": "microcks-app-js",
+      "enabled": true,
+      "publicClient": true,
+      "webOrigins": [
+        "+"
+      ],
+      "redirectUris": [
+        "http://localhost:8080/*"
+      ],
+      "fullScopeAllowed": false
+    },
+    {
+      "name": "microcks-serviceaccount",
+      "enabled": true,
+      "bearerOnly": false,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "clientAuthenticatorType": "client-secret"
+    }
+  ],
+  "keycloakVersion": "10.0.1"
+}

--- a/install/podman-compose/microcks-template-rootless.yml
+++ b/install/podman-compose/microcks-template-rootless.yml
@@ -1,0 +1,49 @@
+version: '2'
+networks:
+  main:
+services:
+  mongo:
+    image: mongo:3.4.23
+    container_name: microcks-mongo
+    volumes:
+      # Podman does not create missing folders, so we need to use an existing one
+      # Adding the "z" flag to get SELinux configured automatically
+      - "./microcks-data:/data/db:z"
+    ports:
+      - "27017:27017"
+  postman:
+    image: quay.io/microcks/microcks-postman-runtime:latest
+    container_name: microcks-postman-runtime
+    ports:
+      - "3000:3000"
+  keycloak:
+    image: jboss/keycloak:10.0.1
+    command: "-b 0.0.0.0 -Dkeycloak.import=/microcks-keycloak-config/microcks-realm-sample.json"
+    container_name: microcks-keycloak
+    ports:
+      - "8180:8080"
+    volumes:
+      # Adding the "z" flag to get SELinux configured automatically
+      - ./keycloak-realm:/microcks-keycloak-config:z
+    environment:
+      KEYCLOAK_USER: "admin"
+      KEYCLOAK_PASSWORD: "123"
+  app:
+    depends_on:
+      - mongo
+      - postman
+      - keycloak
+    image: quay.io/microcks/microcks:latest
+    container_name: microcks
+    volumes:
+      - ./config:/deployments/config
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATA_MONGODB_URI=mongodb://__HOST__:27017
+      - SPRING_DATA_MONGODB_DATABASE=microcks
+      - POSTMAN_RUNNER_URL=http://__HOST__:3000
+      - TEST_CALLBACK_URL=http://__HOST__:8080
+      - KEYCLOAK_URL=http://__HOST__:8180/auth
+      - SERVICES_UPDATE_INTERVAL=0 0 0/2 * * *

--- a/install/podman-compose/microcks-template.yml
+++ b/install/podman-compose/microcks-template.yml
@@ -1,0 +1,45 @@
+version: '2'
+networks:
+  main:
+services:
+  mongo:
+    image: mongo:3.4.23
+    container_name: microcks-mongo
+    volumes:
+      # Podman does not create missing folders, so we need to use an existing one
+      # Adding the "z" flag to get SELinux configured automatically
+      - "./microcks-data:/data/db:z"
+  postman:
+    image: quay.io/microcks/microcks-postman-runtime:latest
+    container_name: microcks-postman-runtime
+  keycloak:
+    image: jboss/keycloak:10.0.1
+    command: "-b 0.0.0.0 -Dkeycloak.import=/microcks-keycloak-config/microcks-realm-sample.json"
+    container_name: microcks-keycloak
+    ports:
+      - "8180:8080"
+    volumes:
+      # Adding the "z" flag to get SELinux configured automatically
+      - ./keycloak-realm:/microcks-keycloak-config:z
+    environment:
+      KEYCLOAK_USER: "admin"
+      KEYCLOAK_PASSWORD: "123"
+  app:
+    depends_on:
+      - mongo
+      - postman
+      - keycloak
+    image: quay.io/microcks/microcks:latest
+    container_name: microcks
+    volumes:
+      - ./config:/deployments/config
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - SPRING_DATA_MONGODB_URI=mongodb://microcks-mongo:27017
+      - SPRING_DATA_MONGODB_DATABASE=microcks
+      - POSTMAN_RUNNER_URL=http://microcks-postman-runtime:3000
+      - TEST_CALLBACK_URL=http://microcks:8080
+      - KEYCLOAK_URL=http://__HOST__:8180/auth
+      - SERVICES_UPDATE_INTERVAL=0 0 0/2 * * *

--- a/install/podman-compose/run-microcks.sh
+++ b/install/podman-compose/run-microcks.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+mkdir -p microcks-data || exit 1
+
+# The chosen podman-compose template depends on who is running this script
+if [ "$UID" -eq 0 ]; then
+  # We are root !
+  template="microcks-template.yml"
+  cmd_prefix="sudo"
+else
+  echo "Running rootless containers..."
+  template="microcks-template-rootless.yml"
+  cmd_prefix=""
+fi
+
+# Find the host ip address on linux systems
+host_ip="$(ip -o route get to 8.8.8.8 2>/dev/null | sed -n 's/.*src \([0-9.]\+\).*/\1/p')"
+if [ -z "$host_ip" ]; then
+  # Fallback method
+  iface="$(awk -F "\t" '$2 == "00000000" { print $1 }' /proc/net/route 2>/dev/null)"
+  host_ip="$(ifconfig wlp3s0 2>/dev/null |awk '$1 == "inet" { print $2 }')"
+fi
+
+# Generate a podman-compose file from the supplied template
+echo "Discovered host IP address: ${host_ip:-none}" 
+sed "s/__HOST__/$host_ip/" "$template" > microcks.yml || exit 1
+
+echo
+echo "Starting Microcks using podman-compose ..."
+echo "------------------------------------------"
+echo "Stop it with: $cmd_prefix podman-compose -f microcks.yml --transform_policy=identity stop"
+echo "Re-launch it with: $cmd_prefix podman-compose -f microcks.yml --transform_policy=identity start"
+echo "Clean everything with: $cmd_prefix podman-compose -f microcks.yml --transform_policy=identity down"
+echo "------------------------------------------"
+echo "Go to https://localhost:8080 - first login with admin/123"
+echo "Having issues? Check you have changed microcks.yml to your platform"
+echo
+
+podman-compose -f microcks.yml --transform_policy=identity up -d

--- a/install/podman-compose/run-microcks.sh
+++ b/install/podman-compose/run-microcks.sh
@@ -18,7 +18,7 @@ host_ip="$(ip -o route get to 8.8.8.8 2>/dev/null | sed -n 's/.*src \([0-9.]\+\)
 if [ -z "$host_ip" ]; then
   # Fallback method
   iface="$(awk -F "\t" '$2 == "00000000" { print $1 }' /proc/net/route 2>/dev/null)"
-  host_ip="$(ifconfig wlp3s0 2>/dev/null |awk '$1 == "inet" { print $2 }')"
+  host_ip="$(ifconfig "$iface" 2>/dev/null |awk '$1 == "inet" { print $2 }')"
 fi
 
 # Generate a podman-compose file from the supplied template


### PR DESCRIPTION
Hi !

This PR is about running Microcks on Linux with podman. 

## Summary

To make it work, I had to:
 - create a dedicated folder for the mongodb volume (podman does not create a folder automatically if it does not exist)
 - change the volumes to add the "z" flag to ask podman [to fix SELinux labels for us](http://docs.podman.io/en/latest/markdown/podman-run.1.html)
   > To change a label in the container context, you can add either of two suffixes :z or :Z to the volume mount. These suffixes tell Podman to relabel file objects on the shared volumes. The z option tells Podman that two containers share the volume content. As a result, Podman labels the content with a shared content label. Shared volume labels allow all containers to read/write content. 
 - provide two podman-compose templates (one for running as root, one for rootless containers) since [the networking stack is different between the two modes](https://podman.io/getting-started/network)
 - change the environment variables of the microcks container to point to the container names instead of network aliases
 - for rootless containers, expose all container ports on the host and change the environment variables to point to the host
 - detect the main IP address of the host and use it for the Keycloak public URL
 - provide a script wrapping all the above
 - switch to HTTP since my firefox could not negociate a common cipher suite with the keycloak container :'(

Note: the `keycloak-realm/microcks-realm-sample.json` is the same as `../docker-compose/keycloak-realm/microcks-realm-sample.json` with just the redirect url changed to accomodate the switch to HTTP. 

## How to use it

As explained in the official [docker-compose doc](https://microcks.io/documentation/installing/docker-compose/)

```
$ git clone https://github.com/microcks/microcks.git
$ cd microcks/install/podman-compose
```

### Rootless containers

```
$ ./run-microcks.sh
Running rootless containers...
Discovered host IP address: 192.168.3.102

Starting Microcks using podman-compose ...
------------------------------------------
Stop it with:  podman-compose -f microcks.yml --transform_policy=identity stop
Re-launch it with:  podman-compose -f microcks.yml --transform_policy=identity start
Clean everything with:  podman-compose -f microcks.yml --transform_policy=identity down
------------------------------------------
Go to https://localhost:8080 - first login with admin/123
Having issues? Check you have changed microcks.yml to your platform

using podman version: podman version 2.1.1
podman run [...]
```

## Rootfull containers

**Pre-requisites**: enable the *dnsname* plugin on the default network.

```
sudo podman network rm podman
sudo podman network create --subnet 10.88.0.0/16 podman
```

Run microcks as root:

```
$ sudo ./run-microcks.sh
Discovered host IP address: 192.168.3.102

Starting Microcks using podman-compose ...
------------------------------------------
Stop it with: sudo podman-compose -f microcks.yml --transform_policy=identity stop
Re-launch it with: sudo podman-compose -f microcks.yml --transform_policy=identity start
Clean everything with: sudo podman-compose -f microcks.yml --transform_policy=identity down
------------------------------------------
Go to https://localhost:8080 - first login with admin/123
Having issues? Check you have changed microcks.yml to your platform

using podman version: podman version 2.1.1
podman run [...]
```
