### PR TITLE
fix: Location override with absolute url

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/AbsoluteUrlMatcher.java
+++ b/webapp/src/main/java/io/github/microcks/util/AbsoluteUrlMatcher.java
@@ -1,0 +1,16 @@
+package io.github.microcks.util;
+
+import java.util.regex.Pattern;
+
+/**
+ * Util class to Match a Absolute URL
+ */
+public class AbsoluteUrlMatcher {
+  static final String regex = ".+://.*";
+
+  static final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+
+  public static boolean matches(String url){
+    return pattern.matcher(url).matches();
+  }
+}

--- a/webapp/src/main/java/io/github/microcks/web/RestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/RestController.java
@@ -23,10 +23,7 @@ import io.github.microcks.domain.Response;
 import io.github.microcks.domain.Service;
 import io.github.microcks.repository.ResponseRepository;
 import io.github.microcks.repository.ServiceRepository;
-import io.github.microcks.util.DispatchCriteriaHelper;
-import io.github.microcks.util.DispatchStyles;
-import io.github.microcks.util.IdBuilder;
-import io.github.microcks.util.ParameterConstraintUtil;
+import io.github.microcks.util.*;
 import io.github.microcks.util.dispatcher.FallbackSpecification;
 import io.github.microcks.util.dispatcher.JsonEvaluationSpecification;
 import io.github.microcks.util.dispatcher.JsonExpressionEvaluator;
@@ -226,10 +223,13 @@ public class RestController {
             if (response.getHeaders() != null) {
                for (Header header : response.getHeaders()) {
                   if ("Location".equals(header.getName())) {
-                     // We should process location in order to make relative URI specified an absolute one from
-                     // the client perspective.
-                     String location = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort()
-                        + request.getContextPath() + "/rest" + serviceAndVersion + header.getValues().iterator().next();
+                    String location = header.getValues().iterator().next();
+                    if (!AbsoluteUrlMatcher.matches(location)) {
+                      // We should process location in order to make relative URI specified an absolute one from
+                      // the client perspective.
+                      location = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort()
+                        + request.getContextPath() + "/rest" + serviceAndVersion + location;
+                    }
                      responseHeaders.add(header.getName(), location);
                   } else {
                      if (!HttpHeaders.TRANSFER_ENCODING.equalsIgnoreCase(header.getName())) {

--- a/webapp/src/test/java/io/github/microcks/util/AbsoluteUrlMatcherTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/AbsoluteUrlMatcherTest.java
@@ -1,0 +1,28 @@
+package io.github.microcks.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AbsoluteUrlMatcherTest {
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "https://www.google.com/search?client=firefox-b-e&q=absolute+urls",
+    "https://github.com/apoorva256/microcks",
+    "file:///Users/unicorn.jpg"
+  })
+  void matches_ShouldReturnTrueForAbsoluteUrls(String absoluteUrl){
+    assertTrue(AbsoluteUrlMatcher.matches(absoluteUrl));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "//www.google.com/",
+    "index.html",
+    "../../file.js"
+  })
+  void matches_ShouldReturnFalseForNonAbsoluteUrls(String nonAbsoluteUrl){
+    assertFalse(AbsoluteUrlMatcher.matches(nonAbsoluteUrl));
+  }
+}


### PR DESCRIPTION
### Problem:
Microcks overrides the Location header when a absolute URL is set.
### Reproduce problem
```yaml
openapi: "3.0.0"
info:
  title: Simple API overview
  version: 2.0.0
paths:
  /:
    get:
      responses:
        '301':
          description: |-
            redirect
          headers:
            Location:
              schema:
                type: string
              examples:
                foo: 
                  value: "http://www.google.com"
          content:
            text/html:
              examples: 
                foo:
                  value: ""
```
![image](https://github.com/microcks/microcks/assets/147162424/37506968-bdb9-43e5-a66e-11d56947e7da)

Microcks Response:
```
http://localhost:8080/rest/Simple+API+overview/2.0.0/
Host: localhost:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
Accept-Language: fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3
Accept-Encoding: gzip, deflate, br
DNT: 1
Connection: keep-alive
Upgrade-Insecure-Requests: 1
Sec-Fetch-Dest: document
Sec-Fetch-Mode: navigate
Sec-Fetch-Site: none
Sec-Fetch-User: ?1

GET: HTTP/1.1 301 
Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
Location: http://localhost:8080/rest/Simple+API+overview/2.0.0http://www.google.com
Content-Type: text/html;charset=UTF-8
Content-Length: 0
Date: Thu, 12 Oct 2023 15:02:01 GMT
Keep-Alive: timeout=60
Connection: keep-alive
---------------------
http://localhost:8080/rest/Simple+API+overview/2.0.0http://www.google.com
Host: localhost:8080
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8
Accept-Language: fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3
Accept-Encoding: gzip, deflate, br
DNT: 1
Connection: keep-alive
Upgrade-Insecure-Requests: 1
Sec-Fetch-Dest: document
Sec-Fetch-Mode: navigate
Sec-Fetch-Site: none
Sec-Fetch-User: ?1
```
As you can see microcks dosen't return the correct Location it adds the url of the path to it

http://localhost:8080/rest/Simple+API+overview/2.0.0http://www.google.com instead of http://www.google.com/

This behaviour is due to theses lines of code [lines](https://github.com/microcks/microcks/blob/master/webapp/src/main/java/io/github/microcks/web/RestController.java#L234-L237)

### Refs:
- https://github.com/orgs/microcks/discussions/927