### PR TITLE
Set Keycloak DB to h2 when using docker-compose

### DIFF
--- a/install/docker-compose/docker-compose.yml
+++ b/install/docker-compose/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     ports:
       - "18080:8080"
     environment:
+      DB_VENDOR: "h2"
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "admin"
       KEYCLOAK_IMPORT: "/tmp/microcks-realm.json"


### PR DESCRIPTION
The current compose fails to launch Keycloak as the entrypoint script expects the "DB_ADDR" environment variable to be set, and then defaults to trying to connect to Postgres. The in-memory database h2 is used instead of running another container with Postgres.