### PR TITLE
Add securityContext to keycloak postgres to fix permissions for vanil…

### DIFF
--- a/install/kubernetes/microcks/templates/deployment.yaml
+++ b/install/kubernetes/microcks/templates/deployment.yaml
@@ -394,6 +394,12 @@ spec:
         container: keycloak-postgresql
         group: microcks
     spec:
+      {{- if not (.Capabilities.APIVersions.Has "route.openshift.io/v1/Route") }}
+      securityContext:
+        runAsUser: 26
+        runAsGroup: 26
+        fsGroup: 26
+      {{- end }}
       terminationGracePeriodSeconds: 60
       containers:
       - name: keycloak-postgresql


### PR DESCRIPTION
…la Kubernetes

This PR is pretty similar to 
https://github.com/microcks/microcks/issues/322
https://github.com/microcks/microcks-ansible-operator/issues/25
but relates to keycloak postgres deployment