### PR TITLE
Add configurable base context to angular and spring app

### DIFF
--- a/install/docker-compose/docker-compose.yml
+++ b/install/docker-compose/docker-compose.yml
@@ -1,9 +1,11 @@
-version: '2'
+version: "2"
 
 services:
   mongo:
     image: mongo:3.4.23
     container_name: microcks-db
+    ports:
+      - "27017:27017"
     volumes:
       - "~/tmp/microcks-data:/data/db"
 
@@ -11,13 +13,13 @@ services:
     image: jboss/keycloak:10.0.1
     container_name: microcks-sso
     ports:
-      - "18080:8080"
+      - "8180:8080"
     environment:
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "admin"
       KEYCLOAK_IMPORT: "/tmp/microcks-realm.json"
-      KEYCLOAK_FRONTEND_URL: "http://localhost:18080/auth"
-    volumes: 
+      KEYCLOAK_FRONTEND_URL: "http://localhost:8180/auth"
+    volumes:
       - "./keycloak-realm/microcks-realm-sample.json:/tmp/microcks-realm.json"
 
   postman:
@@ -41,4 +43,4 @@ services:
       - TEST_CALLBACK_URL=http://microcks:8080
       - SERVICES_UPDATE_INTERVAL=0 0 0/2 * * *
       - KEYCLOAK_URL=http://keycloak:8080/auth
-      - KEYCLOAK_PUBLIC_URL=http://localhost:18080/auth
+      - KEYCLOAK_PUBLIC_URL=http://localhost:8180/auth

--- a/install/docker-compose/keycloak-realm/microcks-realm-sample.json
+++ b/install/docker-compose/keycloak-realm/microcks-realm-sample.json
@@ -5,19 +5,28 @@
   "enabled": true,
   "sslRequired": "none",
   "registrationAllowed": false,
-  "users" : [
+  "users": [
     {
-      "username" : "admin",
+      "username": "admin",
       "enabled": true,
-      "credentials" : [
-        { "type" : "password",
-          "value" : "123" }
+      "credentials": [
+        {
+          "type": "password",
+          "value": "123"
+        }
       ],
       "realmRoles": [],
       "applicationRoles": {
-        "realm-management": [ "manage-users", "manage-clients" ],
-        "account": [ "manage-account" ],
-        "microcks-app": [ "admin "]
+        "realm-management": [
+          "manage-users",
+          "manage-clients"
+        ],
+        "account": [
+          "manage-account"
+        ],
+        "microcks-app": [
+          "admin "
+        ]
       }
     }
   ],
@@ -47,7 +56,9 @@
     }
   },
   "defaultRoles": [],
-  "requiredCredentials": [ "password" ],
+  "requiredCredentials": [
+    "password"
+  ],
   "scopeMappings": [],
   "clientScopeMappings": {
     "microcks-app": [
@@ -87,7 +98,8 @@
         "+"
       ],
       "redirectUris": [
-        "http://localhost:8080/*"
+        "http://localhost:8080/*",
+        "http://localhost:4200/*"
       ],
       "fullScopeAllowed": false
     },

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -74,6 +74,44 @@ You may want to configure an Identity Provider or add some users for your Microc
 username and password found into 'microcks-keycloak-admin' secret.
 ```
 
+### Simple install - listening on sub context
+
+From the [Helm Hub](https://hub.helm.sh) directly - assuming here for the example, you are running `minikube`:
+
+```console
+$ helm repo add microcks https://microcks.io/helm
+
+$ kubectl create namespace microcks
+
+$ helm install microcks microcks/microcks —-version 1.2.0 --namespace microcks \
+  --set microcks.url=microcks.$(minikube ip).nip.io \
+  --set 'microcks.baseContext=/mock-server/microcks/' \
+  --set keycloak.url=keycloak.$(minikube ip).nip.io \
+  --set 'keycloak.baseContext=/mock-server/auth/'
+  
+NAME: microcks
+LAST DEPLOYED: Mon Jan 15 18:57:12 2021
+NAMESPACE: microcks
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+Thank you for installing microcks.
+
+Your release is named microcks.
+
+To learn more about the release, try:
+
+  $ helm status microcks
+  $ helm get microcks
+
+Microcks is available at https://microcks.192.168.64.6.nip.io/mock-server/microcks/.
+
+Keycloak has been deployed on https://keycloak.192.168.64.6.nip.io/mock-server/auth/ to protect user access.
+You may want to configure an Identity Provider or add some users for your Microcks installation by login in using the
+username and password found into 'microcks-keycloak-admin' secret.
+```
+
 ### Advanced install - with asynchronous mocking
 
 Since release `1.0.0`, Microcks support mocking of event-driven API thanks to [AsyncAPI Spec](https://asyncapi.com). Microcks will take car of publishing sample messages for you on a message broker. You mey reuse an existing broker of let Microcks deploy its own (this is the default when turning on this feature).
@@ -144,8 +182,10 @@ The table below describe all the fields of the `values.yaml`, providing informat
 | Section    | Property           | Description   |
 | ------------- | ------------------ | ------------- |
 | `microcks`    | `url`              | **Mandatory**. The URL to use for exposing `Ingress` | 
-| `microcks`    | `ingressSecretRef` | **Optional**. The name of a TLS Secret for securing `Ingress`. If missing, self-signed certificate is generated. |
-| `microcks`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks main pod. | 
+| `microcks`    | `baseContext`      | **Mandatory**. The base context the service is listening on. Default is `/` | 
+| `microcks`    | `ingress.enable`   | **Mandatory**. Install `Ingress` resources. Default is `true`. |
+| `microcks`    | `ingress.secretRef` | **Optional**. The name of a TLS Secret for securing `Ingress`. If missing, self-signed certificate is generated. |
+| `microcks`    | `ingress.annotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks main pod. | 
 | `microcks`    | `replicas`         | **Optional**. The number of replicas for the Microcks main pod. Default is `1`. |
 | `microcks`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
 | `microcks`    | `resources`        | **Optional**. Some resources constraints to apply on Microcks pods. This should be expressed using [Kubernetes syntax](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). | 
@@ -154,9 +194,11 @@ The table below describe all the fields of the `values.yaml`, providing informat
 | `keycloak`    | `install`          | **Optional**. Flag for Keycloak installation. Default is `true`. Set to `false` if you want to reuse an existing Keycloak instance. |
 | `keycloak`    | `realm`            | **Optional**. Name of Keycloak realm to use. Should be setup only if `install` is `false` and you want to reuse an existing realm. Default is `microcks`. |
 | `keycloak`    | `url`              | **Mandatory**. The URL of Keycloak install - indeed just the hostname + port part - if it already exists or the one used for exposing Keycloak `Ingress`. |
+| `keycloak`    | `baseContext`      | **Mandatory**. The base context KeyCloak is listening on. Default is `/auth/` | 
 | `keycloak`    | `privateUrl`       | **Optional**. A private URL - a full URL here - used by the Microcks component to internally join Keycloak. This is also known as `backendUrl` in [Keycloak doc](https://www.keycloak.org/docs/latest/server_installation/#_hostname). When specified, the `keycloak.url` is used as `frontendUrl` in Keycloak terms. | 
-| `keycloak`    | `ingressSecretRef` | **Optional**. The name of a TLS Secret for securing `Ingress`. If missing, self-signed certificate is generated. |
-| `keycloak`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. |  
+| `keycloak`    | `ingress.enable`   | **Mandatory**. Install `Ingress` resources. Default is `true`. |
+| `keycloak`    | `ingress.secretRef` | **Optional**. The name of a TLS Secret for securing `Ingress`. If missing, self-signed certificate is generated. |
+| `keycloak`    | `ingress.annotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. |  
 | `keycloak`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
 | `keycloak`    | `persistent`       | **Optional**. Flag for Keycloak persistence. Default is `true`. Set to `false` if you want an ephemeral Keycloak installation. |
 | `keycloak`    | `volumeSize`       | **Optional**. Size of persistent volume claim for Keycloak. Default is `1Gi`. Not used if not persistent install asked. |
@@ -234,9 +276,10 @@ microcks-mongodb-6d558666dc-zdhxl               1/1     Running   0          39s
 microcks-postman-runtime-58bf695b59-nm858       1/1     Running   0          39s
 ```
 
-## Deleting the Chart
+## Deleting the installed Helm release 
 
 ```console
-$ helm delete microcks
-$ helm del --purge microcks
+$ helm delete microcks --namespace microcks
+# To remove the helm repo
+$ helm repo remove microcks
 ```

--- a/install/kubernetes/microcks/templates/NOTES.txt
+++ b/install/kubernetes/microcks/templates/NOTES.txt
@@ -4,12 +4,12 @@ Your release is named {{ .Release.Name }}.
 
 To learn more about the release, try:
 
-  $ helm status {{ .Release.Name }}
-  $ helm get {{ .Release.Name }}
+  $ helm status {{ .Release.Name }} --namespace {{ .Release.Namespace }}
+  $ helm get all {{ .Release.Name }} --namespace {{ .Release.Namespace }}
 
-Microcks is available at https://{{ .Values.microcks.url }}.
+Microcks is available at https://{{ .Values.microcks.url }}{{ .Values.microcks.baseContext }}.
 
-Keycloak has been deployed on https://{{ .Values.keycloak.url }}/auth to protect user access.
+Keycloak has been deployed on https://{{ .Values.keycloak.url }}{{ .Values.keycloak.baseContext }} to protect user access.
 You may want to configure an Identity Provider or add some users for your Microcks installation by login in using the
 username and password found into '{{ .Values.appName }}-keycloak-admin' secret.
 
@@ -18,6 +18,6 @@ username and password found into '{{ .Values.appName }}-keycloak-admin' secret.
 Kafka broker has been deployed on {{ .Values.appName }}-kafka.{{ .Values.features.async.kafka.url }}.
 It has been exposed using TLS passthrough of the Ingress controller, you shoud extract the certificate for your client using:
 
-  $ kubectl get secret {{ .Values.appName }}-kafka-cluster-ca-cert -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
+  $ kubectl get secret {{ .Values.appName }}-kafka-cluster-ca-cert --namespace {{ .Release.Namespace }} -o jsonpath='{.data.ca\.crt}' | base64 -d > ca.crt
 
 {{- end }}

--- a/install/kubernetes/microcks/templates/configmap.yaml
+++ b/install/kubernetes/microcks/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
     network.username=
     network.password=
 
-    validation.resourceUrl=https://{{ .Values.microcks.url }}/api/resources/
+    validation.resourceUrl=https://{{ .Values.microcks.url }}{{ .Values.microcks.baseContext }}api/resources/
     services.update.interval=${SERVICES_UPDATE_INTERVAL:0 0 0/2 * * *}
     mocks.rest.enable-cors-policy=${ENABLE_CORS_POLICY:true}
 
@@ -273,7 +273,7 @@ data:
             "+"
           ],
           "redirectUris": [
-            "https://{{ .Values.microcks.url }}/*"
+            "https://{{ .Values.microcks.url }}{{ .Values.microcks.baseContext }}*"
           ],
           "fullScopeAllowed": false
         },
@@ -352,3 +352,40 @@ data:
     %kube.minion.restricted-frequencies=30,10
     %kube.minion.default-avro-encoding={{ .Values.features.async.defaultAvroEncoding }}
 {{- end -}}
+{{- if .Values.keycloak.install }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: "{{ .Values.appName }}-keycloak-startup"
+  labels:
+    app: "{{ .Values.appName }}"
+    container: keycloak
+    group: microcks
+data:
+  contextPath.cli: |
+    embed-server --server-config=standalone-ha.xml --std-out=echo
+    batch
+    {{- if ne .Values.keycloak.baseContext "/auth" }}
+    /subsystem=keycloak-server/:write-attribute(name=web-context,value={{ if eq .Values.keycloak.baseContext "" }}/{{ else }}{{ trimAll "/" .Values.keycloak.baseContext }}{{ end }})
+    {{- if eq .Values.keycloak.baseContext "" }}
+    /subsystem=undertow/server=default-server/host=default-host:write-attribute(name=default-web-module,value=keycloak-server.war)
+    {{- end }}
+    {{- end }}
+    run-batch
+    stop-embedded-server
+---
+{{- end -}}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: "{{ .Values.appName }}-environment-config-map"
+  labels:
+    app: "{{ .Values.appName }}"
+    container: spring
+    group: microcks
+data:
+  environment.json: |
+    {"apiUrl":"https://{{ .Values.microcks.url }}{{ .Values.microcks.baseContext }}", "baseContext": "{{ .Values.microcks.baseContext }}" ,"production":true}
+---

--- a/install/kubernetes/microcks/templates/deployment.yaml
+++ b/install/kubernetes/microcks/templates/deployment.yaml
@@ -66,10 +66,10 @@ spec:
           - name: KEYCLOAK_URL
             value: "{{ .Values.keycloak.privateUrl }}"
           - name: KEYCLOAK_PUBLIC_URL
-            value: https://{{ .Values.keycloak.url }}/auth
+            value: https://{{ .Values.keycloak.url }}{{ .Values.keycloak.baseContext }}
           {{- else }}
           - name: KEYCLOAK_URL
-            value: https://{{ .Values.keycloak.url }}/auth
+            value: https://{{ .Values.keycloak.url }}{{ .Values.keycloak.baseContext }}
           {{- end }}
           {{- if and .Values.features.async.enabled }}
           - name: ASYNC_MINION_URL
@@ -81,11 +81,15 @@ spec:
             {{- else }}
             value: "{{ .Values.features.async.kafka.url }}"
             {{- end }}
+          {{- if ne .Values.microcks.baseContext "/" }}
+          - name: SERVER_SERVLET_CONTEXT_PATH
+            value: {{ trimSuffix "/" .Values.microcks.baseContext }}
+          {{- end }}
         resources:
           {{- toYaml .Values.microcks.resources | nindent 10 }}
         livenessProbe:
           httpGet:
-            path: "/api/health"
+            path: "{{ .Values.microcks.baseContext }}api/health"
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 25
@@ -95,7 +99,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: "/api/health"
+            path: "{{ .Values.microcks.baseContext }}api/health"
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 35
@@ -106,11 +110,16 @@ spec:
         volumeMounts:
           - name: "{{ .Values.appName }}-config"
             mountPath: "/deployments/config"
+          - name: "{{ .Values.appName }}-environment-config-map"
+            mountPath: "/deployments/assets/environment"
         terminationMessagePath: "/dev/termination-log"
       volumes:
         - name: "{{ .Values.appName }}-config"
           configMap:
             name: "{{ .Values.appName }}-config"
+        - name: "{{ .Values.appName }}-environment-config-map"
+          configMap:
+            name: "{{ .Values.appName }}-environment-config-map"
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -357,14 +366,25 @@ spec:
           value: https://{{ .Values.keycloak.url }}/auth
         {{- end }}
         volumeMounts:
-        - name: {{ .Values.appName }}-keycloak-config
-          mountPath: "/opt/jboss/keycloak/standalone/configuration/realm"
+          - name: {{ .Values.appName }}-keycloak-config
+            mountPath: "/opt/jboss/keycloak/standalone/configuration/realm"
+          - name: "startup"
+            mountPath: /opt/jboss/startup-scripts/contextPath.cli
+            subPath: contextPath.cli
+            readOnly: true
         securityContext:
           privileged: false
       volumes:
-      - name: "{{ .Values.appName }}-keycloak-config"
-        configMap:
-          name: "{{ .Values.appName }}-keycloak-config"
+        - name: "{{ .Values.appName }}-keycloak-config"
+          configMap:
+            name: "{{ .Values.appName }}-keycloak-config"
+        - name: "startup"
+          configMap:
+            name: "{{ .Values.appName }}-keycloak-startup"
+            defaultMode: 0555
+            items:
+              - key: contextPath.cli
+                path: contextPath.cli
       restartPolicy: Always
       dnsPolicy: ClusterFirst
 ---

--- a/install/kubernetes/microcks/templates/ingress.yaml
+++ b/install/kubernetes/microcks/templates/ingress.yaml
@@ -1,10 +1,15 @@
-kind: Ingress
+{{- if .Values.microcks.ingress.enabled }}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
 metadata:
   name: microcks
   annotations:
-    ingress.kubernetes.io/rewrite-target: /
-  {{- with .Values.microcks.ingressAnnotations }}
+    ingress.kubernetes.io/rewrite-target: "{{ .Values.microcks.baseContext }}"
+  {{- with .Values.microcks.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
@@ -14,23 +19,30 @@ spec:
   tls:
   - hosts:
     - "{{ .Values.microcks.url }}"
-    secretName: {{ .Values.microcks.ingressSecretRef | default (print .Values.appName "-microcks-ingress-secret") }}
+    secretName: {{ .Values.microcks.ingress.secretRef | default (print .Values.appName "-microcks-ingress-secret") }}
   rules:
   - host: "{{ .Values.microcks.url }}"
     http:
       paths:
-      - backend:
+      - path: "{{ .Values.microcks.baseContext }}"
+        pathType: Prefix
+        backend:
           serviceName: "{{ .Values.appName }}"
           servicePort: 8080
-{{- if .Values.keycloak.install }}
+{{- end }}
+{{- if and .Values.keycloak.install .Values.keycloak.ingress.enabled }}
 ---
-kind: Ingress
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
 metadata:
   name: keycloak
   annotations:
-    ingress.kubernetes.io/rewrite-target: /
-  {{- with .Values.keycloak.ingressAnnotations }}
+    ingress.kubernetes.io/rewrite-target: "{{ .Values.keycloak.baseContext }}"
+  {{- with .Values.keycloak.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
@@ -40,12 +52,14 @@ spec:
   tls:
   - hosts:
     - "{{ .Values.keycloak.url }}"
-    secretName: {{ .Values.keycloak.ingressSecretRef | default (print .Values.appName "-keycloak-ingress-secret") }}
+    secretName: {{ .Values.keycloak.ingress.secretRef | default (print .Values.appName "-keycloak-ingress-secret") }}
   rules:
   - host: "{{ .Values.keycloak.url }}"
     http:
       paths:
-      - backend:
+      - path: "{{ .Values.keycloak.baseContext }}"
+        pathType: Prefix
+        backend:
           serviceName: "{{ .Values.appName }}-keycloak"
           servicePort: 8080
 {{- end }}

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -2,12 +2,15 @@ appName: microcks
 
 microcks:
   url: microcks-microcks.192.168.99.100.nip.io
-  #url: microcks-microcks.192.168.64.6.nip.io
-  #ingressSecretRef: my-secret-for-microcks-ingress
-  #ingressAnnotations:
-    #cert-manager.io/issuer: my-cert-issuer
-    #kubernetes.io/tls-acme: "true"
-    #kubernetes.io/ingress.class: nginx
+  # baseContext should always end with a trailing `/`, e.g. `/mock-server/microcks/`
+  baseContext: /
+  ingress:
+    enabled: true
+    secretRef: my-secret-for-microcks-ingress
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      # cert-manager.io/issuer: my-cert-issuer
+      # kubernetes.io/tls-acme: "true"
   generateCert: true
   image: quay.io/microcks/microcks:1.2.0
   replicas: 1
@@ -27,12 +30,16 @@ keycloak:
   install: true
   realm: microcks
   url: keycloak-microcks.192.168.99.100.nip.io
+  # baseContext should always end with a trailing `/`, e.g. `/mock-server/auth/`
+  baseContext: /auth/
   #privateUrl: http://microcks-keycloak.microcks.svc.cluster.local:8080/auth
-  #ingressSecretRef: my-secret-for-keycloak-ingress
-  #ingressAnnotations:
-    #cert-manager.io/issuer: my-cert-issuer
-    #kubernetes.io/tls-acme: "true"
-    #kubernetes.io/ingress.class: nginx
+  ingress:
+    enabled: true
+    secretRef: my-secret-for-keycloak-ingress
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      # cert-manager.io/issuer: my-cert-issuer
+      # kubernetes.io/tls-acme: "true"
   generateCert: true
   image: jboss/keycloak:10.0.1
   adminUsername: admin

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -4,7 +4,7 @@ For development purposes, frontend GUI and backend APIs have been separated and 
 * Frontend is an Angular 6 application served by `ng serve` with livereload enabled,
 * Backend is a Spring Boot application served by Boot internal server
 
-We also need a Keycloak server running on port `8180`. 
+We also need a Keycloak server running on port `8180`. You can run the Keycloak server as a container from docker-compose, just adjust the exposed port to `8180`.
 
 ### Pre-requisites
 
@@ -25,7 +25,7 @@ $ ./standalone.sh -Djboss.socket.binding.port-offset=100
 In a terminal, start frontend GUI server using NG :
 
 ```
-$ cd src/main/webapp
+$ cd webapp/src/main/webapp
 $ ng serve
 ```
 

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -1,22 +1,17 @@
 # Application configuration properties
 spring.jackson.serialization.write-dates-as-timestamps=true
 spring.jackson.default-property-inclusion=non_null
-
 tests-callback.url=${TEST_CALLBACK_URL:http://localhost:8080}
 postman-runner.url=${POSTMAN_RUNNER_URL:http://localhost:3000}
 async-minion.url=${ASYNC_MINION_URL:http://localhost:8081}
-
 network.proxyHost=${PROXY_HOST:}
 network.proxyPort=${PROXY_PORT:}
 network.proxyUsername=${PROXY_USERNAME:}
 network.proxyPassword=${PROXY_PASSWORD:}
 network.nonProxyHosts=${PROXY_EXCLUDE:localhost|127.0.0.1|*.svc.cluster.local}
-
 validation.resourceUrl=http://localhost:8080/api/resources/
 services.update.interval=${SERVICES_UPDATE_INTERVAL:0 0 0/2 * * *}
 mocks.rest.enable-cors-policy=${ENABLE_CORS_POLICY:true}
-
-
 # Keycloak adapter configuration properties
 keycloak.auth-server-url=${KEYCLOAK_URL:http://localhost:8180/auth}
 keycloak.realm=microcks
@@ -24,7 +19,9 @@ keycloak.resource=microcks-app
 keycloak.use-resource-role-mappings=true
 keycloak.bearer-only=true
 keycloak.ssl-required=external
-
+keycloak.cors=true
+keycloak.cors-max-age=3600
+keycloak.cors-allowed-methods=POST, PUT, DELETE, GET, OPTIONS
 keycloak.security-constraints[0].authRoles[0]=admin
 keycloak.security-constraints[0].authRoles[1]=manager
 keycloak.security-constraints[0].authRoles[2]=user
@@ -34,29 +31,25 @@ keycloak.security-constraints[0].securityCollections[0].patterns[1]=/api/service
 keycloak.security-constraints[0].securityCollections[0].patterns[2]=/api/jobs
 keycloak.security-constraints[0].securityCollections[0].patterns[3]=/api/jobs/count
 #keycloak.security-constraints[0].securityCollections[0].patterns[4]=/api/tests
-
 #keycloak.security-constraints[1].authRoles[0]=admin
 #keycloak.security-constraints[1].securityCollections[0].name=Admin stuffs
 #keycloak.security-constraints[1].securityCollections[0].patterns[0]=/api/jobs/*/*
 #keycloak.security-constraints[1].securityCollections[0].patterns[1]=/api/import
 #keycloak.security-constraints[1].securityCollections[0].patterns[2]=/api/export
-
 #keycloak.security-constraints[2].authRoles[0]=manager
 #keycloak.security-constraints[2].securityCollections[0].patterns[0]=/api/services/*/*
 #keycloak.security-constraints[2].securityCollections[0].methods[0]=POST
 #keycloak.security-constraints[2].securityCollections[0].methods[1]=PUT
 #keycloak.security-constraints[2].securityCollections[0].methods[2]=DELETE
-
-
 # Keycloak access configuration properties
 sso.public-url=${KEYCLOAK_PUBLIC_URL:${keycloak.auth-server-url}}
-
 # Async mocking support.
 async-api.enabled=false
 async-api.default-binding=KAFKA
 async-api.default-frequency=3
-
 # Kafka configuration properties
 spring.kafka.producer.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVER:localhost:9092}
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=io.github.microcks.event.ServiceViewChangeEventSerializer
+# Expose Angular environment configuration
+spring.resources.static-locations=classpath:/META-INF/resources/,classpath:/resources/,classpath:/static/,classpath:/public/,file:/deployments/assets/

--- a/webapp/src/main/webapp/angular.json
+++ b/webapp/src/main/webapp/angular.json
@@ -80,9 +80,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "microcks-ui:build",
-            "proxyConfig": "proxy.conf.json"
-          },
+            "browserTarget": "microcks-ui:build"          },
           "configurations": {
             "production": {
               "browserTarget": "microcks-ui:build:production"

--- a/webapp/src/main/webapp/proxy.conf.json
+++ b/webapp/src/main/webapp/proxy.conf.json
@@ -1,6 +1,0 @@
-{
-  "/api": {
-    "target": "http://localhost:8080",
-    "secure": false
-  }
-}

--- a/webapp/src/main/webapp/src/app/app.module.ts
+++ b/webapp/src/main/webapp/src/app/app.module.ts
@@ -74,6 +74,8 @@ import { ArtifactUploaderDialogComponent } from './pages/importers/_components/u
 import { HubPageComponent } from './pages/hub/hub.page';
 import { HubPackagePageComponent } from './pages/hub/package/package.page';
 import { HubAPIVersionPageComponent } from './pages/hub/package/apiVersion/apiVersion.page';
+import { APP_BASE_HREF } from '@angular/common';
+
 
 import json from 'highlight.js/lib/languages/json';
 import xml from 'highlight.js/lib/languages/xml';
@@ -84,8 +86,8 @@ import xml from 'highlight.js/lib/languages/xml';
  */
 export function getHighlightLanguages() {
   return [
-    {name: 'json', func: json},
-    {name: 'xml', func: xml}
+    { name: 'json', func: json },
+    { name: 'xml', func: xml }
   ];
 }
 
@@ -109,10 +111,10 @@ export function configLoader(configService: ConfigService) {
     BrowserModule, FormsModule, AppRoutingModule, HttpClientModule,
     BsDropdownModule.forRoot(), ModalModule.forRoot(), TabsModule.forRoot(), TooltipModule.forRoot(),
     HighlightModule, FileUploadModule,
-    AboutModalModule, 
+    AboutModalModule,
     CardModule, DonutChartModule, SparklineChartModule,
     ListModule, PaginationModule, ToolbarModule,
-    WizardModule, ToastNotificationListModule, 
+    WizardModule, ToastNotificationListModule,
   ],
   providers: [
     ConfigService, {
@@ -132,10 +134,14 @@ export function configLoader(configService: ConfigService) {
       useValue: {
         languages: getHighlightLanguages
       }
-    }
+    },
+    {
+      provide: APP_BASE_HREF,
+      useValue: window['base-href']
+    },
   ],
   entryComponents: [
-    HelpDialogComponent, DynamicAPIDialogComponent, 
+    HelpDialogComponent, DynamicAPIDialogComponent,
     EditLabelsDialogComponent, GenericResourcesDialogComponent,
     ServiceRefsDialogComponent, ImporterWizardComponent, ArtifactUploaderDialogComponent
   ],

--- a/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.html
+++ b/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.html
@@ -6,9 +6,9 @@
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
     </button>
-    <a href="/" class="navbar-brand">
+    <a href="{{ BASE_CONTEXT }}" class="navbar-brand">
       <!-- <img class="navbar-brand-icon" src="/assets/microcks.png" alt="Microcks"/> -->
-      <img class="navbar-brand-icon" src="/assets/microcks-logo-white-name.png" alt="Microcks"/>
+      <img class="navbar-brand-icon" src="{{ BASE_CONTEXT }}assets/microcks-logo-white-name.png" alt="Microcks"/>
     </a>
   </div>
 

--- a/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.ts
+++ b/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.ts
@@ -12,6 +12,9 @@ import { VersionInfoService } from '../../services/versioninfo.service';
 import { User } from "../../models/user.model";
 import { ConfigService } from 'src/app/services/config.service';
 
+import { environment } from 'src/environments/environment';
+
+export const BASE_CONTEXT = `${environment.baseContext}`
 
 // Thanks to https://github.com/onokumus/metismenu/issues/110#issuecomment-317254128
 //import * as $ from 'jquery';
@@ -33,8 +36,8 @@ export class VerticalNavComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.user().subscribe( currentUser => {
-      this.versionInfoSvc.getVersionInfo().subscribe( versionInfo => {
+    this.user().subscribe(currentUser => {
+      this.versionInfoSvc.getVersionInfo().subscribe(versionInfo => {
         this.aboutConfig = {
           additionalInfo: 'Microcks is Open Source mocking and testing platform for API and microservices. Visit https://microcks.io for more information.',
           copyright: 'Distributed under Apache Licence v2.0',
@@ -45,7 +48,7 @@ export class VerticalNavComponent implements OnInit {
             { name: 'Version', value: versionInfo.versionId },
             { name: 'Build timestamp', value: versionInfo.buildTimestamp },
             { name: 'User Login', value: currentUser.login },
-            { name: 'User Name', value: currentUser.name } ]
+            { name: 'User Name', value: currentUser.name }]
         } as AboutModalConfig;
       });
     });
@@ -57,7 +60,7 @@ export class VerticalNavComponent implements OnInit {
 
   public openHelpDialog() {
     const initialState = {};
-    this.modalRef = this.modalService.show(HelpDialogComponent, {initialState});
+    this.modalRef = this.modalService.show(HelpDialogComponent, { initialState });
   }
 
   public openAboutModal(template: TemplateRef<any>): void {

--- a/webapp/src/main/webapp/src/app/pages/admin/_components/snapshots.tab.ts
+++ b/webapp/src/main/webapp/src/app/pages/admin/_components/snapshots.tab.ts
@@ -23,6 +23,13 @@ import { FileUploader } from 'ng2-file-upload';
 
 import { Service } from '../../../models/service.model';
 import { ServicesService } from '../../../services/services.service';
+import { environment } from 'src/environments/environment';
+
+
+const ENDPOINTS = {
+  EXPORT: () => `${environment.apiUrl}api/export?`,
+  IMPORT: () => `${environment.apiUrl}api/import`
+};
 
 @Component({
   selector: 'snapshots-tab',
@@ -36,9 +43,10 @@ export class SnapshotsTabComponent implements OnInit {
   servicesCount: number;
 
   selectedServices: any = { ids: {} };
-  uploader: FileUploader = new FileUploader({url: '/api/import', itemAlias: 'file'});
+  uploader: FileUploader = new FileUploader({ url: ENDPOINTS.IMPORT(), itemAlias: 'file' });
 
-  constructor(private servicesSvc: ServicesService, private notificationService: NotificationService) {}
+
+  constructor(private servicesSvc: ServicesService, private notificationService: NotificationService) { }
 
   ngOnInit() {
     this.getAllServices();
@@ -50,7 +58,7 @@ export class SnapshotsTabComponent implements OnInit {
     };
   }
 
-  getAllServices():void {
+  getAllServices(): void {
     this.servicesSvc.getServices(1, 1000).subscribe(
       results => {
         this.halfServices = results.slice(0, (results.length / 2) + 1);
@@ -61,8 +69,8 @@ export class SnapshotsTabComponent implements OnInit {
   }
 
   public createExport(): void {
-    var downloadPath = '/api/export?';
-    Object.keys(this.selectedServices.ids).forEach(function(element, index, array) {
+    var downloadPath = ENDPOINTS.EXPORT();
+    Object.keys(this.selectedServices.ids).forEach(function (element, index, array) {
       downloadPath += '&serviceIds=' + element;
     });
     window.open(downloadPath, '_blank', '');

--- a/webapp/src/main/webapp/src/app/pages/importers/_components/uploader.dialog.ts
+++ b/webapp/src/main/webapp/src/app/pages/importers/_components/uploader.dialog.ts
@@ -21,7 +21,11 @@ import { Component, OnInit } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap/modal';
 import { Notification, NotificationEvent, NotificationService, NotificationType } from 'patternfly-ng/notification';
 import { FileUploader, FileItem, ParsedResponseHeaders } from 'ng2-file-upload';
+import { environment } from 'src/environments/environment';
 
+const ENDPOINTS = {
+  ARTIFACT_UPLOAD: () => `${environment.apiUrl}api/artifact/upload`
+};
 
 @Component({
   selector: 'uploader-dialog',
@@ -32,10 +36,10 @@ export class ArtifactUploaderDialogComponent implements OnInit {
   title: string;
   closeBtnName: string;
 
-  uploader: FileUploader = new FileUploader({url: '/api/artifact/upload', itemAlias: 'file'});
-  
-  constructor(public bsModalRef: BsModalRef, private notificationService: NotificationService) {}
- 
+  uploader: FileUploader = new FileUploader({ url: ENDPOINTS.ARTIFACT_UPLOAD(), itemAlias: 'file' });
+
+  constructor(public bsModalRef: BsModalRef, private notificationService: NotificationService) { }
+
   ngOnInit() {
     this.uploader.onErrorItem = (item: FileItem, response: string, status: number, headers: ParsedResponseHeaders) => {
       this.notificationService.message(NotificationType.DANGER,

--- a/webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.ts
@@ -36,6 +36,15 @@ import { ConfigService } from '../../../services/config.service';
 import { ContractsService } from '../../../services/contracts.service';
 import { ServicesService } from '../../../services/services.service';
 import { TestsService } from '../../../services/tests.service';
+import { environment } from 'src/environments/environment';
+
+
+const ENDPOINTS = {
+  MOCK_URL: () => `${environment.apiUrl}`,
+};
+
+
+
 
 @Component({
   selector: 'service-detail-page',
@@ -56,16 +65,16 @@ export class ServiceDetailPageComponent implements OnInit {
   operationsListConfig: ListConfig;
   notifications: Notification[];
 
-  constructor(private servicesSvc: ServicesService, private contractsSvc: ContractsService, 
-      private testsSvc: TestsService, protected authService: IAuthenticationService, private config: ConfigService,
-      private modalService: BsModalService, private notificationService: NotificationService,
-      private route: ActivatedRoute, private router: Router, private ref: ChangeDetectorRef) {
+  constructor(private servicesSvc: ServicesService, private contractsSvc: ContractsService,
+    private testsSvc: TestsService, protected authService: IAuthenticationService, private config: ConfigService,
+    private modalService: BsModalService, private notificationService: NotificationService,
+    private route: ActivatedRoute, private router: Router, private ref: ChangeDetectorRef) {
   }
 
   ngOnInit() {
     this.notifications = this.notificationService.getNotifications();
     this.serviceView = this.route.paramMap.pipe(
-      switchMap((params: ParamMap) => 
+      switchMap((params: ParamMap) =>
         this.servicesSvc.getServiceView(params.get('serviceId')))
     );
     this.contracts = this.route.paramMap.pipe(
@@ -76,7 +85,7 @@ export class ServiceDetailPageComponent implements OnInit {
       switchMap((params: ParamMap) =>
         this.testsSvc.listByServiceId(params.get('serviceId')))
     );
-    this.serviceView.subscribe( view => {
+    this.serviceView.subscribe(view => {
       this.serviceId = view.service.id;
       this.resolvedServiceView = view;
       this.operations = view.service.operations;
@@ -126,7 +135,7 @@ export class ServiceDetailPageComponent implements OnInit {
     if (this.resolvedServiceView.service.metadata.labels != undefined) {
       initialState.labels = JSON.parse(JSON.stringify(this.resolvedServiceView.service.metadata.labels));
     }
-    this.modalRef = this.modalService.show(EditLabelsDialogComponent, {initialState});
+    this.modalRef = this.modalService.show(EditLabelsDialogComponent, { initialState });
     this.modalRef.content.saveLabelsAction.subscribe((labels) => {
       this.resolvedServiceView.service.metadata.labels = labels;
       this.servicesSvc.updateServiceMetadata(this.resolvedServiceView.service, this.resolvedServiceView.service.metadata).subscribe(
@@ -155,7 +164,7 @@ export class ServiceDetailPageComponent implements OnInit {
       closeBtnName: 'Close',
       service: this.resolvedServiceView.service
     };
-    this.modalRef = this.modalService.show(GenericResourcesDialogComponent, {initialState});
+    this.modalRef = this.modalService.show(GenericResourcesDialogComponent, { initialState });
   }
 
   public getHeaderName(exchange: Exchange): string {
@@ -172,11 +181,11 @@ export class ServiceDetailPageComponent implements OnInit {
       result += " is <code>required</code>";
     }
     if (constraint.recopy) {
-      if (result != "Parameter ") { result += ", "}
+      if (result != "Parameter ") { result += ", " }
       result += " will be <code>recopied</code> as response header"
     }
     if (constraint.mustMatchRegexp) {
-      if (result != "Parameter ") { result += ", "}
+      if (result != "Parameter ") { result += ", " }
       result += " must match the <code>" + constraint.mustMatchRegexp + "</code> regular expression"
     }
     return result;
@@ -187,7 +196,7 @@ export class ServiceDetailPageComponent implements OnInit {
     if (operation.bindings != null) {
       var result = "";
       var bindings = Object.keys(operation.bindings);
-      for (let i=0; i<bindings.length; i++) {
+      for (let i = 0; i < bindings.length; i++) {
         var b = bindings[i];
         switch (b) {
           case 'KAFKA':
@@ -200,7 +209,7 @@ export class ServiceDetailPageComponent implements OnInit {
             result += 'AMQP 1.0';
             break;
         }
-        if (i+1 < bindings.length) {
+        if (i + 1 < bindings.length) {
           result += ", ";
         }
       }
@@ -227,33 +236,33 @@ export class ServiceDetailPageComponent implements OnInit {
 
   public formatMockUrl(operation: Operation, dispatchCriteria: string): string {
     console.log("[ServiceDetailPageComponent.formatMockUrl()]");
-    var result = document.location.origin;
+    var result = ENDPOINTS.MOCK_URL();
 
     if (this.resolvedServiceView.service.type === ServiceType.REST) {
-      result += '/rest/';
+      result += 'rest/';
       result += this.encodeUrl(this.resolvedServiceView.service.name) + '/' + this.resolvedServiceView.service.version;
 
       var parts = {};
       var params = {};
       var operationName = operation.name;
-      
+
       if (dispatchCriteria != null) {
         var partsCriteria = (dispatchCriteria.indexOf('?') == -1 ? dispatchCriteria : dispatchCriteria.substring(0, dispatchCriteria.indexOf('?')));
         var paramsCriteria = (dispatchCriteria.indexOf('?') == -1 ? null : dispatchCriteria.substring(dispatchCriteria.indexOf('?') + 1));
 
         partsCriteria = this.encodeUrl(partsCriteria);
-        partsCriteria.split('/').forEach(function(element, index, array) {
-          if (element){
+        partsCriteria.split('/').forEach(function (element, index, array) {
+          if (element) {
             parts[element.split('=')[0]] = element.split('=')[1];
           }
         });
-      
+
         //operationName = operationName.replace(/{(\w+)}/g, function(match, p1, string) {
-        operationName = operationName.replace(/{([a-zA-Z0-9-_]+)}/g, function(match, p1, string) {
+        operationName = operationName.replace(/{([a-zA-Z0-9-_]+)}/g, function (match, p1, string) {
           return parts[p1];
         });
         // Support also Postman syntax with /:part
-        operationName = operationName.replace(/:([a-zA-Z0-9-_]+)/g, function(match, p1, string) {
+        operationName = operationName.replace(/:([a-zA-Z0-9-_]+)/g, function (match, p1, string) {
           return parts[p1];
         });
         if (paramsCriteria != null) {
@@ -265,14 +274,14 @@ export class ServiceDetailPageComponent implements OnInit {
       operationName = this.removeVerbInUrl(operationName);
       result += operationName;
     } else if (this.resolvedServiceView.service.type === ServiceType.SOAP_HTTP) {
-      result += '/soap/';
+      result += 'soap/';
       result += this.encodeUrl(this.resolvedServiceView.service.name) + '/' + this.resolvedServiceView.service.version;
     } else if (this.resolvedServiceView.service.type === ServiceType.GENERIC_REST) {
-      result += '/dynarest/';
+      result += 'dynarest/';
       var resourceName = this.removeVerbInUrl(operation.name);
       result += this.encodeUrl(this.resolvedServiceView.service.name) + '/' + this.resolvedServiceView.service.version + resourceName;
     }
-    
+
     return result;
   }
   public formatAsyncDestination(operation: Operation, eventMessage: EventMessage): string {
@@ -309,12 +318,12 @@ export class ServiceDetailPageComponent implements OnInit {
 
   private removeVerbInUrl(operationName: string): string {
     if (operationName.startsWith("GET ") || operationName.startsWith("PUT ")
-        || operationName.startsWith("POST ") || operationName.startsWith("DELETE ")
-        || operationName.startsWith("OPTIONS ") || operationName.startsWith("PATCH ")
-        || operationName.startsWith("HEAD ") || operationName.startsWith("TRACE ")
-        || operationName.startsWith("SUBSCRIBE ") || operationName.startsWith("PUBLISH ")) {
+      || operationName.startsWith("POST ") || operationName.startsWith("DELETE ")
+      || operationName.startsWith("OPTIONS ") || operationName.startsWith("PATCH ")
+      || operationName.startsWith("HEAD ") || operationName.startsWith("TRACE ")
+      || operationName.startsWith("SUBSCRIBE ") || operationName.startsWith("PUBLISH ")) {
       operationName = operationName.slice(operationName.indexOf(' ') + 1);
-    } 
+    }
     return operationName;
   }
   private encodeUrl(url: string): string {
@@ -330,8 +339,8 @@ export class ServiceDetailPageComponent implements OnInit {
   }
 
   public allowOperationsPropertiesEdit(): boolean {
-    return (this.hasRole('admin') || this.hasRole('manager')) 
-        && (this.resolvedServiceView.service.type === 'REST' || (this.resolvedServiceView.service.type === 'EVENT' && this.asyncAPIFeatureEnabled()));
+    return (this.hasRole('admin') || this.hasRole('manager'))
+      && (this.resolvedServiceView.service.type === 'REST' || (this.resolvedServiceView.service.type === 'EVENT' && this.asyncAPIFeatureEnabled()));
   }
 
   public asyncAPIFeatureEnabled(): boolean {

--- a/webapp/src/main/webapp/src/app/services/auth.http-interceptor.ts
+++ b/webapp/src/main/webapp/src/app/services/auth.http-interceptor.ts
@@ -30,20 +30,20 @@ export class AuthenticationHttpInterceptor implements HttpInterceptor {
   //constructor() { }
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    console.log('[AuthenticationHttpInterceptor] intercept for ' + req.method);
-    
+    console.log('[AuthenticationHttpInterceptor] intercept for ' + req.method + ' ' + req.url);
+
     if (req.method === 'OPTIONS') {
       return next.handle(req);
     }
-    
+
     // Build new set of headers for authentication purpose.
     if (this.authService.isAuthenticated) {
-      var authHeaders: {[header: string]: string} = {};
+      var authHeaders: { [header: string]: string } = {};
       this.authService.injectAuthHeaders(authHeaders);
-      const changedReq = req.clone({setHeaders: authHeaders});
+      const changedReq = req.clone({ setHeaders: authHeaders });
       return next.handle(changedReq);
     }
-    
+
     return next.handle(req);
   }
 }

--- a/webapp/src/main/webapp/src/app/services/config.service.ts
+++ b/webapp/src/main/webapp/src/app/services/config.service.ts
@@ -19,12 +19,18 @@
 import { Injectable } from "@angular/core";
 import { HttpClient } from '@angular/common/http';
 import { User } from "../models/user.model";
+import { environment } from 'src/environments/environment';
+
 
 let DEFAULT_CONFIG: any = {
   mode: "dev",
   auth: {
     type: "keycloakjs"
   }
+};
+
+const ENDPOINTS = {
+  CONFIG_URL: () => `${environment.apiUrl}api/features/config`
 };
 
 /**
@@ -35,7 +41,7 @@ export class ConfigService {
 
   private config: any;
 
-  
+
   constructor(private http: HttpClient) {
     let w: any = window;
     if (w["MicrocksConfig"]) {
@@ -86,12 +92,12 @@ export class ConfigService {
     return <any>this.config.user;
   }
 
-  public loadConfiguredFeatures() : Promise<any>  {
-    console.info("[ConfigService] Completing config with additional features...");
-    const featurePromise = this.http.get<any>('/api/features/config')
+  public loadConfiguredFeatures(): Promise<any> {
+    console.log("[ConfigService] Completing config with additional features...");
+    const featurePromise = this.http.get<any>(ENDPOINTS.CONFIG_URL())
       .toPromise().then(results => {
         this.config.features = results;
-        console.info("[ConfigService] Got config: " + JSON.stringify(this.config.features));
+        console.log("[ConfigService] Got config: " + JSON.stringify(this.config.features));
         return results;
       });
     return featurePromise;

--- a/webapp/src/main/webapp/src/app/services/contracts.service.ts
+++ b/webapp/src/main/webapp/src/app/services/contracts.service.ts
@@ -19,17 +19,21 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 import { Contract } from '../models/service.model';
+
+const ENDPOINTS = {
+  GET_CONTRACT: () => `${environment.apiUrl}api/resources/service/`
+};
 
 @Injectable({ providedIn: 'root' })
 export class ContractsService {
 
-  private rootUrl: string = '/api';
 
   constructor(private http: HttpClient) { }
 
   public listByServiceId(serviceId: string): Observable<Contract[]> {
-    return this.http.get<Contract[]>(this.rootUrl + '/resources/service/' + serviceId);
+    return this.http.get<Contract[]>(ENDPOINTS.GET_CONTRACT() + serviceId);
   }
 }

--- a/webapp/src/main/webapp/src/app/services/importers.service.ts
+++ b/webapp/src/main/webapp/src/app/services/importers.service.ts
@@ -19,52 +19,55 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 import { ImportJob } from '../models/importer.model';
 
+const ENDPOINTS = {
+  IMPORT_JOB: () => `${environment.apiUrl}api/jobs`,
+  JOB_COUNT: () => `${environment.apiUrl}api/jobs/count`
+};
 
 @Injectable({ providedIn: 'root' })
 export class ImportersService {
-
-  private rootUrl: string = '/api';
 
   constructor(private http: HttpClient) { }
 
   getImportJobs(page: number = 1, pageSize: number = 20): Observable<ImportJob[]> {
     const options = { params: new HttpParams().set('page', String(page - 1)).set('size', String(pageSize)) };
-    return this.http.get<ImportJob[]>(this.rootUrl + '/jobs', options);
+    return this.http.get<ImportJob[]>(ENDPOINTS.IMPORT_JOB(), options);
   }
 
   filterImportJobs(filter: string): Observable<ImportJob[]> {
     const options = { params: new HttpParams().set('name', filter) };
-    return this.http.get<ImportJob[]>(this.rootUrl + '/jobs', options);
+    return this.http.get<ImportJob[]>(ENDPOINTS.IMPORT_JOB(), options);
   }
 
-  countImportJobs(): Observable<any> { 
-    return this.http.get<any>(this.rootUrl + '/jobs/count');
+  countImportJobs(): Observable<any> {
+    return this.http.get<any>(ENDPOINTS.JOB_COUNT());
   }
 
   createImportJob(job: ImportJob): Observable<ImportJob> {
-    return this.http.post<ImportJob>(this.rootUrl + '/jobs', job);
+    return this.http.post<ImportJob>(ENDPOINTS.IMPORT_JOB(), job);
   }
 
   updateImportJob(job: ImportJob): Observable<ImportJob> {
-    return this.http.post<ImportJob>(this.rootUrl + '/jobs/' + job.id, job);
+    return this.http.post<ImportJob>(ENDPOINTS.IMPORT_JOB() + '/' + job.id, job);
   }
 
   deleteImportJob(job: ImportJob): Observable<ImportJob> {
-    return this.http.delete<ImportJob>(this.rootUrl + '/jobs/' + job.id);
+    return this.http.delete<ImportJob>(ENDPOINTS.IMPORT_JOB() + '/' + job.id);
   }
 
   activateImportJob(job: ImportJob): Observable<ImportJob> {
-    return this.http.put<ImportJob>(this.rootUrl + '/jobs/' + job.id + '/activate', job);
+    return this.http.put<ImportJob>(ENDPOINTS.IMPORT_JOB() + '/' + job.id + '/activate', job);
   }
 
   startImportJob(job: ImportJob): Observable<ImportJob> {
-    return this.http.put<ImportJob>(this.rootUrl + '/jobs/' + job.id + '/start', job);
+    return this.http.put<ImportJob>(ENDPOINTS.IMPORT_JOB() + '/' + job.id + '/start', job);
   }
 
   stopImportJob(job: ImportJob): Observable<ImportJob> {
-    return this.http.put<ImportJob>(this.rootUrl + '/jobs/' + job.id + '/stop', job);
+    return this.http.put<ImportJob>(ENDPOINTS.IMPORT_JOB() + '/' + job.id + '/stop', job);
   }
 }

--- a/webapp/src/main/webapp/src/app/services/invocations.service.ts
+++ b/webapp/src/main/webapp/src/app/services/invocations.service.ts
@@ -19,54 +19,61 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 import { DailyInvocations } from '../models/metric.model';
+
+const ENDPOINTS = {
+  INVOCATIONS: () => `${environment.apiUrl}api/invocations`,
+  INVOCATIONS_GLOBAL: () => ENDPOINTS.INVOCATIONS() + `/global`,
+  INVOCATIONS_GLOBAL_LAST: () => ENDPOINTS.INVOCATIONS() + `/global/last`,
+  INVOCATIONS_TOP: () => ENDPOINTS.INVOCATIONS() + `/top`,
+
+};
 
 @Injectable({ providedIn: 'root' })
 export class InvocationsService {
 
-  private rootUrl: string = '/api';
-
   constructor(private http: HttpClient) { }
 
-  public getInvocationStats(day: Date) : Observable<DailyInvocations> {
+  public getInvocationStats(day: Date): Observable<DailyInvocations> {
     if (day != null) {
       const dayStr = this.formatDayDate(day);
       const options = { params: new HttpParams().set('day', dayStr) };
-      return this.http.get<DailyInvocations>(this.rootUrl + '/invocations/global', options);
+      return this.http.get<DailyInvocations>(ENDPOINTS.INVOCATIONS_GLOBAL(), options);
     }
-    return this.http.get<DailyInvocations>(this.rootUrl + '/invocations/global');
+    return this.http.get<DailyInvocations>(ENDPOINTS.INVOCATIONS_GLOBAL());
   }
 
-  public getTopInvocations(day: Date) : Observable<DailyInvocations[]> {
+  public getTopInvocations(day: Date): Observable<DailyInvocations[]> {
     if (day != null) {
       const dayStr = this.formatDayDate(day);
       const options = { params: new HttpParams().set('day', dayStr) };
-      return this.http.get<DailyInvocations[]>(this.rootUrl + '/invocations/top', options);
+      return this.http.get<DailyInvocations[]>(ENDPOINTS.INVOCATIONS_TOP(), options);
     }
-    return this.http.get<DailyInvocations[]>(this.rootUrl + '/invocations/top');
+    return this.http.get<DailyInvocations[]>(ENDPOINTS.INVOCATIONS_TOP());
   }
 
-  public getServiceInvocationStats(serviceName: string, serviceVersion: string, day: Date) : Observable<DailyInvocations> {
+  public getServiceInvocationStats(serviceName: string, serviceVersion: string, day: Date): Observable<DailyInvocations> {
     if (day != null) {
       const dayStr = this.formatDayDate(day);
       const options = { params: new HttpParams().set('day', dayStr) };
-      return this.http.get<DailyInvocations>(this.rootUrl + '/invocations/' + serviceName + '/' + serviceVersion, options);
+      return this.http.get<DailyInvocations>(ENDPOINTS.INVOCATIONS() + '/' + serviceName + '/' + serviceVersion, options);
     }
-    return this.http.get<DailyInvocations>(this.rootUrl + '/invocations/' + serviceName + '/' + serviceVersion);
+    return this.http.get<DailyInvocations>(ENDPOINTS.INVOCATIONS() + '/' + serviceName + '/' + serviceVersion);
   }
 
-  public getInvocationsStatsTrend(limit: number) : Observable<any> {
+  public getInvocationsStatsTrend(limit: number): Observable<any> {
     if (limit != null) {
       const options = { params: new HttpParams().set('limit', limit.toString()) };
-      return this.http.get<any>(this.rootUrl + '/invocations/global/last', options);
+      return this.http.get<any>(ENDPOINTS.INVOCATIONS_GLOBAL_LAST(), options);
     }
-    return this.http.get<any>(this.rootUrl + '/invocations/global/last');
+    return this.http.get<any>(ENDPOINTS.INVOCATIONS_GLOBAL_LAST());
   }
 
-  public formatDayDate(day: Date) : string {
+  public formatDayDate(day: Date): string {
     var result = day.getFullYear().toString();
-    result += day.getMonth() < 9 ? '0' + (day.getMonth()+1).toString() : (day.getMonth()+1).toString();
+    result += day.getMonth() < 9 ? '0' + (day.getMonth() + 1).toString() : (day.getMonth() + 1).toString();
     result += day.getDate() < 10 ? '0' + day.getDate().toString() : day.getDate().toString();
     return result;
   }

--- a/webapp/src/main/webapp/src/app/services/secrets.service.ts
+++ b/webapp/src/main/webapp/src/app/services/secrets.service.ts
@@ -19,41 +19,42 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 import { Secret } from '../models/secret.model';
 import { IAuthenticationService } from './auth.service';
 
-
+const ENDPOINTS = {
+  SECRETS: () => `${environment.apiUrl}api/secrets`
+};
 @Injectable({ providedIn: 'root' })
 export class SecretsService {
-
-  private rootUrl: string = '/api';
 
   constructor(private http: HttpClient) { }
 
   getSecrets(page: number = 1, pageSize: number = 20): Observable<Secret[]> {
     const options = { params: new HttpParams().set('page', String(page - 1)).set('size', String(pageSize)) };
-    return this.http.get<Secret[]>(this.rootUrl + '/secrets', options);
+    return this.http.get<Secret[]>(ENDPOINTS.SECRETS(), options);
   }
 
   filterSecrets(filter: string): Observable<Secret[]> {
     const options = { params: new HttpParams().set('name', filter) };
-    return this.http.get<Secret[]>(this.rootUrl + '/secrets', options);
+    return this.http.get<Secret[]>(ENDPOINTS.SECRETS(), options);
   }
 
-  countSecrets(): Observable<any> { 
-    return this.http.get<any>(this.rootUrl + '/secrets/count');
+  countSecrets(): Observable<any> {
+    return this.http.get<any>(ENDPOINTS.SECRETS() + '/count');
   }
 
   createSecret(secret: Secret): Observable<Secret> {
-    return this.http.post<Secret>(this.rootUrl + '/secrets', secret);
+    return this.http.post<Secret>(ENDPOINTS.SECRETS(), secret);
   }
 
   updateSecret(secret: Secret): Observable<Secret> {
-    return this.http.put<Secret>(this.rootUrl + '/secrets/' + secret.id, secret);
+    return this.http.put<Secret>(ENDPOINTS.SECRETS() + '/' + secret.id, secret);
   }
 
   deleteSecret(secret: Secret): Observable<Secret> {
-    return this.http.delete<Secret>(this.rootUrl + '/secrets/' + secret.id);
+    return this.http.delete<Secret>(ENDPOINTS.SECRETS() + '/' + secret.id);
   }
 }

--- a/webapp/src/main/webapp/src/app/services/services.service.ts
+++ b/webapp/src/main/webapp/src/app/services/services.service.ts
@@ -19,19 +19,24 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 import { Service, ServiceView, Api, GenericResource, OperationMutableProperties, Metadata } from '../models/service.model';
+
+const ENDPOINTS = {
+  GENERIC_RESOURCE: () => `${environment.apiUrl}api/genericresources/service`,
+  SERVICES: () => `${environment.apiUrl}api/services`
+};
 
 @Injectable({ providedIn: 'root' })
 export class ServicesService {
 
-  private rootUrl: string = '/api';
 
   constructor(private http: HttpClient) { }
 
   public getServices(page: number = 1, pageSize: number = 20): Observable<Service[]> {
     const options = { params: new HttpParams().set('page', String(page - 1)).set('size', String(pageSize)) };
-    return this.http.get<Service[]>(this.rootUrl + '/services', options);
+    return this.http.get<Service[]>(ENDPOINTS.SERVICES(), options);
   }
 
   public filterServices(labelsFilter: Map<string, string>, nameFilter: string): Observable<Service[]> {
@@ -40,60 +45,60 @@ export class ServicesService {
       httpParams = httpParams.set('name', nameFilter);
     }
     if (labelsFilter != null) {
-      for (let key of Array.from( labelsFilter.keys() )) {
+      for (let key of Array.from(labelsFilter.keys())) {
         httpParams = httpParams.set('labels.' + key, labelsFilter.get(key));
       }
     }
-    
+
     const options = { params: httpParams };
-    return this.http.get<Service[]>(this.rootUrl + '/services/search', options);
+    return this.http.get<Service[]>(ENDPOINTS.SERVICES() + '/search', options);
   }
 
-  public countServices(): Observable<any> { 
-    return this.http.get<any>(this.rootUrl + '/services/count');
+  public countServices(): Observable<any> {
+    return this.http.get<any>(ENDPOINTS.SERVICES() + '/count');
   }
 
   public getServicesMap(): Observable<any> {
-    return this.http.get<any>(this.rootUrl + '/services/map');
+    return this.http.get<any>(ENDPOINTS.SERVICES() + '/map');
   }
 
   public getServicesLabels(): Observable<any> {
-    return this.http.get<any>(this.rootUrl + '/services/labels');
+    return this.http.get<any>(ENDPOINTS.SERVICES() + '/labels');
   }
 
   public getServiceView(serviceId: string): Observable<ServiceView> {
     const options = { params: new HttpParams().set('messages', 'true') };
-    return this.http.get<ServiceView>(this.rootUrl + '/services/' + serviceId, options);
+    return this.http.get<ServiceView>(ENDPOINTS.SERVICES() + '/' + serviceId, options);
   }
 
   public getService(serviceId: string): Observable<Service> {
     const options = { params: new HttpParams().set('messages', 'false') };
-    return this.http.get<Service>(this.rootUrl + '/services/' + serviceId, options);
+    return this.http.get<Service>(ENDPOINTS.SERVICES() + '/' + serviceId, options);
   }
 
   public createDynamicAPI(api: Api): Observable<Service> {
-    return this.http.post<Service>(this.rootUrl + '/services/generic', api);
+    return this.http.post<Service>(ENDPOINTS.SERVICES() + '/generic', api);
   }
 
   public deleteService(service: Service): Observable<Service> {
-    return this.http.delete<Service>(this.rootUrl + '/services/' + service.id);
+    return this.http.delete<Service>(ENDPOINTS.SERVICES() + '/' + service.id);
   }
 
   public getGenericResources(service: Service, page: number = 1, pageSize: number = 20): Observable<GenericResource[]> {
     const options = { params: new HttpParams().set('page', String(page - 1)).set('size', String(pageSize)) };
-    return this.http.get<GenericResource[]>(this.rootUrl + '/genericresources/service/' + service.id, options);
+    return this.http.get<GenericResource[]>(ENDPOINTS.GENERIC_RESOURCE() + '/' + service.id, options);
   }
 
   public updateServiceMetadata(service: Service, metadata: Metadata): Observable<any> {
-    return this.http.put<any>(this.rootUrl + '/services/' + service.id + '/metadata', metadata);
+    return this.http.put<any>(ENDPOINTS.SERVICES() + '/' + service.id + '/metadata', metadata);
   }
 
   public updateServiceOperationProperties(service: Service, operationName: string, properties: OperationMutableProperties): Observable<any> {
     const options = { params: new HttpParams().set('operationName', operationName) };
-    return this.http.put<any>(this.rootUrl + '/services/' + service.id + '/operation', properties, options);
+    return this.http.put<any>(ENDPOINTS.SERVICES() + '/' + service.id + '/operation', properties, options);
   }
 
   public countGenericResources(service: Service): Observable<any> {
-    return this.http.get<any>(this.rootUrl + '/genericresources/service/' + service.id + '/count');
+    return this.http.get<any>(ENDPOINTS.GENERIC_RESOURCE() + '/' + service.id + '/count');
   }
 }

--- a/webapp/src/main/webapp/src/app/services/tests.service.ts
+++ b/webapp/src/main/webapp/src/app/services/tests.service.ts
@@ -19,32 +19,36 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 import { TestRequest, TestResult } from '../models/test.model';
 import { RequestResponsePair, UnidirectionalEvent } from '../models/service.model';
 
+const ENDPOINTS = {
+  TESTS: () => `${environment.apiUrl}api/tests`,
+  TESTS_SERVICES: () => ENDPOINTS.TESTS() + `/service`
+};
+
 @Injectable({ providedIn: 'root' })
 export class TestsService {
-
-  private rootUrl: string = '/api';
 
   constructor(private http: HttpClient) { }
 
   public listByServiceId(serviceId: string, page: number = 1, pageSize: number = 20): Observable<TestResult[]> {
     const options = { params: new HttpParams().set('page', String(page - 1)).set('size', String(pageSize)) };
-    return this.http.get<TestResult[]>(this.rootUrl + '/tests/service/' + serviceId, options);
+    return this.http.get<TestResult[]>(ENDPOINTS.TESTS_SERVICES() + '/' + serviceId, options);
   }
 
   public countByServiceId(serviceId: string): Observable<any> {
-    return this.http.get<any>(this.rootUrl + '/tests/service/' + serviceId + '/count');
+    return this.http.get<any>(ENDPOINTS.TESTS_SERVICES() + '/' + serviceId + '/count');
   }
 
   public getTestResult(resultId: string): Observable<TestResult> {
-    return this.http.get<any>(this.rootUrl + '/tests/' + resultId);
+    return this.http.get<any>(ENDPOINTS.TESTS() + '/' + resultId);
   }
 
   public create(testRequest: TestRequest): Observable<TestResult> {
-    return this.http.post<TestResult>(this.rootUrl +  '/tests', testRequest);
+    return this.http.post<TestResult>(ENDPOINTS.TESTS(), testRequest);
   }
 
   public getMessages(test: TestResult, operation: string): Observable<RequestResponsePair> {
@@ -53,7 +57,7 @@ export class TestsService {
     operation = operation.replace(/\//g, '_');
     var testCaseId = test.id + '-' + test.testNumber + '-' + encodeURIComponent(operation);
     console.log("[getMessages] called for " + testCaseId);
-    return this.http.get<RequestResponsePair>(this.rootUrl + '/tests/' + test.id + '/messages/' + testCaseId);
+    return this.http.get<RequestResponsePair>(ENDPOINTS.TESTS() + '/' + test.id + '/messages/' + testCaseId);
   }
 
   public getEventMessages(test: TestResult, operation: string): Observable<UnidirectionalEvent> {
@@ -62,6 +66,6 @@ export class TestsService {
     operation = operation.replace(/\//g, '_');
     var testCaseId = test.id + '-' + test.testNumber + '-' + encodeURIComponent(operation);
     console.log("[getEventMessages] called for " + testCaseId);
-    return this.http.get<UnidirectionalEvent>(this.rootUrl + '/tests/' + test.id + '/events/' + testCaseId);
+    return this.http.get<UnidirectionalEvent>(ENDPOINTS.TESTS() + '/' + test.id + '/events/' + testCaseId);
   }
 }

--- a/webapp/src/main/webapp/src/app/services/users.service.ts
+++ b/webapp/src/main/webapp/src/app/services/users.service.ts
@@ -20,6 +20,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
+import { environment } from 'src/environments/environment';
 
 import { User } from '../models/user.model';
 import { IAuthenticationService } from './auth.service';
@@ -30,7 +31,7 @@ import { KeycloakAuthenticationService } from './auth-keycloak.service';
 export class UsersService {
 
   private rootUrl: string = '/api';
-  
+
   private microcksAppClientId: string;
 
   constructor(private http: HttpClient, protected authService: IAuthenticationService) {
@@ -72,13 +73,13 @@ export class UsersService {
   getMicrocksAppClientId(): string {
     return this.microcksAppClientId;
   }
-  
+
   filterUsers(filter: string): Observable<User[]> {
     const options = { params: new HttpParams().set('search', filter) };
     return this.http.get<User[]>(this.rootUrl + '/users', options);
   }
 
-  countUsers(): Observable<any> { 
+  countUsers(): Observable<any> {
     return this.http.get<User[]>(this.rootUrl + '/users/count');
   }
 
@@ -86,10 +87,10 @@ export class UsersService {
     return this.http.get<any[]>(this.rootUrl + '/users/' + userId + '/role-mappings/clients/' + this.microcksAppClientId);
   }
 
-  assignRoleToUser(userId: string, role: string): Observable<any> { 
+  assignRoleToUser(userId: string, role: string): Observable<any> {
     return this.getRoleByName(role).pipe(
       switchMap((role: any) => {
-        return this.http.post<any[]>(this.rootUrl + '/users/' + userId + '/role-mappings/clients/' + this.microcksAppClientId, [ role ]); 
+        return this.http.post<any[]>(this.rootUrl + '/users/' + userId + '/role-mappings/clients/' + this.microcksAppClientId, [role]);
       })
     );
   }
@@ -97,8 +98,8 @@ export class UsersService {
   removeRoleFromUser(userId: string, role: string): Observable<any> {
     return this.getRoleByName(role).pipe(
       switchMap((role: any) => {
-        return this.http.request<any[]>('delete', 
-          this.rootUrl + '/users/' + userId + '/role-mappings/clients/' + this.microcksAppClientId, { body: [ role ] });
+        return this.http.request<any[]>('delete',
+          this.rootUrl + '/users/' + userId + '/role-mappings/clients/' + this.microcksAppClientId, { body: [role] });
       })
     );
   }

--- a/webapp/src/main/webapp/src/app/services/versioninfo.service.ts
+++ b/webapp/src/main/webapp/src/app/services/versioninfo.service.ts
@@ -19,15 +19,19 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+
+const ENDPOINTS = {
+  VERSION_INFO: () => `${environment.apiUrl}api/version/info/`
+};
 
 @Injectable({ providedIn: 'root' })
 export class VersionInfoService {
 
-  private rootUrl: string = '/api';
-
   constructor(private http: HttpClient) { }
 
   public getVersionInfo(): Observable<any> {
-    return this.http.get<any>(this.rootUrl + '/version/info/');
+    return this.http.get<any>(ENDPOINTS.VERSION_INFO());
   }
 }

--- a/webapp/src/main/webapp/src/environments/environment-loader.ts
+++ b/webapp/src/main/webapp/src/environments/environment-loader.ts
@@ -1,0 +1,20 @@
+import { environment as defaultEnvironment } from './environment';
+
+/**
+ * Loads the environment available in the assets folder. This enables dynamic configuration for Docker images.
+ */
+export const environmentLoader = new Promise<any>((resolve, reject) => {
+    const xmlhttp = new XMLHttpRequest();
+    const url = './environment/environment.json';
+    console.log("Loading environment from url", url)
+    xmlhttp.open('GET', url, true);
+    xmlhttp.onload = () => {
+        if (xmlhttp.status === 200) {
+            resolve(JSON.parse(xmlhttp.responseText));
+        } else {
+            console.log('Default env is used!');
+            resolve(defaultEnvironment);
+        }
+    };
+    xmlhttp.send();
+});

--- a/webapp/src/main/webapp/src/environments/environment.prod.ts
+++ b/webapp/src/main/webapp/src/environments/environment.prod.ts
@@ -1,3 +1,5 @@
 export const environment = {
-  production: true
+  production: true,
+  apiUrl: 'http://localhost:8080/',
+  baseContext: '/'
 };

--- a/webapp/src/main/webapp/src/environments/environment.ts
+++ b/webapp/src/main/webapp/src/environments/environment.ts
@@ -3,7 +3,9 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: 'http://localhost:8080/',
+  baseContext: '/'
 };
 
 /*

--- a/webapp/src/main/webapp/src/index.html
+++ b/webapp/src/main/webapp/src/index.html
@@ -4,10 +4,13 @@
 <head>
   <meta charset="utf-8">
   <title>Microcks-UI</title>
-  <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="assets/favicon.ico">
+  <script>
+    window['base-href'] = window.location.pathname;
+    console.log(window['base-href']);
+  </script>
 </head>
 
 <body>

--- a/webapp/src/main/webapp/src/main.ts
+++ b/webapp/src/main/webapp/src/main.ts
@@ -3,24 +3,48 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+import { environmentLoader } from './environments/environment-loader';
 
-if (environment.production) {
-  enableProdMode();
-}
 
-var keycloak = window["Keycloak"](location.origin + '/api/keycloak/config');
-var loginOptions = {onLoad: 'login-required'};
-console.log("location.origin: " + location.origin);
-if (location.origin.indexOf("/localhost:") != -1) {
-  console.log("[Microcks launch] Running locally so disabling Keycloak checkLogin Iframe to respect modern browser restrictions");
-  loginOptions['checkLoginIframe'] = false;
-}
-keycloak.init(loginOptions).then(function (authenticated) {
-  if (authenticated) {
+environmentLoader.then((env) => {
+
+  /**
+   * Replaces the environment values with the assets environment.json data.
+   */
+  Object.assign(environment, env);
+
+  /**
+   * Enables production mode and disables all logs.
+   */
+  if (environment.production) {
+    enableProdMode();
+    console.log = () => { };
+    console.warn = () => { };
+  }
+
+  console.log('loaded environment: ' + JSON.stringify(env));
+
+  let keycloakUrl = `${environment.apiUrl}api/keycloak/config`
+
+  initKeycloakConnection(keycloakUrl);
+});
+
+function initKeycloakConnection(keycloakUrl: string) {
+  var keycloak = window["Keycloak"](keycloakUrl);
+
+  var loginOptions = { onLoad: 'login-required' };
+  if (location.origin.indexOf("/localhost:") != -1) {
+    console.log("[Microcks launch] Running locally so disabling Keycloak checkLogin Iframe to respect modern browser restrictions");
+    loginOptions['checkLoginIframe'] = false;
+  }
+  keycloak.init(loginOptions).then(function (authenticated) {
+    if (authenticated) {
       window['keycloak'] = keycloak;
       platformBrowserDynamic().bootstrapModule(AppModule)
-      .catch(err => console.log(err));
-  }
-}).catch(function () {
-  alert('Failed to initialize authentication subsystem.');
-});
+        .catch(err => console.log(err));
+    }
+  }).catch(function () {
+    alert('Failed to initialize authentication subsystem.');
+  });
+}
+


### PR DESCRIPTION
This PR allows to configure a subcontext (sub http path) for the Angular and Spring boot app and Keycloak. For example, the services then listen to the following urls: `https://example.com/mock-server/auth/` & `https://example.com/mock-server/microcks/`

Work is still in progress, but I already have a working deployment up and running on my Azure Kubernetes cluster with Istio. 

Signed-off-by: Florian Hopfensperger <florian.hopfensperger@de.ibm.com>