### PR TITLE
Handle SOAP 1.2 requests (Issue #356)

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/SoapController.java
+++ b/webapp/src/main/java/io/github/microcks/web/SoapController.java
@@ -189,9 +189,16 @@ public class SoapController {
             response = responses.get(0);
          }
 
-         // Set Content-Type to "text/xml".
          HttpHeaders responseHeaders = new HttpHeaders();
-         responseHeaders.setContentType(MediaType.valueOf("text/xml;charset=UTF-8"));
+
+         // Check to see if we are processing a SOAP 1.2 request
+         if (request.getContentType().startsWith("application/soap+xml")) {
+           // we are; set Content-Type to "application/soap+xml"
+           responseHeaders.setContentType(MediaType.valueOf("application/soap+xml;charset=UTF-8"));
+         } else {
+           // Set Content-Type to "text/xml".
+           responseHeaders.setContentType(MediaType.valueOf("text/xml;charset=UTF-8"));
+         }
 
          // Render response content before waiting and returning.
          String responseContent = MockControllerCommons.renderResponseContent(body, null, request, response);


### PR DESCRIPTION
This fix does a simple check to see if the request Content-Type was SOAP 1.2 based and returns that Content-Type value if true.  It assumes the creator of the Mock SOAP service has used the correct SOAP envelope namespace value to match the response type (1.1="xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/", 1.2=xmlns:soap="http://www.w3.org/2003/05/soap-envelope").

It would be helpful if the SoapUI instructions included a paragraph about the above + some other things I had to discover the hard way (e.g. SoapUI script dispatching needs to return a specific response and cannot use scripting to throw an error; when looking for an attribute name, you have to use the namespace value if present)