### PR TITLE
fix #801: GraphQL multi-queries of different operations throws exception

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
+++ b/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
@@ -62,6 +62,7 @@ import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import graphql.parser.Parser;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -247,8 +248,10 @@ public class GraphQLController {
          ObjectNode aggregated = mapper.createObjectNode();
          ObjectNode dataNode = aggregated.putObject("data");
          for (GraphQLQueryResponse response : graphqlResponses) {
-            dataNode.set(response.getAlias(), response.getJsonResponse().path("data")
-                  .path(response.getOperationName()).deepCopy());
+            dataNode.set(
+               StringUtils.defaultIfBlank(response.getAlias(), response.getOperationName()),
+               response.getJsonResponse().path("data").path(response.getOperationName()).deepCopy()
+            );
          }
          responseNode = aggregated;
       }

--- a/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
@@ -215,5 +215,66 @@ public class GraphQLControllerIT extends AbstractBaseIT {
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
+
+      // Check query with multiple selection no aliases
+      query = "{\"query\": \"{\\n" +
+          "  film(id: \\\"ZmlsbXM6MQ==\\\") {\\n" +
+          "    id\\n" +
+          "    title\\n" +
+          "    episodeID\\n" +
+          "    rating\\n" +
+          "  }\\n" +
+          "  allFilms {\\n" +
+          "    films {\\n" +
+          "      id\\n" +
+          "      title\\n" +
+          "    }\\n" +
+          "  }\\n" +
+          "}\"}";
+      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatusCode().value());
+      try {
+        JSONAssert.assertEquals("{\n" +
+                  "  \"data\": {\n" +
+                  "    \"film\": {\n" +
+                  "      \"id\": \"ZmlsbXM6MQ==\",\n" +
+                  "      \"title\": \"A New Hope\",\n" +
+                  "      \"episodeID\": 4,\n" +
+                  "      \"rating\": 4.3\n" +
+                  "    },\n" +
+                  "    \"allFilms\": {\n" +
+                  "      \"films\": [\n" +
+                  "        {\n" +
+                  "          \"id\": \"ZmlsbXM6MQ==\",\n" +
+                  "          \"title\": \"A New Hope\"\n" +
+                  "        },\n" +
+                  "        {\n" +
+                  "          \"id\": \"ZmlsbXM6Mg==\",\n" +
+                  "          \"title\": \"The Empire Strikes Back\"\n" +
+                  "        },\n" +
+                  "        {\n" +
+                  "          \"id\": \"ZmlsbXM6Mw==\",\n" +
+                  "          \"title\": \"Return of the Jedi\"\n" +
+                  "        },\n" +
+                  "        {\n" +
+                  "          \"id\": \"ZmlsbXM6NA==\",\n" +
+                  "          \"title\": \"The Phantom Menace\"\n" +
+                  "        },\n" +
+                  "        {\n" +
+                  "          \"id\": \"ZmlsbXM6NQ==\",\n" +
+                  "          \"title\": \"Attack of the Clones\"\n" +
+                  "        },\n" +
+                  "        {\n" +
+                  "          \"id\": \"ZmlsbXM6Ng==\",\n" +
+                  "          \"title\": \"Revenge of the Sith\"\n" +
+                  "        }\n" +
+                  "      ]\n" +
+                  "    }\n" +
+                  "  }\n" +
+                  "}",
+          response.getBody(), JSONCompareMode.LENIENT);
+        } catch (Exception e) {
+          fail("No Exception should be thrown here");
+        }
    }
 }


### PR DESCRIPTION
### Description
- GraphQL - Allows querying multiple distinct operations without aliases

### Related issue(s)
Resolves #801
