### PR TITLE
feat: add auto-cors

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/filter/DynamicOriginCorsFilter.java
+++ b/webapp/src/main/java/io/github/microcks/web/filter/DynamicOriginCorsFilter.java
@@ -1,0 +1,43 @@
+package io.github.microcks.web.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+public class DynamicOriginCorsFilter implements Filter {
+  private final String corsAllowedOrigins;
+  private final Boolean corsAllowCredentials;
+
+  public DynamicOriginCorsFilter(String corsAllowedOrigins, Boolean corsAllowCredentials) {
+    this.corsAllowedOrigins = corsAllowedOrigins;
+    this.corsAllowCredentials = corsAllowCredentials;
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+  }
+
+  @Override
+  public void destroy() {
+  }
+
+  @Override
+  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+    throws IOException, ServletException {
+    HttpServletResponse response = (HttpServletResponse) servletResponse;
+    HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+    String origin = httpRequest.getHeader("Origin");
+    if (origin == null) {
+      origin = corsAllowedOrigins;
+    }
+    response.setHeader("Access-Control-Allow-Origin", origin);
+    response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE");
+    response.setHeader("Access-Control-Max-Age", "3600");
+    response.setHeader("Access-Control-Allow-Headers", "*");
+    if (corsAllowCredentials) {
+      response.setHeader("Access-Control-Allow-Credentials", "true");
+    }
+    chain.doFilter(servletRequest, servletResponse);
+  }
+}


### PR DESCRIPTION
This PR adds dynamic cors handeling to microcks rest endpoints.
It takes the request made to microcks and returns the cors headers generated with the request's origin header.
If that header is not found it uses a default value.


Testing:
Go to https://microcks.io/ in your browser. Do a fetch request in the console to a mock