### PR TITLE
Use same password as operator install

### DIFF
--- a/install/docker-compose/README.md
+++ b/install/docker-compose/README.md
@@ -31,7 +31,7 @@ This will start the required containers and setup an simple environment for your
 Open a new browser tab and point to the `http://localhost:8080` endpoint. This will redirect you to the [Keycloak](https://www.keycloak.org/) Single Sign On page for login. Use the following default credentials:
 
 * **Username:** admin
-* **Password:** 123
+* **Password:** microcks123
 
 You will be redirected to the main dashboard page. You can now start [using Microcks](https://microcks.io/documentation/getting-started/#using-microcks).
 

--- a/install/docker-compose/keycloak-realm/microcks-realm-sample.json
+++ b/install/docker-compose/keycloak-realm/microcks-realm-sample.json
@@ -11,7 +11,7 @@
       "enabled": true,
       "credentials" : [
         { "type" : "password",
-          "value" : "123" }
+          "value" : "microcks123" }
       ],
       "realmRoles": [],
       "applicationRoles": {


### PR DESCRIPTION
change the docker-compose user's password to use the same as the operator.