### PR TITLE
Delays per exemple

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/Response.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/Response.java
@@ -33,7 +33,7 @@ public class Response extends Message {
    private String mediaType;
    private String dispatchCriteria;
    private boolean isFault = false;
-   private Long delay = 0L;
+   private long delay = 0L;
 
    public String getId() {
       return id;
@@ -74,10 +74,10 @@ public class Response extends Message {
    public void setFault(boolean isFault) {
       this.isFault = isFault;
    }
-   public Long getDelay(){
+   public long getDelay(){
     return delay;
    }
-   public void setDelay(Long delay){
+   public void setDelay(long delay){
     this.delay = delay;
    }
 }

--- a/commons/model/src/main/java/io/github/microcks/domain/Response.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/Response.java
@@ -33,6 +33,7 @@ public class Response extends Message {
    private String mediaType;
    private String dispatchCriteria;
    private boolean isFault = false;
+   private Long delay = 0L;
 
    public String getId() {
       return id;
@@ -72,5 +73,11 @@ public class Response extends Message {
 
    public void setFault(boolean isFault) {
       this.isFault = isFault;
+   }
+   public Long getDelay(){
+    return delay;
+   }
+   public void setDelay(Long delay){
+    this.delay = delay;
    }
 }

--- a/webapp/src/main/java/io/github/microcks/util/metadata/MetadataExtensions.java
+++ b/webapp/src/main/java/io/github/microcks/util/metadata/MetadataExtensions.java
@@ -26,4 +26,7 @@ public class MetadataExtensions {
 
    /** Name of OpenAPI / AsyncAPI operation Microcks extension attribute. */
    public static final String MICROCKS_OPERATION_EXTENSION = "x-microcks-operation";
+
+   /** Name of OpenApi / AsyncAPI exemple Microcks extension attribute */
+   public static final String MICROCKS_EXAMPLE_EXTENSION = "x-microcks-example";
 }

--- a/webapp/src/main/java/io/github/microcks/util/metadata/MetadataExtractor.java
+++ b/webapp/src/main/java/io/github/microcks/util/metadata/MetadataExtractor.java
@@ -73,7 +73,7 @@ public class MetadataExtractor {
     * Complete a Response object with the extracted properties from JsonNode
     *
     * @param response the response to complete
-    * @param path     Node representing an operation node
+    * @param node     Node representing an operation node
     */
    public static void completeResponseProperties(Response response, JsonNode node) {
       if (node.has("delay")) {

--- a/webapp/src/main/java/io/github/microcks/util/metadata/MetadataExtractor.java
+++ b/webapp/src/main/java/io/github/microcks/util/metadata/MetadataExtractor.java
@@ -17,23 +17,28 @@ package io.github.microcks.util.metadata;
 
 import io.github.microcks.domain.Metadata;
 import io.github.microcks.domain.Operation;
+import io.github.microcks.domain.Response;
 
 import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * Util methods for extracting Metadata or operation properties from JsonNode.
+ *
  * @author laurent
  */
 public class MetadataExtractor {
 
    /**
     * Complete a Metadata object with extracted metadata from JsonNode.
+    *
     * @param metadata The object to complete
-    * @param node Node representing a metadata node
+    * @param node     Node representing a metadata node
     */
    public static void completeMetadata(Metadata metadata, JsonNode node) {
       JsonNode annotationsNode = node.get("annotations");
       if (annotationsNode != null) {
-         annotationsNode.fields().forEachRemaining(entry -> metadata.setAnnotation(entry.getKey(), entry.getValue().asText()));
+         annotationsNode.fields()
+               .forEachRemaining(entry -> metadata.setAnnotation(entry.getKey(), entry.getValue().asText()));
       }
       JsonNode labelsNode = node.get("labels");
       if (labelsNode != null) {
@@ -43,8 +48,9 @@ public class MetadataExtractor {
 
    /**
     * Complete an Operation object with extracted properties from JsonNode.
+    *
     * @param operation The object to complete
-    * @param node Node representing an operation node
+    * @param node      Node representing an operation node
     */
    public static void completeOperationProperties(Operation operation, JsonNode node) {
       if (node.has("delay")) {
@@ -58,6 +64,20 @@ public class MetadataExtractor {
       }
       if (node.has("dispatcherRules")) {
          operation.setDispatcherRules(node.path("dispatcherRules").asText());
+      }
+   }
+
+   /**
+    *
+    *
+    * Complete a Response object with the extracted properties from JsonNode
+    *
+    * @param response the response to complete
+    * @param path     Node representing an operation node
+    */
+   public static void completeResponseProperties(Response response, JsonNode node) {
+      if (node.has("delay")) {
+         response.setDelay(node.path("delay").asLong(0));
       }
    }
 }

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -205,7 +205,7 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                         Iterator<String> exampleNames = examplesNode.fieldNames();
                         while (exampleNames.hasNext()) {
                            String exampleName = exampleNames.next();
-                           JsonNode example = examplesNode.path(exampleName);
+                           JsonNode example = followRefIfAny(examplesNode.path(exampleName));
 
                            // We should have everything at hand to build response here.
                            Response response = new Response();

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -213,6 +213,12 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                            response.setMediaType(contentValue);
                            response.setStatus(responseCode.getKey());
                            response.setContent(getSerializedExampleValue(example));
+
+                           // Complete response properties if any.
+                           if (example.has(MetadataExtensions.MICROCKS_OPERATION_EXTENSION)) {
+                              MetadataExtractor.completeResponseProperties(response,
+                                 example.path(MetadataExtensions.MICROCKS_OPERATION_EXTENSION));
+                           }
                            if (!responseCode.getKey().startsWith("2")) {
                               response.setFault(true);
                            }

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -215,9 +215,9 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                            response.setContent(getSerializedExampleValue(example));
 
                            // Complete response properties if any.
-                           if (example.has(MetadataExtensions.MICROCKS_OPERATION_EXTENSION)) {
+                           if (example.has(MetadataExtensions.MICROCKS_EXAMPLE_EXTENSION)) {
                               MetadataExtractor.completeResponseProperties(response,
-                                 example.path(MetadataExtensions.MICROCKS_OPERATION_EXTENSION));
+                                 example.path(MetadataExtensions.MICROCKS_EXAMPLE_EXTENSION));
                            }
                            if (!responseCode.getKey().startsWith("2")) {
                               response.setFault(true);

--- a/webapp/src/main/java/io/github/microcks/web/RestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/RestController.java
@@ -250,6 +250,9 @@ public class RestController {
             // Setting delay to default one if not set.
             if (delay == null && rOperation.getDefaultDelay() != null) {
                delay = rOperation.getDefaultDelay();
+               if (response.getDelay() != 0){
+                  delay = response.getDelay();
+               }
             }
             MockControllerCommons.waitForDelay(startTime, delay);
 

--- a/webapp/src/main/java/io/github/microcks/web/RestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/RestController.java
@@ -248,11 +248,13 @@ public class RestController {
                   dispatchContext.requestContext(), response);
 
             // Setting delay to default one if not set.
-            if (delay == null && rOperation.getDefaultDelay() != null) {
-               delay = rOperation.getDefaultDelay();
-               if (response.getDelay() != 0){
-                  delay = response.getDelay();
-               }
+            if (delay == null) {
+              if (rOperation.getDefaultDelay() != null){
+                delay = rOperation.getDefaultDelay();
+              }
+              if (response.getDelay() != 0) {
+                delay = response.getDelay();
+              }
             }
             MockControllerCommons.waitForDelay(startTime, delay);
 

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
@@ -1861,10 +1861,10 @@ public class OpenAPIImporterTest {
          assertNotNull(response);
          switch (response.getName()) {
           case "laurent_cars":
-            assertEquals(Long.valueOf(10L), response.getDelay());
+            assertEquals(Long.valueOf(1000L), response.getDelay());
             break;
           case "maxime_cars":
-            assertEquals(Long.valueOf(20L), response.getDelay());
+            assertEquals(Long.valueOf(5000L), response.getDelay());
             break;
           case "tom_cars":
             assertEquals(Long.valueOf(0L), response.getDelay());

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
@@ -1861,13 +1861,13 @@ public class OpenAPIImporterTest {
          assertNotNull(response);
          switch (response.getName()) {
           case "laurent_cars":
-            assertEquals(Long.valueOf(1000L), response.getDelay());
+            assertTrue(1000 == response.getDelay());
             break;
           case "maxime_cars":
-            assertEquals(Long.valueOf(5000L), response.getDelay());
+            assertTrue(5000 == response.getDelay());
             break;
           case "tom_cars":
-            assertEquals(Long.valueOf(0L), response.getDelay());
+            assertTrue(0 == response.getDelay());
             break;
 
           default:

--- a/webapp/src/test/resources/io/github/microcks/util/openapi/openapi-extensions-delay.yaml
+++ b/webapp/src/test/resources/io/github/microcks/util/openapi/openapi-extensions-delay.yaml
@@ -1,0 +1,95 @@
+---
+  openapi: 3.0.0
+  info:
+    title: OpenAPI Car API
+    description: Sample OpenAPI API using cars
+    contact:
+      name: Laurent Broudoux
+      url: https://github.com/lbroudoux
+      email: laurent.broudoux@gmail.com
+    license:
+      name: MIT License
+      url: https://opensource.org/licenses/MIT
+    version: 1.0.0
+  paths:
+    /owner/{owner}/car:
+      get:
+        summary: List all cars of owner
+        description: List all cars of owner description
+        operationId: getCarsOp
+        parameters:
+        - name: page
+          in: query
+          description: Result page wanted
+          required: false
+          schema:
+            type: integer
+          examples:
+            laurent_cars:
+              value: 0
+        - name: limit
+          in: query
+          description: Number of result in page
+          required: false
+          schema:
+            type: integer
+          examples:
+            laurent_cars:
+              value: 20
+        responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Car'
+                examples:
+                  laurent_cars:
+                    value:
+                      [
+                          {"name": "307", "model": "Peugeot 307", "year": 2003},
+                          {"name": "jean-pierre", "model": "Peugeot Traveler", "year": 2017}
+                      ]
+                    x-microcks-example:
+                      delay: 10
+
+
+
+                  maxime_cars:
+                    $ref: "#/components/examples/maxime_cars"
+
+                  tom_cars:
+                    value:
+                      [
+                        {"name": "Car 1", "model": "Bmw", "year": 2003},
+                      ]
+
+
+  components:
+    schemas:
+      Car:
+        required:
+        - name
+        properties:
+          name:
+            description: Name of the car
+            type: string
+          year:
+            description: Build year
+            type: integer
+          model:
+            description: Model of the car
+            type: string
+    examples:
+      maxime_cars:
+        value:
+          [
+              {"name": "123", "model": "Pewpew Moblie", "year": 2000}
+          ]
+        x-microcks-example:
+            delay: 20
+  tags:
+  - name: car
+    description:

--- a/webapp/src/test/resources/io/github/microcks/util/openapi/openapi-extensions-delay.yaml
+++ b/webapp/src/test/resources/io/github/microcks/util/openapi/openapi-extensions-delay.yaml
@@ -48,7 +48,7 @@
                           {"name": "jean-pierre", "model": "Peugeot Traveler", "year": 2017}
                       ]
                     x-microcks-example:
-                      delay: 10
+                      delay: 1000
 
 
 
@@ -84,7 +84,4 @@
               {"name": "123", "model": "Pewpew Moblie", "year": 2000}
           ]
         x-microcks-example:
-            delay: 20
-  tags:
-  - name: car
-    description:
+            delay: 5000

--- a/webapp/src/test/resources/io/github/microcks/util/openapi/openapi-extensions-delay.yaml
+++ b/webapp/src/test/resources/io/github/microcks/util/openapi/openapi-extensions-delay.yaml
@@ -18,24 +18,19 @@
         description: List all cars of owner description
         operationId: getCarsOp
         parameters:
-        - name: page
-          in: query
+        - name: owner
+          in: path
           description: Result page wanted
-          required: false
+          required: true
           schema:
             type: integer
           examples:
             laurent_cars:
               value: 0
-        - name: limit
-          in: query
-          description: Number of result in page
-          required: false
-          schema:
-            type: integer
-          examples:
-            laurent_cars:
-              value: 20
+            maxime_cars:
+              value: 1
+            tom_cars:
+              value: 2
         responses:
           200:
             description: Success


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

Reason/Context
I need to be able to simulate a timeout in a specific exemple.

Description
When adding response delays per exemple, we can have an exemple that will simulate a timeout.

This PR includes
- [x] Add microcks custom annotations per exemple
- [x] Add delay data to Response Object
- [x] Use the Response Object in RestController to make a delay

### Related issue(s)
#1069

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->