### PR TITLE
$ref component not being parsed in json schema causing issue with nullable field

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get involved with our community, please make sure you are familiar with the p
 
 ## Build Status
 
-The current development version is `1.8.0-SNAPSHOT`. [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/microcks/microcks/build-verify.yml?branch=1.8.x&logo=github&style=for-the-badge)](https://github.com/microcks/microcks/actions)
+The current development version is `1.8.1-SNAPSHOT`. [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/microcks/microcks/build-verify.yml?branch=1.8.x&logo=github&style=for-the-badge)](https://github.com/microcks/microcks/actions)
 
 #### Sonarcloud Quality metrics
 
@@ -39,8 +39,8 @@ Here are the naming conventions we're using for current releases, ongoing develo
 
 | Status      | Version          | Branch   | Container images tags |
 | ----------- |------------------| -------- |-----------------------|
-| Stable      | `1.7.1`          | `master` | `1.7.1`, `latest`     |
-| Dev         | `1.8.0-SNAPSHOT` | `1.8.x`  | `nightly`             |
+| Stable      | `1.8.0`          | `master` | `1.8.0`, `latest`     |
+| Dev         | `1.8.1-SNAPSHOT` | `1.8.x`  | `nightly`             |
 | Maintenance | `1.7.2-SNAPSHOT` | `1.7.x`  | `maintenance`         |
 
 

--- a/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
@@ -264,6 +264,10 @@ public class OpenAPISchemaValidator {
 
    /** Entry point method for converting an OpenAPI schema node to Json schema. */
    private static JsonNode convertOpenAPISchemaToJsonSchema(JsonNode jsonNode) {
+     // Convert components
+     if(jsonNode.has("components")){
+       convertProperties(jsonNode.path("components").path("schemas").elements());
+     }
       // Convert schema for all structures.
       for (String structure : STRUCTURES) {
          if (jsonNode.has(structure) && jsonNode.path(structure).isArray()) {

--- a/commons/util/src/test/java/io/github/microcks/util/openapi/OpenAPISchemaValidatorTest.java
+++ b/commons/util/src/test/java/io/github/microcks/util/openapi/OpenAPISchemaValidatorTest.java
@@ -432,4 +432,48 @@ public class OpenAPISchemaValidatorTest {
 
       assertTrue(errors.isEmpty());
    }
+
+   @Test
+   public void testNullableFieldInComponentRef(){
+     String openAPIText = null;
+     String jsonText = """
+        [
+          {
+           "name": "Brian May",
+           "birthDate": "1947-07-19T00:00:00.0Z"
+          },
+          {
+           "name": "Roger Taylor",
+           "birthDate": "1949-07-26T00:00:00.0Z"
+          },
+          {
+           "name": "John Deacon",
+           "birthDate": "1951-08-19T00:00:00.0Z"
+          },
+          {
+            "name": "Freddy Mercury",
+            "birthDate": "1946-09-15T00:00:00.0Z",
+            "deathDate": "1946-11-24T00:00:00.0Z"
+          }
+        ]
+       """;
+     JsonNode openAPISpec = null;
+     JsonNode contentNode = null;
+
+     try {
+       // Load full specification from file.
+       openAPIText =  FileUtils.readFileToString(
+         new File("target/test-classes/io/github/microcks/util/openapi/nullable-fields-openapi.yaml"));
+       // Extract JSON nodes using OpenAPISchemaValidator methods.
+       openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
+       contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
+     } catch (Exception e) {
+       fail("Exception should not be thrown");
+     }
+
+     // Validate the content for Get /accounts response message.
+     List<String> errors = OpenAPISchemaValidator.validateJsonMessage(openAPISpec, contentNode,
+       "/paths/~1queen~1members/get/responses/200", "application/json");
+     assertTrue(errors.isEmpty());
+   }
 }

--- a/commons/util/src/test/java/io/github/microcks/util/openapi/OpenAPISchemaValidatorTest.java
+++ b/commons/util/src/test/java/io/github/microcks/util/openapi/OpenAPISchemaValidatorTest.java
@@ -440,15 +440,18 @@ public class OpenAPISchemaValidatorTest {
         [
           {
            "name": "Brian May",
-           "birthDate": "1947-07-19T00:00:00.0Z"
+           "birthDate": "1947-07-19T00:00:00.0Z",
+           "deathDate": null
           },
           {
            "name": "Roger Taylor",
-           "birthDate": "1949-07-26T00:00:00.0Z"
+           "birthDate": "1949-07-26T00:00:00.0Z",
+           "deathDate": null
           },
           {
            "name": "John Deacon",
-           "birthDate": "1951-08-19T00:00:00.0Z"
+           "birthDate": "1951-08-19T00:00:00.0Z",
+           "deathDate": null
           },
           {
             "name": "Freddy Mercury",

--- a/commons/util/src/test/resources/io/github/microcks/util/openapi/nullable-fields-openapi.yaml
+++ b/commons/util/src/test/resources/io/github/microcks/util/openapi/nullable-fields-openapi.yaml
@@ -1,0 +1,66 @@
+openapi: 3.0.3
+info:
+  title: Sample API
+  version: '1.0'
+paths:
+  /queen/members:
+    get:
+      parameters:
+        - $ref: "#/components/parameters/alive"
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/human"
+              examples:
+                "Alive":
+                  $ref: '#/components/examples/alive'
+                "Dead":
+                  $ref: '#/components/examples/dead'
+
+components:
+  parameters:
+    alive:
+      name: isAlive
+      in: path
+      required: true
+      schema:
+        type: boolean
+      examples:
+        "Alive":
+          value: true
+        "Dead":
+          value: false
+  schemas:
+    human:
+      properties:
+        name:
+          type: string
+          nullable: false
+        birthDate:
+          type: string
+          format: date-time
+          nullable: false
+        deathDate:
+          type: string
+          format: date-time
+          nullable: true
+
+  examples:
+    alive:
+      value:
+        - name: "Brian May"
+          birthDate: "1947-07-19T00:00:00.0Z"
+        - name: "Roger Taylor"
+          birthDate: "1949-07-26T00:00:00.0Z"
+        - name: "John Deacon"
+          birthDate: "1951-08-19T00:00:00.0Z"
+    dead:
+      value:
+        - name: "Freddy Mercury"
+          birthDate: "1946-09-15T00:00:00.0Z"
+          deathDate: "1946-11-24T00:00:00.0Z"

--- a/commons/util/src/test/resources/io/github/microcks/util/openapi/nullable-fields-openapi.yaml
+++ b/commons/util/src/test/resources/io/github/microcks/util/openapi/nullable-fields-openapi.yaml
@@ -37,6 +37,7 @@ components:
           value: false
   schemas:
     human:
+      type: object
       properties:
         name:
           type: string


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
- Added a step to parse the $ref component as well as the models
- Added a test to make sure that component having a nullable field won't make the json schema validator chash the api test
### Related issue(s)
Fixes #995 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->