### PR TITLE
DynamicOriginCorsFilter Overhaul

### DIFF
--- a/webapp/src/main/java/io/github/microcks/config/WebConfiguration.java
+++ b/webapp/src/main/java/io/github/microcks/config/WebConfiguration.java
@@ -16,7 +16,7 @@
 package io.github.microcks.config;
 
 import io.github.microcks.web.filter.CorsFilter;
-import io.github.microcks.web.filter.DynamicOriginCorsFilter;
+import io.github.microcks.web.filter.DynamicCorsFilter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,8 +71,8 @@ public class WebConfiguration implements ServletContextInitializer {
       corsFilter.addMappingForUrlPatterns(disps, true, "/dynarest/*");
       corsFilter.setAsyncSupported(true);
       if (Boolean.TRUE.equals(enableCorsPolicy)) {
-         FilterRegistration.Dynamic dynamicOriginCorsFilter = servletContext.addFilter("dynamicOriginCorsFilter", new DynamicOriginCorsFilter(corsAllowedOrigins, corsAllowCredentials));
-         dynamicOriginCorsFilter.addMappingForUrlPatterns(disps, true, "/rest/*");
+         FilterRegistration.Dynamic dynamicCorsFilter = servletContext.addFilter("dynamicCorsFilter", new DynamicCorsFilter(corsAllowedOrigins, corsAllowCredentials));
+         dynamicCorsFilter.addMappingForUrlPatterns(disps, true, "/rest/*");
       }
    }
 }

--- a/webapp/src/main/java/io/github/microcks/web/filter/DynamicCorsFilter.java
+++ b/webapp/src/main/java/io/github/microcks/web/filter/DynamicCorsFilter.java
@@ -25,14 +25,13 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
 
 /**
  * Servlet filter that set the response CORS headers accordingly the configuration
  * and incoming request.
  */
-public class DynamicOriginCorsFilter implements Filter {
+public class DynamicCorsFilter implements Filter {
    private final String corsAllowedOrigins;
    private final Boolean corsAllowCredentials;
 
@@ -41,7 +40,7 @@ public class DynamicOriginCorsFilter implements Filter {
    * @param corsAllowedOrigins Allowed origin forced if nothing found in incoming request
    * @param corsAllowCredentials Whether to set allow credentials
    */
-   public DynamicOriginCorsFilter(String corsAllowedOrigins, Boolean corsAllowCredentials) {
+   public DynamicCorsFilter(String corsAllowedOrigins, Boolean corsAllowCredentials) {
       this.corsAllowedOrigins = corsAllowedOrigins;
       this.corsAllowCredentials = corsAllowCredentials;
    }

--- a/webapp/src/main/java/io/github/microcks/web/filter/DynamicCorsFilter.java
+++ b/webapp/src/main/java/io/github/microcks/web/filter/DynamicCorsFilter.java
@@ -25,43 +25,55 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
+import java.util.Enumeration;
 
 /**
- * Servlet filter that set the response CORS headers accordingly the configuration
+ * Servlet filter that set the response CORS headers accordingly the
+ * configuration
  * and incoming request.
  */
 public class DynamicCorsFilter implements Filter {
-   private final String corsAllowedOrigins;
-   private final Boolean corsAllowCredentials;
+  private final String corsAllowedOrigins;
+  private final Boolean corsAllowCredentials;
 
   /**
    * Build a new DynamicOriginCorsFilter.
-   * @param corsAllowedOrigins Allowed origin forced if nothing found in incoming request
+   *
+   * @param corsAllowedOrigins   Allowed origin forced if nothing found in
+   *                             incoming request
    * @param corsAllowCredentials Whether to set allow credentials
    */
-   public DynamicCorsFilter(String corsAllowedOrigins, Boolean corsAllowCredentials) {
-      this.corsAllowedOrigins = corsAllowedOrigins;
-      this.corsAllowCredentials = corsAllowCredentials;
-   }
+  public DynamicCorsFilter(String corsAllowedOrigins, Boolean corsAllowCredentials) {
+    this.corsAllowedOrigins = corsAllowedOrigins;
+    this.corsAllowCredentials = corsAllowCredentials;
+  }
 
-   @Override
-   public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
-         throws IOException, ServletException {
-      HttpServletResponse response = (HttpServletResponse) servletResponse;
-      HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
-      String origin = httpRequest.getHeader("Origin");
-      if (origin == null) {
-         origin = corsAllowedOrigins;
-      }
-      List<String> headerNames = Collections.list(httpRequest.getHeaderNames());
-      response.setHeader("Access-Control-Allow-Origin", origin);
-      response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE");
-      response.setHeader("Access-Control-Max-Age", "3600");
-      response.setHeader("Access-Control-Allow-Headers", String.join(", ", headerNames));
-      if (Boolean.TRUE.equals(corsAllowCredentials)) {
-         response.setHeader("Access-Control-Allow-Credentials", "true");
-      }
-      chain.doFilter(servletRequest, servletResponse);
-   }
+  @Override
+  public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletResponse response = (HttpServletResponse) servletResponse;
+    HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+    String origin = httpRequest.getHeader("Origin");
+    if (origin == null) {
+      origin = corsAllowedOrigins;
+    }
+    response.setHeader("Access-Control-Allow-Origin", origin);
+    response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE");
+    response.setHeader("Access-Control-Max-Age", "3600");
+    response.setHeader("Access-Control-Allow-Headers", getHeadersString(httpRequest));
+    if (Boolean.TRUE.equals(corsAllowCredentials)) {
+      response.setHeader("Access-Control-Allow-Credentials", "true");
+    }
+    chain.doFilter(servletRequest, servletResponse);
+  }
+
+  private String getHeadersString(HttpServletRequest httpRequest) {
+    Enumeration<String> headerNamesEnumeration = httpRequest.getHeaderNames();
+    if (headerNamesEnumeration != null) {
+      var headerNamesList = Collections.list(headerNamesEnumeration);
+      return String.join(", ", headerNamesList);
+    } else {
+      return "*";
+    }
+  }
 }

--- a/webapp/src/main/java/io/github/microcks/web/filter/DynamicOriginCorsFilter.java
+++ b/webapp/src/main/java/io/github/microcks/web/filter/DynamicOriginCorsFilter.java
@@ -24,6 +24,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
 
 /**
  * Servlet filter that set the response CORS headers accordingly the configuration
@@ -52,10 +55,11 @@ public class DynamicOriginCorsFilter implements Filter {
       if (origin == null) {
          origin = corsAllowedOrigins;
       }
+      List<String> headerNames = Collections.list(httpRequest.getHeaderNames());
       response.setHeader("Access-Control-Allow-Origin", origin);
       response.setHeader("Access-Control-Allow-Methods", "POST, PUT, GET, OPTIONS, DELETE");
       response.setHeader("Access-Control-Max-Age", "3600");
-      response.setHeader("Access-Control-Allow-Headers", "*");
+      response.setHeader("Access-Control-Allow-Headers", String.join(", ", headerNames));
       if (Boolean.TRUE.equals(corsAllowCredentials)) {
          response.setHeader("Access-Control-Allow-Credentials", "true");
       }

--- a/webapp/src/test/java/io/github/microcks/web/filter/DynamicCorsFilterTest.java
+++ b/webapp/src/test/java/io/github/microcks/web/filter/DynamicCorsFilterTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.web.filter;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Vector;
+
+public class DynamicCorsFilterTest {
+
+  HttpServletRequest request;
+  HttpServletResponse response;
+  FilterChain chain;
+
+  @BeforeEach
+  void setUp() {
+    // mock HttpServletRequest, HttpServletResponse, and FilterChain
+    request = mock(HttpServletRequest.class);
+    response = mock(HttpServletResponse.class);
+    chain = mock(FilterChain.class);
+  }
+
+  @Nested
+  class WithAllowCredentials {
+
+    private final DynamicCorsFilter filter = new DynamicCorsFilter("http://allowed-origin.com", true);
+
+    @Test
+    void shouldSetAllowCredentialsHeader() throws IOException, ServletException {
+      when(request.getHeader("Origin")).thenReturn("http://example.com");
+      filter.doFilter(request, response, chain);
+      verify(response).setHeader("Access-Control-Allow-Credentials", "true");
+    }
+
+    @Test
+    void shouldSetOriginHeader() throws IOException, ServletException {
+      when(request.getHeader("Origin")).thenReturn("http://example.com");
+      filter.doFilter(request, response, chain);
+      verify(response).setHeader("Access-Control-Allow-Origin", "http://example.com");
+    }
+
+    @Test
+    void shouldSetAccessControlAllowHeaders() throws IOException, ServletException {
+      Vector<String> headerNames = new Vector<>();
+      headerNames.add("Content-Type");
+      headerNames.add("Authorization");
+      Enumeration<String> headerNamesEnum = headerNames.elements();
+      when(request.getHeaderNames()).thenReturn(headerNamesEnum);
+
+      filter.doFilter(request, response, chain);
+      verify(response).setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    }
+  }
+
+  @Nested
+  class WithoutAllowCredentials {
+
+    private final DynamicCorsFilter filter = new DynamicCorsFilter("http://allowed-origin.com", false);
+
+    @Test
+    void shouldNotSetAllowCredentialsHeader() throws IOException, ServletException {
+      when(request.getHeader("Origin")).thenReturn("http://example.com");
+      filter.doFilter(request, response, chain);
+      verify(response, never()).setHeader(eq("Access-Control-Allow-Credentials"), anyString());
+    }
+  }
+}


### PR DESCRIPTION
### Description
DynamicOriginCorsFilter generates CORS responses by coping the Origin from the request to the "Access-Control-Allow-Origin" Header and adding the rest of the CORS headers such as "Access-Control-Allow-Methods", "Access-Control-Max-Age", "Access-Control-Allow-Headers", "Access-Control-Allow-Credentials".

### Problem
When setting "Access-Control-Allow-Credentials" to "true", "`*`" in "Access-Control-Allow-Headers" is not a wild card and is interpreted as the "`*`" header. So CORS fails when there is a custom header "x-smth" in the request.

### Solution
Make the "Access-Control-Allow-Headers" dynamic by getting the headers of the request and putting it in "Access-Control-Allow-Headers".


### Related issue(s)

- [x] rename DynamicOriginCorsFilter to DynamicCorsFilter
- [x] add header generation
- [x] test 
