### PR TITLE
Fix podman-compose (missing config volume)

### DIFF
--- a/install/podman-compose/config
+++ b/install/podman-compose/config
@@ -1,1 +1,0 @@
-../docker-compose/config

--- a/install/podman-compose/microcks-template-rootless.yml
+++ b/install/podman-compose/microcks-template-rootless.yml
@@ -35,8 +35,6 @@ services:
       - keycloak
     image: quay.io/microcks/microcks:latest
     container_name: microcks
-    volumes:
-      - ./config:/deployments/config
     ports:
       - "8080:8080"
     environment:

--- a/install/podman-compose/microcks-template.yml
+++ b/install/podman-compose/microcks-template.yml
@@ -31,8 +31,6 @@ services:
       - keycloak
     image: quay.io/microcks/microcks:latest
     container_name: microcks
-    volumes:
-      - ./config:/deployments/config
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
The podman-compose files were broken due to a dangling "config" symlink (removed from docker-compose)