### PR TITLE
Chore: update redocly

### DIFF
--- a/webapp/src/main/resources/templates/redoc.html
+++ b/webapp/src/main/resources/templates/redoc.html
@@ -16,6 +16,6 @@
   </head>
   <body>
     <redoc spec-url="{RESOURCE_URL}"></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
### Description
This is an update of the redoc url.
The new documentation specifies another url to use for redoc

```
Add an HTML element to the page
Create an HTML page, or edit an existing one, and add the following within the body tags:

    <redoc spec-url="http://petstore.swagger.io/v2/swagger.json"></redoc>
    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
```
https://github.com/Redocly/redoc