### PR TITLE
chore: use import realm startup argument instead of using a custom script to import realm

### DIFF
--- a/install/docker-compose/docker-compose-osx-m1.yml
+++ b/install/docker-compose/docker-compose-osx-m1.yml
@@ -10,20 +10,19 @@ services:
     user: "1024631:1000"
 
   keycloak:
-    image: quay.io/microcks/microcks-keycloak:20.0.2
+    image: quay.io/keycloak/keycloak:20.0.2
     container_name: microcks-sso
     ports:
       - "18080:8080"
     environment:
       KEYCLOAK_ADMIN: "admin"
       KEYCLOAK_ADMIN_PASSWORD: "admin"
-      KEYCLOAK_IMPORT: "/tmp/microcks-realm.json"
       KC_HOSTNAME_ADMIN_URL: "http://localhost:18080"
       KC_HOSTNAME_URL: "http://localhost:18080"
     volumes:
-      - "./keycloak-realm/microcks-realm-sample.json:/tmp/microcks-realm.json"
+      - "./keycloak-realm/microcks-realm-sample.json:/opt/keycloak/data/import/microcks-realm.json"
     command:
-      - start-dev
+      - start-dev --import-realm
 
   postman:
     image: quay.io/microcks/microcks-postman-runtime:latest

--- a/install/docker-compose/docker-compose-with-proxy.yml
+++ b/install/docker-compose/docker-compose-with-proxy.yml
@@ -8,18 +8,19 @@ services:
       - "~/tmp/microcks-data:/data/db"
 
   keycloak:
-    image: quay.io/microcks/microcks-keycloak:20.0.2
+    image: quay.io/keycloak/keycloak:20.0.2
     container_name: microcks-sso
     ports:
       - "18080:8080"
     environment:
       KEYCLOAK_ADMIN: "admin"
       KEYCLOAK_ADMIN_PASSWORD: "admin"
-      KEYCLOAK_IMPORT: "/tmp/microcks-realm.json"
       KC_HOSTNAME_ADMIN_URL: "http://localhost:18080"
       KC_HOSTNAME_URL: "http://localhost:18080"
     volumes:
-      - "./keycloak-realm/microcks-realm-sample.json:/tmp/microcks-realm.json"
+      - "./keycloak-realm/microcks-realm-sample.json:/opt/keycloak/data/import/microcks-realm.json"
+    command:
+      - start-dev --import-realm
 
   postman:
     image: quay.io/microcks/microcks-postman-runtime:latest

--- a/install/docker-compose/docker-compose.yml
+++ b/install/docker-compose/docker-compose.yml
@@ -9,20 +9,19 @@ services:
 
   keycloak:
     #image: jboss/keycloak:14.0.0
-    image: quay.io/microcks/microcks-keycloak:20.0.2
+    image: quay.io/keycloak/keycloak:21.0.2
     container_name: microcks-sso
     ports:
       - "18080:8080"
     environment:
       KEYCLOAK_ADMIN: "admin"
       KEYCLOAK_ADMIN_PASSWORD: "admin"
-      KEYCLOAK_IMPORT: "/tmp/microcks-realm.json"
       KC_HOSTNAME_ADMIN_URL: "http://localhost:18080"
       KC_HOSTNAME_URL: "http://localhost:18080"
     volumes:
-      - "./keycloak-realm/microcks-realm-sample.json:/tmp/microcks-realm.json"
+      - "./keycloak-realm/microcks-realm-sample.json:/opt/keycloak/data/import/microcks-realm.json"
     command:
-      - start-dev
+      - start-dev --import-realm
 
   postman:
     image: quay.io/microcks/microcks-postman-runtime:latest

--- a/install/docker-compose/docker-compose.yml
+++ b/install/docker-compose/docker-compose.yml
@@ -9,7 +9,7 @@ services:
 
   keycloak:
     #image: jboss/keycloak:14.0.0
-    image: quay.io/keycloak/keycloak:21.0.2
+    image: quay.io/keycloak/keycloak:20.0.2
     container_name: microcks-sso
     ports:
       - "18080:8080"


### PR DESCRIPTION
### Description

- used import-realm that can import the json realm file automatically from the /opt/keycloak/data/import folder while starting up
- The earlier solution also worked but the new one is straightforward