### PR TITLE
Dependency management cleaning + little changes

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -8,7 +8,7 @@ We also need a Keycloak server running on port `8180`.
 
 ### Pre-requisites
 
-* NodeJS (version >= 16.0) and associated tools : NPM and ng-cli (`npm install -g ng-cli`)
+* NodeJS (version >= 16.0) and associated tools : NPM and ng-cli (`npm i -g @angular/cli`)
 * Java Development Kit (version >= 11) and Apache Maven (version >= 3.0)
 * Keycloak 14.0.0
 * MongoDB 3.4
@@ -26,13 +26,22 @@ In a terminal, start frontend GUI server using NG :
 
 ```
 $ cd src/main/webapp
+$ npm install
 $ ng serve
 ```
 
 Server is started on port `4200`. Open a new browser tab pointing to `http://localhost:4200` where application is hosted.
 
+with keycloak:
+
 ```
 $ mvn spring-boot:run
+```
+
+with keycloak disabled:
+
+```
+$ KEYCLOAK_ENABLED=false mvn spring-boot:run
 ```
 
 Server is started on port `8080` and will be used as API endpoints root by frontend GUI (URLs starting by `http://localhost:4200/api` will be in fact proxied to port `8080`).

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -95,11 +95,6 @@
     </dependency>
     <!-- Required since Spring 1.5 to 2.3 migration -->
     <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <version>1.4.01</version>
-    </dependency>
-    <dependency>
       <groupId>com.smartbear.soapui</groupId>
       <artifactId>soapui</artifactId>
       <version>${soapui.version}</version>
@@ -180,6 +175,30 @@
         <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+	      <groupId>xml-apis</groupId>
+	      <artifactId>xml-apis</artifactId>        
+        </exclusion>
+        <exclusion>
+		  <groupId>org.apache.xerces</groupId>
+		  <artifactId>xml-apis</artifactId>        
+        </exclusion>
+        <exclusion>
+		  <groupId>javax.xml.bind</groupId>
+		  <artifactId>jsr173_api</artifactId>        
+        </exclusion>
+        <exclusion>
+          <groupId>stax</groupId>
+  		  <artifactId>stax-api</artifactId>
+        </exclusion>
+        <exclusion>
+		  <groupId>xerces</groupId>
+		  <artifactId>xmlParserAPIs</artifactId>        
+        </exclusion>
+        <exclusion>
+		  <groupId>xom</groupId>
+		  <artifactId>xom</artifactId>        
         </exclusion>
       </exclusions>
     </dependency>

--- a/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLTestRunner.java
@@ -122,7 +122,7 @@ public class GraphQLTestRunner extends HttpTestRunner {
             graphqlSchemaResource = resources.get(0);
          }
          if (graphqlSchemaResource == null) {
-            log.debug("Found no GraphQL specification resource for service {0}, so failing validating", service.getId());
+            log.debug("Found no GraphQL specification resource for service {}, so failing validating", service.getId());
             return TestReturn.FAILURE_CODE;
          }
 

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPITestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPITestRunner.java
@@ -154,7 +154,7 @@ public class OpenAPITestRunner extends HttpTestRunner {
             }
          }
          if (openapiSpecResource == null) {
-            log.debug("Found no OpenAPI specification resource for service {0}, so failing validating", service.getId());
+            log.debug("Found no OpenAPI specification resource for service {} - {}, so failing validating", service.getId(), service.getName());
             return TestReturn.FAILURE_CODE;
          }
 


### PR DESCRIPTION
@lbroudoux a very small contribution, but it would have helped me a lot to get up and running on my local devenv.

The dependency excludes are required to satisfy eclipse, which was reporting stuff like:
`The package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml` 
in my tests everything worked still fine.

I made separate commits if you don't like all the changes...

Note: I was not able to get it to work with a local keycloak installation, therefore my update in the README.