### PR TITLE
Fix podman-compose support

### DIFF
--- a/install/podman-compose/microcks-template-rootless.yml
+++ b/install/podman-compose/microcks-template-rootless.yml
@@ -17,8 +17,7 @@ services:
     ports:
       - "3000:3000"
   keycloak:
-    image: jboss/keycloak:10.0.1
-    command: "-b 0.0.0.0 -Dkeycloak.import=/microcks-keycloak-config/microcks-realm-sample.json"
+    image: jboss/keycloak:14.0.0
     container_name: microcks-keycloak
     ports:
       - "8180:8080"
@@ -28,6 +27,8 @@ services:
     environment:
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "123"
+      KEYCLOAK_IMPORT: "/microcks-keycloak-config/microcks-realm-sample.json"
+      KEYCLOAK_FRONTEND_URL: "http://__HOST__:8180/auth"
   app:
     depends_on:
       - mongo

--- a/install/podman-compose/microcks-template.yml
+++ b/install/podman-compose/microcks-template.yml
@@ -13,8 +13,7 @@ services:
     image: quay.io/microcks/microcks-postman-runtime:latest
     container_name: microcks-postman-runtime
   keycloak:
-    image: jboss/keycloak:10.0.1
-    command: "-b 0.0.0.0 -Dkeycloak.import=/microcks-keycloak-config/microcks-realm-sample.json"
+    image: jboss/keycloak:14.0.0
     container_name: microcks-keycloak
     ports:
       - "8180:8080"
@@ -24,6 +23,8 @@ services:
     environment:
       KEYCLOAK_USER: "admin"
       KEYCLOAK_PASSWORD: "123"
+      KEYCLOAK_IMPORT: "/microcks-keycloak-config/microcks-realm-sample.json"
+      KEYCLOAK_FRONTEND_URL: "http://__HOST__:8180/auth"
   app:
     depends_on:
       - mongo

--- a/install/podman-compose/run-microcks.sh
+++ b/install/podman-compose/run-microcks.sh
@@ -28,12 +28,12 @@ sed "s/__HOST__/$host_ip/" "$template" > microcks.yml || exit 1
 echo
 echo "Starting Microcks using podman-compose ..."
 echo "------------------------------------------"
-echo "Stop it with: $cmd_prefix podman-compose -f microcks.yml --transform_policy=identity stop"
-echo "Re-launch it with: $cmd_prefix podman-compose -f microcks.yml --transform_policy=identity start"
-echo "Clean everything with: $cmd_prefix podman-compose -f microcks.yml --transform_policy=identity down"
+echo "Stop it with: $cmd_prefix podman-compose -f microcks.yml stop"
+echo "Re-launch it with: $cmd_prefix podman-compose -f microcks.yml start"
+echo "Clean everything with: $cmd_prefix podman-compose -f microcks.yml down"
 echo "------------------------------------------"
 echo "Go to https://localhost:8080 - first login with admin/123"
 echo "Having issues? Check you have changed microcks.yml to your platform"
 echo
 
-podman-compose -f microcks.yml --transform_policy=identity up -d
+podman-compose -f microcks.yml up -d


### PR DESCRIPTION
This PR is enabling support for podman-compose 1.x.

Since podman-compose v1.0, the --transform_policy option is not accepted anymore and at the same time, not needed anymore.
