### PR TITLE
Feature/add ingressClassName

### DIFF
--- a/install/kubernetes/microcks/templates/ingress.yaml
+++ b/install/kubernetes/microcks/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     app: "{{ .Values.appName }}"
     group: microcks
 spec:
+  {{- if .Values.microcks.ingressClassName }}
+  ingressClassName: {{ .Values.microcks.ingressClassName | quote }}
+  {{- end }}
   tls:
   - hosts:
     - "{{ .Values.microcks.url }}"
@@ -44,6 +47,9 @@ metadata:
     app: "{{ .Values.appName }}"
     group: microcks
 spec:
+  {{- if .Values.microcks.grpcIngressClassName }}
+  ingressClassName: {{ .Values.microcks.grpcIngressClassName | quote }}
+  {{- end }}
   tls:
   - hosts:
      - {{ ( include "microcks-grpc.url" . ) }}
@@ -73,6 +79,9 @@ metadata:
     app: "{{ .Values.appName }}"
     group: microcks
 spec:
+  {{- if .Values.keycloak.ingressClassName }}
+  ingressClassName: {{ .Values.keycloak.ingressClassName | quote }}
+  {{- end }}
   tls:
   - hosts:
     - "{{ .Values.keycloak.url }}"
@@ -106,6 +115,9 @@ metadata:
     app: "{{ .Values.appName }}"
     group: microcks
 spec:
+  {{- if .Values.features.async.ws.ingressClassName }}
+  ingressClassName: {{ .Values.features.async.ws.ingressClassName | quote }}
+  {{- end }}
   tls:
   - hosts:
     - "{{ ( include "microcks-ws.url" . ) }}"

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -8,7 +8,8 @@ microcks:
   #ingressAnnotations:
     #cert-manager.io/issuer: my-cert-issuer
     #kubernetes.io/tls-acme: "true"
-    #kubernetes.io/ingress.class: nginx
+  #ingressClassName: nginx
+  #grpcIngressClassName: nginx
   generateCert: true
   image: quay.io/microcks/microcks:1.7.1
   replicas: 1
@@ -16,7 +17,6 @@ microcks:
   #serviceType: NodePort
 
   #grpcIngressAnnotations:
-    #kubernetes.io/ingress.class: myclass
     #myclass.ingress.kubernetes.io/backend-protocol: "GRPC"
     #myclass.ingress.kubernetes.io/ssl-passthrough: "true"
 
@@ -62,7 +62,7 @@ keycloak:
   #ingressAnnotations:
     #cert-manager.io/issuer: my-cert-issuer
     #kubernetes.io/tls-acme: "true"
-    #kubernetes.io/ingress.class: nginx
+  # ingressClassName: nginx
   #pvcAnnotations:
     #helm.sh/resource-policy: keep
   generateCert: true
@@ -262,7 +262,7 @@ features:
       #ingressAnnotations:
         #cert-manager.io/issuer: my-ws-cert-issuer
         #kubernetes.io/tls-acme: "true"
-        #kubernetes.io/ingress.class: nginx
+      #ingressClassName: nginx
       generateCert: true
 
   repositoryFilter:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
This PR adds the 'ingressClassName' field to the spec property of the ingress yaml. It will allow to specify a custom ingress directly in the property rather than using the annotation.

The chart was tested with and without the ingressClassesName and it works as expected.

![image](https://github.com/microcks/microcks/assets/74715150/9d17817b-2cae-48bc-a53a-a061ee235f50)
*Example shows microcks-grpc ingress without ingressClassName set and microcks-keycloak with ingressClassName added*

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->