### PR TITLE
Allow keycloak-less kubernetes installation

### DIFF
--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -145,7 +145,10 @@ Typically, you may want to configure the following blocks and options:
 * Global part is mandatory and contain attributes like `appName` of your install,
 * `microcks` part is mandatory and contain attributes like the number of `replicas` and the access `url` if you want some customizations,
 * `postman` part is mandatory for the number of `replicas`
-* `keycloak` part is optional and allows specifying if you want a new install or reuse an existing instance,
+* `keycloak` part is optional and allows specifying :
+  * if you want a new install or reuse an existing instance: `keycloak.install`
+  * if you want microcks to delegate authentication to keycloak: `keycloak.enabled`.
+  * Note that `keycloak.enabled=false` forces keycloak not be installed in this release
 * `mongodb` part is optional and allows specifying if you want a new install or reuse an existing instance.
 * `features` part is optional and allows enabling and configuring opt-in features of Microcks.
 

--- a/install/kubernetes/microcks/templates/NOTES.txt
+++ b/install/kubernetes/microcks/templates/NOTES.txt
@@ -14,9 +14,11 @@ It has been exposed using TLS passthrough on the Ingress controller, you should 
 
   $ kubectl get secret {{ .Values.appName }}-microcks-grpc-secret -n {{ .Release.Namespace }} -o jsonpath='{.data.tls\.crt}' | base64 -d > tls.crt
 
+{{- if and .Values.keycloak.enabled .Values.keycloak.install }}
 Keycloak has been deployed on https://{{ .Values.keycloak.url }}/auth to protect user access.
 You may want to configure an Identity Provider or add some users for your Microcks installation by login in using the
 username and password found into '{{ .Values.appName }}-keycloak-admin' secret.
+{{- end }}
 
 {{- if and .Values.features.async.enabled .Values.features.async.kafka.install }}
 

--- a/install/kubernetes/microcks/templates/claim.yaml
+++ b/install/kubernetes/microcks/templates/claim.yaml
@@ -22,7 +22,7 @@ spec:
   storageClassName: {{ .Values.mongodb.storageClassName }}
   {{- end }}
 {{- end }}
-{{- if and .Values.keycloak.install .Values.keycloak.persistent }}
+{{- if and .Values.keycloak.enabled .Values.keycloak.install .Values.keycloak.persistent }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/install/kubernetes/microcks/templates/configmap.yaml
+++ b/install/kubernetes/microcks/templates/configmap.yaml
@@ -198,7 +198,7 @@ data:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
-{{- if .Values.keycloak.install }}
+{{- if and .Values.keycloak.enabled .Values.keycloak.install }}
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -444,7 +444,7 @@ data:
     {{ else }}
     %kube.kafka.bootstrap.servers={{ .Values.features.async.kafka.url }}
     %kube.mp.messaging.incoming.microcks-services-updates.bootstrap.servers={{ .Values.features.async.kafka.url }}
-    
+
       {{- if eq .Values.features.async.kafka.authentication.type "SSL" }}
     %kube.kafka.security.protocol=SSL
       {{- if .Values.features.async.kafka.authentication.truststoreSecretRef }}
@@ -507,14 +507,14 @@ data:
     %kube.amqp.username={{ .Values.features.async.amqp.username }}
     %kube.amqp.password={{ .Values.features.async.amqp.password }}
     {{- end }}
-    
+
     {{- if .Values.features.async.nats.url }}
     # Access to NATS broker.
     %kube.nats.server={{ .Values.features.async.nats.url }}
     %kube.nats.username={{ .Values.features.async.nats.username }}
     %kube.nats.password={{ .Values.features.async.nats.password }}
     {{- end }}
-    
+
     {{- if .Values.features.async.googlepubsub.project }}
     # Access to Google PubSub.
     %kube.googlepubsub.project={{ .Values.features.async.googlepubsub.project }}

--- a/install/kubernetes/microcks/templates/deployment.yaml
+++ b/install/kubernetes/microcks/templates/deployment.yaml
@@ -66,6 +66,8 @@ spec:
             value: http://{{ .Values.appName }}-postman-runtime:8080
           - name: TEST_CALLBACK_URL
             value: http://{{ .Values.appName }}:8080
+          - name: KEYCLOAK_ENABLED
+            value: "{{ .Values.keycloak.enabled }}"
           {{- if hasKey .Values.keycloak "privateUrl" }}
           - name: KEYCLOAK_URL
             value: "{{ .Values.keycloak.privateUrl }}"
@@ -335,7 +337,7 @@ spec:
       restartPolicy: Always
       dnsPolicy: ClusterFirst
 {{- end }}
-{{- if and .Values.keycloak.install }}
+{{- if and .Values.keycloak.enabled .Values.keycloak.install }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/install/kubernetes/microcks/templates/ingress.yaml
+++ b/install/kubernetes/microcks/templates/ingress.yaml
@@ -64,7 +64,7 @@ spec:
             name: "{{ .Values.appName }}-grpc"
             port:
               number: 9090
-{{- if .Values.keycloak.install }}
+{{- if and .Values.keycloak.enabled .Values.keycloak.install }}
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1

--- a/install/kubernetes/microcks/templates/secret.yaml
+++ b/install/kubernetes/microcks/templates/secret.yaml
@@ -42,7 +42,7 @@ data:
   {{- end }}
   adminPassword: {{ randAlphaNum 40 | b64enc | quote }}
 {{- end }}
-{{- if .Values.keycloak.install }}
+{{- if and .Values.keycloak.enabled .Values.keycloak.install }}
 {{- if and (.Values.ingresses) (not .Values.keycloak.ingressSecretRef) (.Values.keycloak.generateCert) }}
 ---
 kind: Secret

--- a/install/kubernetes/microcks/templates/service.yaml
+++ b/install/kubernetes/microcks/templates/service.yaml
@@ -84,7 +84,7 @@ spec:
   type: ClusterIP
   sessionAffinity: None
 {{- end }}
-{{- if and .Values.keycloak.install }}
+{{- if and .Values.keycloak.enabled .Values.keycloak.install }}
 ---
 kind: Service
 apiVersion: v1

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -56,6 +56,9 @@ postman:
   replicas: 1
 
 keycloak:
+  # Use keycloack in this release
+  enabled: true
+  # Install keycloack in this release
   install: true
   realm: microcks
   # Now that we switched to newer version of Keycloak-X, default url does not contain '/auth' path
@@ -112,7 +115,7 @@ mongodb:
   # Unless you uncomment following line and set class, persistent volume claim is created
   # with no storage class and relies on cluster default one.
   #storageClassName: my-awesome-class
-  
+
   username: userM
   # Unless you uncomment following line, admin password will be randomly generated.
   # Beware that in case of update, new value will be generated and overwrite existing one.
@@ -141,7 +144,7 @@ features:
     defaultBinding: KAFKA
     defaultFrequency: 10
     defaultAvroEncoding: RAW
-    
+
     image: quay.io/microcks/microcks-async-minion:nightly
 
     env:


### PR DESCRIPTION
In the context of local kubernetes deployment installed on laptop, mickrocks helm allow_disable_keycloak_in_helm_charts offers the possibility to bypass the keycloak installation and use microcks without any authentication mechanism

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

Fixes #1001 
