### PR TITLE
fix: add null check to getFileName

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/GitLabReferenceURLBuilder.java
+++ b/webapp/src/main/java/io/github/microcks/util/GitLabReferenceURLBuilder.java
@@ -35,7 +35,7 @@ public class GitLabReferenceURLBuilder extends SimpleReferenceURLBuilder {
    public String getFileName(String baseRepositoryURL, Map<String, List<String>> headers) {
       if (headers != null) {
          for (String key : headers.keySet()) {
-            if (key.equalsIgnoreCase(GITLAB_FILE_NAME_HEADER)) {
+            if (key!= null && key.equalsIgnoreCase(GITLAB_FILE_NAME_HEADER)) {
                return headers.get(key).get(0);
             }
          }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
When importing from gitlab the code fails when trying to get the filename as there is a null key in the Headers

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->