### PR TITLE
Allow service type override on helm install

### DIFF
--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -76,7 +76,7 @@ username and password found into 'microcks-keycloak-admin' secret.
 
 ### Advanced install - with asynchronous mocking
 
-Since release `1.0.0`, Microcks support mocking of event-driven API thanks to [AsyncAPI Spec](https://asyncapi.com). Microcks will take car of publishing sample messages for you on a message broker. You mey reuse an existing broker of let Microcks deploy its own (this is the default when turning on this feature).
+Since release `1.0.0`, Microcks supports mocking of event-driven API thanks to [AsyncAPI Spec](https://asyncapi.com). Microcks will take care of publishing sample messages for you on a message broker. You may reuse an existing broker or let Microcks deploy its own (this is the default when turning on this feature).
 
 To install a Kafka message broker during its deployment, Microcks relies on [Strimzi Operator](https://strimzi.io) and will try to create such custom resources such as `Kafka` and `KafkaTopic`. When using this configuration, you will thus need to install Strimzi Operator cluster-wide or on targeted namespace.
 
@@ -133,19 +133,19 @@ All configurable variables and default values can be seen in `values.yaml`, with
 Typically, you may want to configure the following blocks and options:
 
 * Global part is mandatory and contain attributes like `appName` of your install,
-* `microcks` part is mandatory and contain attributes like the number of `replicas` and the access `url` if you want some customizations, 
+* `microcks` part is mandatory and contain attributes like the number of `replicas` and the access `url` if you want some customizations,
 * `postman` part is mandatory for the number of `replicas`
 * `keycloak` part is optional and allows specifying if you want a new install or reuse an existing instance,
 * `mongodb` part is optional and allows specifying if you want a new install or reuse an existing instance.
 * `features` part is optional and allows enabling and configuring opt-in features of Microcks.
 
-The table below describe all the fields of the `values.yaml`, providing informations on what's mandatory and what's optional as well as default values.
+The table below describes all the fields of the `values.yaml`, providing information on what's mandatory and what's optional as well as default values.
 
 | Section       | Property           | Description   |
 | ------------- | ------------------ | ------------- |
-| `microcks`    | `url`              | **Mandatory**. The URL to use for exposing `Ingress` | 
+| `microcks`    | `url`              | **Mandatory**. The URL to use for exposing `Ingress` |
 | `microcks`    | `ingressSecretRef` | **Optional**. The name of a TLS Secret for securing `Ingress`. If missing, self-signed certificate is generated. |
-| `microcks`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks main pod. If these annotations are triggering a Certificate generation (for example through https://cert-manager.io/). The `generateCert` property should be set to `false`. | 
+| `microcks`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks main pod. If these annotations are triggering a Certificate generation (for example through [cert-mamanger.io](https://cert-manager.io/)). The `generateCert` property should be set to `false`. |
 | `microcks`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |
 | `microcks`    | `replicas`         | **Optional**. The number of replicas for the Microcks main pod. Default is `1`. |
 | `microcks`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
@@ -157,9 +157,9 @@ The table below describe all the fields of the `values.yaml`, providing informat
 | `keycloak`    | `install`          | **Optional**. Flag for Keycloak installation. Default is `true`. Set to `false` if you want to reuse an existing Keycloak instance. |
 | `keycloak`    | `realm`            | **Optional**. Name of Keycloak realm to use. Should be setup only if `install` is `false` and you want to reuse an existing realm. Default is `microcks`. |
 | `keycloak`    | `url`              | **Mandatory**. The URL of Keycloak install - indeed just the hostname + port part - if it already exists or the one used for exposing Keycloak `Ingress`. |
-| `keycloak`    | `privateUrl`       | **Optional**. A private URL - a full URL here - used by the Microcks component to internally join Keycloak. This is also known as `backendUrl` in [Keycloak doc](https://www.keycloak.org/docs/latest/server_installation/#_hostname). When specified, the `keycloak.url` is used as `frontendUrl` in Keycloak terms. | 
+| `keycloak`    | `privateUrl`       | **Optional**. A private URL - a full URL here - used by the Microcks component to internally join Keycloak. This is also known as `backendUrl` in [Keycloak doc](https://www.keycloak.org/docs/latest/server_installation/#_hostname). When specified, the `keycloak.url` is used as `frontendUrl` in Keycloak terms. |
 | `keycloak`    | `ingressSecretRef` | **Optional**. The name of a TLS Secret for securing `Ingress`. If missing, self-signed certificate is generated. |
-| `keycloak`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. If these annotations are triggering a Certificate generation (for example through https://cert-manager.io/). The `generateCert` property should be set to `false`. |
+| `keycloak`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. If these annotations are triggering a Certificate generation (for example through [cert-mamanger.io](https://cert-manager.io/)). The `generateCert` property should be set to `false`. |
 | `keycloak`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |  
 | `keycloak`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
 | `keycloak`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
@@ -178,11 +178,10 @@ The table below describe all the fields of the `values.yaml`, providing informat
 | `features`    | `async.enabled`    | **Optional**. Feature allowing to mock an tests asynchronous APIs through Events. Enabling it requires an active message broker. Default is `false`. |
 | `features`    | `async.image`      | **Optional**. The reference of container image used for `async-minion` component. Chart comes with its default version. |
 
-
 ### Kafka feature details
 
 Here are below the configuration properties of the Kafka support feature:
- 
+
 | Section       | Property           | Description   |
 | ------------- | ------------------ | ------------- |
 | `features.async.kafka` | `install`    | **Optional**. Flag for Kafka installation. Default is `true` and required Strimzi Operator to be setup. Set to `false` if you want to reuse an existing Kafka instance. |
@@ -197,7 +196,7 @@ Here are below the configuration properties of the Kafka support feature:
 #### MQTT feature details
 
 Here are below the configuration properties of the MQTT support feature:
- 
+
 | Section       | Property           | Description   |
 | ------------- | ------------------ | ------------- |
 | `features.async.mqtt` | `url`        | **Optional**. The URL of MQTT broker (eg: `my-mqtt-broker.example.com:1883`). Default is undefined which means that feature is disabled. |
@@ -207,18 +206,17 @@ Here are below the configuration properties of the MQTT support feature:
 ### WebSocket feature details
 
 Here are below the configuration properties of the WebSocket support feature:
- 
+
 | Section       | Property           | Description   |
 | ------------- | ------------------ | ------------- |
 | `features.async.ws` | `ingressSecretRef`    | **Optional**. The name of a TLS Secret for securing WebSocket `Ingress`. If missing, self-signed certificate is generated. |
-| `features.async.ws` | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks WebSocket mocks. If these annotations are triggering a Certificate generation (for example through https://cert-manager.io/). The `generateCert` property should be set to `false`. |
+| `features.async.ws` | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks WebSocket mocks. If these annotations are triggering a Certificate generation (for example through [cert-mamanger.io](https://cert-manager.io/)). The `generateCert` property should be set to `false`. |
 | `features.async.ws` | `generateCert`        | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |
-
 
 ### Examples
 
 You may want to launch custom installation with such a command:
- 
+
  ```console
  $ helm install microcks ./microcks --namespace=microcks \
     --set appName=mocks --set mongodb.volumeSize=5Gi \
@@ -253,6 +251,6 @@ microcks-postman-runtime-58bf695b59-nm858       1/1     Running   0          39s
 ## Deleting the Chart
 
 ```console
-$ helm delete microcks
-$ helm del --purge microcks
+helm delete microcks
+helm del --purge microcks
 ```

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -149,6 +149,7 @@ The table below describe all the fields of the `values.yaml`, providing informat
 | `microcks`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |
 | `microcks`    | `replicas`         | **Optional**. The number of replicas for the Microcks main pod. Default is `1`. |
 | `microcks`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
+| `microcks`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
 | `microcks`    | `resources`        | **Optional**. Some resources constraints to apply on Microcks pods. This should be expressed using [Kubernetes syntax](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). |
 | `microcks`    | `logLevel`         | **Optional**. Allows to tune the verbosity level of logs. Default is `INFO` You can use `DEBUG` for more verbosity or `WARN` for less. |
 | `postman`     | `replicas`         | **Optional**. The number of replicas for the Microcks Postman pod. Default is `1`. |
@@ -161,6 +162,7 @@ The table below describe all the fields of the `values.yaml`, providing informat
 | `keycloak`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. If these annotations are triggering a Certificate generation (for example through https://cert-manager.io/). The `generateCert` property should be set to `false`. |
 | `keycloak`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |  
 | `keycloak`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
+| `keycloak`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
 | `keycloak`    | `persistent`       | **Optional**. Flag for Keycloak persistence. Default is `true`. Set to `false` if you want an ephemeral Keycloak installation. |
 | `keycloak`    | `volumeSize`       | **Optional**. Size of persistent volume claim for Keycloak. Default is `1Gi`. Not used if not persistent install asked. |
 | `keycloak`    | `postgresImage`    | **Optional**. The reference of container image used. Chart comes with its default version. |

--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -149,7 +149,7 @@ The table below describes all the fields of the `values.yaml`, providing informa
 | `microcks`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |
 | `microcks`    | `replicas`         | **Optional**. The number of replicas for the Microcks main pod. Default is `1`. |
 | `microcks`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
-| `microcks`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
+| `microcks`    | `serviceType`      | **Optional**. The service type used. Defaults to `ClusterIP`. |
 | `microcks`    | `resources`        | **Optional**. Some resources constraints to apply on Microcks pods. This should be expressed using [Kubernetes syntax](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). |
 | `microcks`    | `logLevel`         | **Optional**. Allows to tune the verbosity level of logs. Default is `INFO` You can use `DEBUG` for more verbosity or `WARN` for less. |
 | `postman`     | `replicas`         | **Optional**. The number of replicas for the Microcks Postman pod. Default is `1`. |
@@ -162,7 +162,7 @@ The table below describes all the fields of the `values.yaml`, providing informa
 | `keycloak`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. If these annotations are triggering a Certificate generation (for example through [cert-mamanger.io](https://cert-manager.io/)). The `generateCert` property should be set to `false`. |
 | `keycloak`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |  
 | `keycloak`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
-| `keycloak`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
+| `keycloak`    | `serviceType`      | **Optional**. The service type used. Defaults to `ClusterIP`. |
 | `keycloak`    | `persistent`       | **Optional**. Flag for Keycloak persistence. Default is `true`. Set to `false` if you want an ephemeral Keycloak installation. |
 | `keycloak`    | `volumeSize`       | **Optional**. Size of persistent volume claim for Keycloak. Default is `1Gi`. Not used if not persistent install asked. |
 | `keycloak`    | `postgresImage`    | **Optional**. The reference of container image used. Chart comes with its default version. |

--- a/install/kubernetes/microcks/README.md
+++ b/install/kubernetes/microcks/README.md
@@ -76,7 +76,7 @@ username and password found into 'microcks-keycloak-admin' secret.
 
 ### Advanced install - with asynchronous mocking
 
-Since release `1.0.0`, Microcks support mocking of event-driven API thanks to [AsyncAPI Spec](https://asyncapi.com). Microcks will take car of publishing sample messages for you on a message broker. You mey reuse an existing broker of let Microcks deploy its own (this is the default when turning on this feature).
+Since release `1.0.0`, Microcks supports mocking of event-driven API thanks to [AsyncAPI Spec](https://asyncapi.com). Microcks will take care of publishing sample messages for you on a message broker. You may reuse an existing broker or let Microcks deploy its own (this is the default when turning on this feature).
 
 To install a Kafka message broker during its deployment, Microcks relies on [Strimzi Operator](https://strimzi.io) and will try to create such custom resources such as `Kafka` and `KafkaTopic`. When using this configuration, you will thus need to install Strimzi Operator cluster-wide or on targeted namespace.
 
@@ -133,22 +133,23 @@ All configurable variables and default values can be seen in `values.yaml`, with
 Typically, you may want to configure the following blocks and options:
 
 * Global part is mandatory and contain attributes like `appName` of your install,
-* `microcks` part is mandatory and contain attributes like the number of `replicas` and the access `url` if you want some customizations, 
+* `microcks` part is mandatory and contain attributes like the number of `replicas` and the access `url` if you want some customizations,
 * `postman` part is mandatory for the number of `replicas`
 * `keycloak` part is optional and allows specifying if you want a new install or reuse an existing instance,
 * `mongodb` part is optional and allows specifying if you want a new install or reuse an existing instance.
 * `features` part is optional and allows enabling and configuring opt-in features of Microcks.
 
-The table below describe all the fields of the `values.yaml`, providing informations on what's mandatory and what's optional as well as default values.
+The table below describes all the fields of the `values.yaml`, providing information on what's mandatory and what's optional as well as default values.
 
 | Section       | Property           | Description   |
 | ------------- | ------------------ | ------------- |
-| `microcks`    | `url`              | **Mandatory**. The URL to use for exposing `Ingress` | 
+| `microcks`    | `url`              | **Mandatory**. The URL to use for exposing `Ingress` |
 | `microcks`    | `ingressSecretRef` | **Optional**. The name of a TLS Secret for securing `Ingress`. If missing, self-signed certificate is generated. |
-| `microcks`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks main pod. If these annotations are triggering a Certificate generation (for example through https://cert-manager.io/). The `generateCert` property should be set to `false`. | 
+| `microcks`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks main pod. If these annotations are triggering a Certificate generation (for example through [cert-mamanger.io](https://cert-manager.io/)). The `generateCert` property should be set to `false`. |
 | `microcks`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |
 | `microcks`    | `replicas`         | **Optional**. The number of replicas for the Microcks main pod. Default is `1`. |
 | `microcks`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
+| `microcks`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
 | `microcks`    | `resources`        | **Optional**. Some resources constraints to apply on Microcks pods. This should be expressed using [Kubernetes syntax](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). |
 | `microcks`    | `logLevel`         | **Optional**. Allows to tune the verbosity level of logs. Default is `INFO` You can use `DEBUG` for more verbosity or `WARN` for less. |
 | `postman`     | `replicas`         | **Optional**. The number of replicas for the Microcks Postman pod. Default is `1`. |
@@ -156,11 +157,12 @@ The table below describe all the fields of the `values.yaml`, providing informat
 | `keycloak`    | `install`          | **Optional**. Flag for Keycloak installation. Default is `true`. Set to `false` if you want to reuse an existing Keycloak instance. |
 | `keycloak`    | `realm`            | **Optional**. Name of Keycloak realm to use. Should be setup only if `install` is `false` and you want to reuse an existing realm. Default is `microcks`. |
 | `keycloak`    | `url`              | **Mandatory**. The URL of Keycloak install - indeed just the hostname + port part - if it already exists or the one used for exposing Keycloak `Ingress`. |
-| `keycloak`    | `privateUrl`       | **Optional**. A private URL - a full URL here - used by the Microcks component to internally join Keycloak. This is also known as `backendUrl` in [Keycloak doc](https://www.keycloak.org/docs/latest/server_installation/#_hostname). When specified, the `keycloak.url` is used as `frontendUrl` in Keycloak terms. | 
+| `keycloak`    | `privateUrl`       | **Optional**. A private URL - a full URL here - used by the Microcks component to internally join Keycloak. This is also known as `backendUrl` in [Keycloak doc](https://www.keycloak.org/docs/latest/server_installation/#_hostname). When specified, the `keycloak.url` is used as `frontendUrl` in Keycloak terms. |
 | `keycloak`    | `ingressSecretRef` | **Optional**. The name of a TLS Secret for securing `Ingress`. If missing, self-signed certificate is generated. |
-| `keycloak`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. If these annotations are triggering a Certificate generation (for example through https://cert-manager.io/). The `generateCert` property should be set to `false`. |
+| `keycloak`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. If these annotations are triggering a Certificate generation (for example through [cert-mamanger.io](https://cert-manager.io/)). The `generateCert` property should be set to `false`. |
 | `keycloak`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |  
 | `keycloak`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
+| `keycloak`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
 | `keycloak`    | `persistent`       | **Optional**. Flag for Keycloak persistence. Default is `true`. Set to `false` if you want an ephemeral Keycloak installation. |
 | `keycloak`    | `volumeSize`       | **Optional**. Size of persistent volume claim for Keycloak. Default is `1Gi`. Not used if not persistent install asked. |
 | `keycloak`    | `postgresImage`    | **Optional**. The reference of container image used. Chart comes with its default version. |
@@ -176,11 +178,10 @@ The table below describe all the fields of the `values.yaml`, providing informat
 | `features`    | `async.enabled`    | **Optional**. Feature allowing to mock an tests asynchronous APIs through Events. Enabling it requires an active message broker. Default is `false`. |
 | `features`    | `async.image`      | **Optional**. The reference of container image used for `async-minion` component. Chart comes with its default version. |
 
-
 ### Kafka feature details
 
 Here are below the configuration properties of the Kafka support feature:
- 
+
 | Section       | Property           | Description   |
 | ------------- | ------------------ | ------------- |
 | `features.async.kafka` | `install`    | **Optional**. Flag for Kafka installation. Default is `true` and required Strimzi Operator to be setup. Set to `false` if you want to reuse an existing Kafka instance. |
@@ -195,7 +196,7 @@ Here are below the configuration properties of the Kafka support feature:
 #### MQTT feature details
 
 Here are below the configuration properties of the MQTT support feature:
- 
+
 | Section       | Property           | Description   |
 | ------------- | ------------------ | ------------- |
 | `features.async.mqtt` | `url`        | **Optional**. The URL of MQTT broker (eg: `my-mqtt-broker.example.com:1883`). Default is undefined which means that feature is disabled. |
@@ -205,18 +206,17 @@ Here are below the configuration properties of the MQTT support feature:
 ### WebSocket feature details
 
 Here are below the configuration properties of the WebSocket support feature:
- 
+
 | Section       | Property           | Description   |
 | ------------- | ------------------ | ------------- |
 | `features.async.ws` | `ingressSecretRef`    | **Optional**. The name of a TLS Secret for securing WebSocket `Ingress`. If missing, self-signed certificate is generated. |
-| `features.async.ws` | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks WebSocket mocks. If these annotations are triggering a Certificate generation (for example through https://cert-manager.io/). The `generateCert` property should be set to `false`. |
+| `features.async.ws` | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Microcks WebSocket mocks. If these annotations are triggering a Certificate generation (for example through [cert-mamanger.io](https://cert-manager.io/)). The `generateCert` property should be set to `false`. |
 | `features.async.ws` | `generateCert`        | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |
-
 
 ### Examples
 
 You may want to launch custom installation with such a command:
- 
+
  ```console
  $ helm install microcks ./microcks --namespace=microcks \
     --set appName=mocks --set mongodb.volumeSize=5Gi \
@@ -251,6 +251,6 @@ microcks-postman-runtime-58bf695b59-nm858       1/1     Running   0          39s
 ## Deleting the Chart
 
 ```console
-$ helm delete microcks
-$ helm del --purge microcks
+helm delete microcks
+helm del --purge microcks
 ```

--- a/install/kubernetes/microcks/README.md
+++ b/install/kubernetes/microcks/README.md
@@ -149,7 +149,7 @@ The table below describes all the fields of the `values.yaml`, providing informa
 | `microcks`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |
 | `microcks`    | `replicas`         | **Optional**. The number of replicas for the Microcks main pod. Default is `1`. |
 | `microcks`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
-| `microcks`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
+| `microcks`    | `serviceType`      | **Optional**. The service type used. Defaults to `ClusterIP`. |
 | `microcks`    | `resources`        | **Optional**. Some resources constraints to apply on Microcks pods. This should be expressed using [Kubernetes syntax](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container). |
 | `microcks`    | `logLevel`         | **Optional**. Allows to tune the verbosity level of logs. Default is `INFO` You can use `DEBUG` for more verbosity or `WARN` for less. |
 | `postman`     | `replicas`         | **Optional**. The number of replicas for the Microcks Postman pod. Default is `1`. |
@@ -162,7 +162,7 @@ The table below describes all the fields of the `values.yaml`, providing informa
 | `keycloak`    | `ingressAnnotations`  | **Optional**. A map of annotations that will be added to the `Ingress` for Keycloak pod. If these annotations are triggering a Certificate generation (for example through [cert-mamanger.io](https://cert-manager.io/)). The `generateCert` property should be set to `false`. |
 | `keycloak`    | `generateCert`     | **Optional**. Whether to generate self-signed certificate or not if no valid `ingressSecretRef` provided. Default is `true` |  
 | `keycloak`    | `image`            | **Optional**. The reference of container image used. Chart comes with its default version. |
-| `keycloak`    | `service`          | **Optional**. Some service spec values to use. Supports `type` which defaults to `ClusterIP`. |
+| `keycloak`    | `serviceType`      | **Optional**. The service type used. Defaults to `ClusterIP`. |
 | `keycloak`    | `persistent`       | **Optional**. Flag for Keycloak persistence. Default is `true`. Set to `false` if you want an ephemeral Keycloak installation. |
 | `keycloak`    | `volumeSize`       | **Optional**. Size of persistent volume claim for Keycloak. Default is `1Gi`. Not used if not persistent install asked. |
 | `keycloak`    | `postgresImage`    | **Optional**. The reference of container image used. Chart comes with its default version. |

--- a/install/kubernetes/microcks/templates/service.yaml
+++ b/install/kubernetes/microcks/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
     port: 8080
     targetPort: 8080
     name: spring
-  type: {{ .Values.microcks.service.type }}
+  type: {{ .Values.microcks.service.type | default "ClusterIP" | quote }}
   sessionAffinity: None
   selector:
     app: "{{ .Values.appName }}"
@@ -100,7 +100,7 @@ spec:
     port: 8080
     targetPort: 8080
     name: keycloak
-  type: {{ .Values.keycloak.service.type }}
+  type: {{ .Values.keycloak.service.type | default "ClusterIP" | quote }}
   sessionAffinity: None
   selector:
     app: "{{ .Values.appName }}"

--- a/install/kubernetes/microcks/templates/service.yaml
+++ b/install/kubernetes/microcks/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
     port: 8080
     targetPort: 8080
     name: spring
-  type: ClusterIP
+  type: {{ .Values.microcks.service.type }}
   sessionAffinity: None
   selector:
     app: "{{ .Values.appName }}"
@@ -100,7 +100,7 @@ spec:
     port: 8080
     targetPort: 8080
     name: keycloak
-  type: ClusterIP
+  type: {{ .Values.keycloak.service.type }}
   sessionAffinity: None
   selector:
     app: "{{ .Values.appName }}"

--- a/install/kubernetes/microcks/templates/service.yaml
+++ b/install/kubernetes/microcks/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
     port: 8080
     targetPort: 8080
     name: spring
-  type: {{ .Values.microcks.service.type | default "ClusterIP" | quote }}
+  type: {{ .Values.microcks.serviceType | default "ClusterIP" | quote }}
   sessionAffinity: None
   selector:
     app: "{{ .Values.appName }}"
@@ -100,7 +100,7 @@ spec:
     port: 8080
     targetPort: 8080
     name: keycloak
-  type: {{ .Values.keycloak.service.type | default "ClusterIP" | quote }}
+  type: {{ .Values.keycloak.serviceType | default "ClusterIP" | quote }}
   sessionAffinity: None
   selector:
     app: "{{ .Values.appName }}"

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -11,6 +11,8 @@ microcks:
   generateCert: true
   image: quay.io/microcks/microcks:1.2.1
   replicas: 1
+  service:
+    type: ClusterIP
   resources:
     #requests:
       #cpu: 250m
@@ -42,6 +44,8 @@ keycloak:
   # Unless you uncomment following line, admin password will be randomly generated.
   # Beware that in case of update, new value will be generated and
   #adminPassword: 123
+  service:
+    type: ClusterIP
 
   persistent: true
   volumeSize: 1Gi

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -12,8 +12,7 @@ microcks:
   image: quay.io/microcks/microcks:1.2.1
   replicas: 1
   # Uncomment to change Microcks Service to a NodePort
-  #service:
-  #  type: NodePort
+  #serviceType: NodePort
 
   resources:
     #requests:
@@ -48,8 +47,7 @@ keycloak:
   #adminPassword: 123
 
   # Uncomment to change Keycloak Service to a NodePort
-  #service:
-  #  type: NodePort
+  #serviceType: NodePort
 
   persistent: true
   volumeSize: 1Gi

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -11,8 +11,10 @@ microcks:
   generateCert: true
   image: quay.io/microcks/microcks:1.2.1
   replicas: 1
-  service:
-    type: ClusterIP
+  # Uncomment to change Microcks Service to a NodePort
+  #service:
+  #  type: NodePort
+
   resources:
     #requests:
       #cpu: 250m
@@ -44,8 +46,10 @@ keycloak:
   # Unless you uncomment following line, admin password will be randomly generated.
   # Beware that in case of update, new value will be generated and
   #adminPassword: 123
-  service:
-    type: ClusterIP
+
+  # Uncomment to change Keycloak Service to a NodePort
+  #service:
+  #  type: NodePort
 
   persistent: true
   volumeSize: 1Gi


### PR DESCRIPTION
This PR should allow people to override the Service type of microcks and keycloak, if they need to, without cloning the code (i.e. following [the helm installation instructions](https://microcks.io/documentation/installing/kubernetes/#helm-3)). The helm install command would look like:
`helm install microcks microcks/microcks —-version 1.1.0 --namespace microcks --set microcks.url=microcks.$(minikube ip).nip.io --set keycloak.url=keycloak.$(minikube ip).nip.io  --set microcks.serviceType=NodePort --set keycloak.serviceType=NodePort`

This should address https://github.com/microcks/microcks/issues/450