### PR TITLE
Add topic channel substitution parameters for AsyncAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ target
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+.settings
+.classpath
+.project
+.DS_Store
+*.log
+microcks-async-minion-100-tcpmr1i5g7tif6z9hmessagingsolacecloud1883/.lck

--- a/commons/model/src/main/java/io/github/microcks/domain/EventMessage.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/EventMessage.java
@@ -29,6 +29,7 @@ public class EventMessage extends Message {
    @Id
    private String id;
    private String mediaType;
+   private String dispatchCriteria;
 
    public String getId() {
       return id;
@@ -44,5 +45,13 @@ public class EventMessage extends Message {
 
    public void setMediaType(String mediaType) {
       this.mediaType = mediaType;
+   }
+
+   public String getDispatchCriteria() {
+      return dispatchCriteria;
+   }
+
+   public void setDispatchCriteria(String dispatchCriteria) {
+      this.dispatchCriteria = dispatchCriteria;
    }
 }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/MQTTProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/MQTTProducerManager.java
@@ -80,7 +80,8 @@ public class MQTTProducerManager {
     */
    protected IMqttClient createClient() throws Exception {
       MqttConnectOptions options = new MqttConnectOptions();
-      if (mqttUsername != null && mqttUsername.length() > 0 && mqttPassword != null && mqttPassword.length() > 0) {
+      if (mqttUsername != null && mqttUsername.length() > 0 
+            && mqttPassword != null && mqttPassword.length() > 0) {
          options.setUserName(mqttUsername);
          options.setPassword(mqttPassword.toCharArray());
       }
@@ -96,7 +97,6 @@ public class MQTTProducerManager {
 
    /**
     * Publish a message on specified topic.
-    * 
     * @param topic The destination topic for message
     * @param value The message payload
     */

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
@@ -82,6 +82,7 @@ public class ProducerManager {
 
       Set<AsyncMockDefinition> mockDefinitions = mockRepository.getMockDefinitionsByFrequency(frequency);
       for (AsyncMockDefinition definition : mockDefinitions) {
+         logger.debugf("Processing definition of service {%s}", definition.getOwnerService().getName() + ':' + definition.getOwnerService().getVersion());
 
          for (String binding : definition.getOperation().getBindings().keySet()) {
             // Ensure this minion supports this binding.
@@ -101,12 +102,14 @@ public class ProducerManager {
 
                            try {
                               if ("REGISTRY".equals(defaultAvroEncoding) && kafkaProducerManager.isRegistryEnabled()) {
+                                 logger.debug("Using a registry and converting message to Avro record");
                                  GenericRecord avroRecord = AvroUtil.jsonToAvroRecord(message, schemaContent);
                                  kafkaProducerManager.publishMessage(topic, key, avroRecord,
                                        kafkaProducerManager.renderEventMessageHeaders(
                                              TemplateEngineFactory.getTemplateEngine(), eventMessage.getHeaders()
                                        ));
                               } else {
+                                 logger.debug("Converting message to Avro bytes array");
                                  byte[] avroBinary = AvroUtil.jsonToAvro(message, schemaContent);
                                  kafkaProducerManager.publishMessage(topic, key, avroBinary,
                                        kafkaProducerManager.renderEventMessageHeaders(

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
@@ -44,11 +44,9 @@ import java.util.Set;
 @Unremovable
 @ApplicationScoped
 /**
- * ProducerManager is the responsible for emitting mock event messages when specific frequency
- * triggered is reached. Need to specify it as @Unremovable to avoid Quarkus ARC optimization
- * removing beans that are not injected elsewhere (this one is resolved using
- * Arc.container().instance() method from ProducerScheduler).
- * 
+ * ProducerManager is the responsible for emitting mock event messages when specific frequency triggered is reached. 
+ * Need to specify it as @Unremovable to avoid Quarkus ARC optimization removing beans that are not injected elsewhere 
+ * (this one is resolved using Arc.container().instance() method from ProducerScheduler).
  * @author laurent
  */
 public class ProducerManager {
@@ -76,7 +74,6 @@ public class ProducerManager {
 
    /**
     * Produce all the async mock messages corresponding to specified frequency.
-    * 
     * @param frequency The frequency to emit messages for
     */
    public void produceAsyncMockMessagesAt(Long frequency) {

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
@@ -20,7 +20,6 @@ package io.github.microcks.minion.async.producer;
 
 import io.github.microcks.domain.BindingType;
 import io.github.microcks.domain.EventMessage;
-import io.github.microcks.domain.Header;
 import io.github.microcks.minion.async.AsyncMockDefinition;
 import io.github.microcks.minion.async.AsyncMockRepository;
 import io.github.microcks.minion.async.SchemaRegistry;
@@ -37,17 +36,19 @@ import org.jboss.logging.Logger;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Unremovable
 @ApplicationScoped
 /**
- * ProducerManager is the responsible for emitting mock event messages when specific frequency triggered is reached.
- * Need to specify it as @Unremovable to avoid Quarkus ARC optimization removing beans that are not injected elsewhere
- * (this one is resolved using Arc.container().instance() method from ProducerScheduler).
+ * ProducerManager is the responsible for emitting mock event messages when specific frequency
+ * triggered is reached. Need to specify it as @Unremovable to avoid Quarkus ARC optimization
+ * removing beans that are not injected elsewhere (this one is resolved using
+ * Arc.container().instance() method from ProducerScheduler).
+ * 
  * @author laurent
  */
 public class ProducerManager {
@@ -75,6 +76,7 @@ public class ProducerManager {
 
    /**
     * Produce all the async mock messages corresponding to specified frequency.
+    * 
     * @param frequency The frequency to emit messages for
     */
    public void produceAsyncMockMessagesAt(Long frequency) {
@@ -89,8 +91,8 @@ public class ProducerManager {
             if (Arrays.asList(supportedBindings).contains(binding)) {
                switch (BindingType.valueOf(binding)) {
                   case KAFKA:
-                     String topic = getKafkaTopicName(definition);
                      for (EventMessage eventMessage : definition.getEventMessages()) {
+                        String topic = kafkaProducerManager.getTopicName(definition, eventMessage);
                         String key = String.valueOf(System.currentTimeMillis());
                         String message = renderEventMessageContent(eventMessage);
 
@@ -104,43 +106,41 @@ public class ProducerManager {
                               if ("REGISTRY".equals(defaultAvroEncoding) && kafkaProducerManager.isRegistryEnabled()) {
                                  logger.debug("Using a registry and converting message to Avro record");
                                  GenericRecord avroRecord = AvroUtil.jsonToAvroRecord(message, schemaContent);
-                                 kafkaProducerManager.publishMessage(topic, key, avroRecord,
-                                       kafkaProducerManager.renderEventMessageHeaders(
-                                             TemplateEngineFactory.getTemplateEngine(), eventMessage.getHeaders()
-                                       ));
+                                 kafkaProducerManager.publishMessage(topic, key, avroRecord, kafkaProducerManager
+                                       .renderEventMessageHeaders(TemplateEngineFactory.getTemplateEngine(), eventMessage.getHeaders()));
                               } else {
                                  logger.debug("Converting message to Avro bytes array");
                                  byte[] avroBinary = AvroUtil.jsonToAvro(message, schemaContent);
-                                 kafkaProducerManager.publishMessage(topic, key, avroBinary,
-                                       kafkaProducerManager.renderEventMessageHeaders(
-                                             TemplateEngineFactory.getTemplateEngine(), eventMessage.getHeaders()
-                                       ));
+                                 kafkaProducerManager.publishMessage(topic, key, avroBinary, kafkaProducerManager
+                                       .renderEventMessageHeaders(TemplateEngineFactory.getTemplateEngine(), eventMessage.getHeaders()));
                               }
                            } catch (Exception e) {
                               logger.errorf("Exception while converting {%s} to Avro using schema {%s}", message, schemaContent, e);
                            }
                         } else {
-                           kafkaProducerManager.publishMessage(topic, key, message, kafkaProducerManager.renderEventMessageHeaders(
-                                 TemplateEngineFactory.getTemplateEngine(), eventMessage.getHeaders()
-                           ));
+                           kafkaProducerManager.publishMessage(topic, key, message, kafkaProducerManager
+                                 .renderEventMessageHeaders(TemplateEngineFactory.getTemplateEngine(), eventMessage.getHeaders()));
                         }
                      }
                      break;
                   case MQTT:
-                     topic = getMQTTTopicName(definition);
                      for (EventMessage eventMessage : definition.getEventMessages()) {
+                        String topic = mqttProducerManager.getTopicName(definition, eventMessage);
                         String message = renderEventMessageContent(eventMessage);
                         mqttProducerManager.publishMessage(topic, message);
                      }
                      break;
-               }
+                  default:
+                     break;
+                }
             }
          }
-
       }
    }
 
-   /** Render event message content from definition applying template rendering if required. */
+   /**
+    * Render event message content from definition applying template rendering if required.
+    */
    private String renderEventMessageContent(EventMessage eventMessage) {
       String content = eventMessage.getContent();
       if (content.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
@@ -156,36 +156,19 @@ public class ProducerManager {
       return content;
    }
 
-   /** Get the Kafka topic name corresponding to a AsyncMockDefinition, sanitizing all parameters. */
-   private String getKafkaTopicName(AsyncMockDefinition definition) {
-      // Produce service name part of topic name.
-      String serviceName = definition.getOwnerService().getName().replace(" ", "");
-      serviceName = serviceName.replace("-", "");
-      // Produce version name part of topic name.
-      String versionName = definition.getOwnerService().getVersion().replace(" " , "");
-      // Produce operation name part of topic name.
-      String operationName = definition.getOperation().getName();
-      if (operationName.startsWith("SUBSCRIBE ")) {
-         operationName = operationName.substring(operationName.indexOf(" ") + 1);
+   public static String replacePartPlaceholders(EventMessage eventMessage, String operationName) {
+      String partsCriteria = eventMessage.getDispatchCriteria();
+      if (partsCriteria != null && !partsCriteria.isBlank()) {
+         String[] criterion = partsCriteria.split("/");
+         for (String criteria : criterion) {
+            if (criteria != null && !criteria.isBlank()) {
+               String[] element = criteria.split("=");
+               String key = String.format("\\{%s\\}", element[0]);
+               operationName = operationName.replaceAll(key, URLEncoder.encode(element[1], Charset.defaultCharset()));
+            }
+         }
       }
-      operationName = operationName.replace('/', '-');
-      // Aggregate the 3 parts using '-' as delimiter.
-      return serviceName + "-" + versionName + "-" + operationName;
+      return operationName;
    }
 
-   /** Get the MQTT topic name corresponding to a AsyncMockDefinition, sanitizing all parameters. */
-   private String getMQTTTopicName(AsyncMockDefinition definition) {
-      // Produce service name part of topic name.
-      String serviceName = definition.getOwnerService().getName().replace(" ", "");
-      serviceName = serviceName.replace("-", "");
-      // Produce version name part of topic name.
-      String versionName = definition.getOwnerService().getVersion().replace(" " , "");
-      // Produce operation name part of topic name.
-      String operationName = definition.getOperation().getName();
-      if (operationName.startsWith("SUBSCRIBE ")) {
-         operationName = operationName.substring(operationName.indexOf(" ") + 1);
-      }
-      // Aggregate the 3 parts using '-' as delimiter.
-      return serviceName + "-" + versionName + "-" + operationName;
-   }
 }

--- a/webapp/src/main/java/io/github/microcks/util/asyncapi/AsyncAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/asyncapi/AsyncAPIImporter.java
@@ -452,7 +452,7 @@ public class AsyncAPIImporter implements MockRepositoryImporter  {
 
    /** Check variables parts presence into given channel. */
    private static boolean channelHasParts(String channel) {
-      return (channel.indexOf("/:") != -1 || channel.indexOf("/{") != -1);
+      return (channel.indexOf("/{") != -1);
    }
 
    /**

--- a/webapp/src/main/java/io/github/microcks/web/TestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/TestController.java
@@ -134,9 +134,10 @@ public class TestController {
          @PathVariable("testCaseId") String testCaseId
       ) {
       // We may have testCaseId being URLEncoded, with forbidden '/' replaced by '_' so unwrap id.
+      // Switched form _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal
       try {
          testCaseId = URLDecoder.decode(testCaseId, StandardCharsets.UTF_8.toString());
-         testCaseId = testCaseId.replace('_', '/');
+         testCaseId = testCaseId.replace('!', '/');
       } catch (UnsupportedEncodingException e) {
          return null;
       }
@@ -150,9 +151,10 @@ public class TestController {
          @PathVariable("testCaseId") String testCaseId
    ) {
       // We may have testCaseId being URLEncoded, with forbidden '/' replaced by '_' so unwrap id.
+      // Switched form _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal
       try {
          testCaseId = URLDecoder.decode(testCaseId, StandardCharsets.UTF_8.toString());
-         testCaseId = testCaseId.replace('_', '/');
+         testCaseId = testCaseId.replace('!', '/');
       } catch (UnsupportedEncodingException e) {
          return null;
       }

--- a/webapp/src/main/webapp/src/app/models/service.model.ts
+++ b/webapp/src/main/webapp/src/app/models/service.model.ts
@@ -143,6 +143,7 @@ export class Response extends Message {
 export class EventMessage extends Message {
   id: string;
   mediaType: string;
+  dispatchCriteria: string;  
 }
 
 export abstract class Exchange {

--- a/webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.ts
@@ -285,6 +285,22 @@ export class ServiceDetailPageComponent implements OnInit {
 
     // Remove verb and replace '/' by '-' in operation name.
     operationName = this.removeVerbInUrl(operationName);
+    const parts = {};
+    let partsCriteria = eventMessage.dispatchCriteria;
+    if (partsCriteria != null) {
+
+      partsCriteria = this.encodeUrl(partsCriteria);
+      partsCriteria.split('/').forEach(function (element, index, array) {
+        if (element) {
+          parts[element.split('=')[0]] = element.split('=')[1];
+        }
+      });
+
+      operationName = operationName.replace(/{([a-zA-Z0-9-_]+)}/g, function (match, p1, string) {
+        return (parts[p1] != null) ? parts[p1] : match;
+      });
+    }
+
     if ('KAFKA' === binding) {
       operationName = operationName.replace(/\//g, '-');
     }

--- a/webapp/src/main/webapp/src/app/services/tests.service.ts
+++ b/webapp/src/main/webapp/src/app/services/tests.service.ts
@@ -49,8 +49,9 @@ export class TestsService {
 
   public getMessages(test: TestResult, operation: string): Observable<RequestResponsePair> {
     // operation may contain / that are forbidden within encoded URI.
-    // Replace them by "_" and implement same protocole on server-side.
-    operation = operation.replace(/\//g, '_');
+    // Replace them by "!" and implement same protocole on server-side.
+    // Switched from _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal
+    operation = operation.replace(/\//g, '!');
     var testCaseId = test.id + '-' + test.testNumber + '-' + encodeURIComponent(operation);
     console.log("[getMessages] called for " + testCaseId);
     return this.http.get<RequestResponsePair>(this.rootUrl + '/tests/' + test.id + '/messages/' + testCaseId);
@@ -58,8 +59,9 @@ export class TestsService {
 
   public getEventMessages(test: TestResult, operation: string): Observable<UnidirectionalEvent> {
     // operation may contain / that are forbidden within encoded URI.
-    // Replace them by "_" and implement same protocole on server-side.
-    operation = operation.replace(/\//g, '_');
+    // Replace them by "!" and implement same protocole on server-side.
+    // Switched from _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal
+    operation = operation.replace(/\//g, '!');
     var testCaseId = test.id + '-' + test.testNumber + '-' + encodeURIComponent(operation);
     console.log("[getEventMessages] called for " + testCaseId);
     return this.http.get<UnidirectionalEvent>(this.rootUrl + '/tests/' + test.id + '/events/' + testCaseId);


### PR DESCRIPTION
Uses examples given in schema definition for channel parameters  to replace placeholders in topic string.

Implemented in app (the mock urls/topics displayed for each sample message) and also in the minion's AsyncAPI Producer.

See - MQTT Topic in this screenshot - 
![image](https://user-images.githubusercontent.com/3858485/113730958-42aec700-96f0-11eb-8b34-6daa63714b95.png)

Also - an example AsyncAPI file for testing attached:

[api-maintenance.async-api-spec.txt](https://github.com/microcks/microcks/files/6265538/api-maintenance.async-api-spec.txt)
