### PR TITLE
Add missing headers for DynamicCorsFilter

### DIFF
--- a/webapp/src/test/java/io/github/microcks/web/filter/DynamicCorsFilterTest.java
+++ b/webapp/src/test/java/io/github/microcks/web/filter/DynamicCorsFilterTest.java
@@ -73,7 +73,7 @@ public class DynamicCorsFilterTest {
       when(request.getHeaderNames()).thenReturn(headerNamesEnum);
 
       filter.doFilter(request, response, chain);
-      verify(response).setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+      verify(response).setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
     }
 
     @Test

--- a/webapp/src/test/java/io/github/microcks/web/filter/DynamicCorsFilterTest.java
+++ b/webapp/src/test/java/io/github/microcks/web/filter/DynamicCorsFilterTest.java
@@ -75,6 +75,23 @@ public class DynamicCorsFilterTest {
       filter.doFilter(request, response, chain);
       verify(response).setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
     }
+
+    @Test
+    void shouldAddRequestHeadersToAccessControlAllowHeaders() throws IOException, ServletException {
+      Vector<String> headerNames = new Vector<>();
+      headerNames.add("Content-Type");
+      headerNames.add("Authorization");
+      headerNames.add("X-Custom-Header");
+      headerNames.add("Access-Control-Request-Headers");
+      Enumeration<String> headerNamesEnum = headerNames.elements();
+      when(request.getHeaderNames()).thenReturn(headerNamesEnum);
+
+      when(request.getHeader("Access-Control-Request-Headers")).thenReturn("X-Custom-Header-1, X-Custom-Header-2");
+
+      filter.doFilter(request, response, chain);
+
+      verify(response).setHeader("Access-Control-Allow-Headers", "Authorization, X-Custom-Header, Access-Control-Request-Headers, X-Custom-Header-1, X-Custom-Header-2, Content-Type");
+    }
   }
 
   @Nested

--- a/webapp/src/test/java/io/github/microcks/web/filter/DynamicCorsFilterTest.java
+++ b/webapp/src/test/java/io/github/microcks/web/filter/DynamicCorsFilterTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import graphql.language.Argument;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -73,7 +76,11 @@ public class DynamicCorsFilterTest {
       when(request.getHeaderNames()).thenReturn(headerNamesEnum);
 
       filter.doFilter(request, response, chain);
-      verify(response).setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type");
+      ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+      verify(response).setHeader(eq("Access-Control-Allow-Headers"), captor.capture());
+      String value = captor.getValue();
+      assert value.contains("Content-Type");
+      assert value.contains("Authorization");
     }
 
     @Test
@@ -90,7 +97,16 @@ public class DynamicCorsFilterTest {
 
       filter.doFilter(request, response, chain);
 
-      verify(response).setHeader("Access-Control-Allow-Headers", "Authorization, X-Custom-Header, Access-Control-Request-Headers, X-Custom-Header-1, X-Custom-Header-2, Content-Type");
+      ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+
+      verify(response).setHeader(eq("Access-Control-Allow-Headers"), captor.capture());
+      String value = captor.getValue();
+      assert value.contains("Content-Type");
+      assert value.contains("Authorization");
+      assert value.contains("X-Custom-Header");
+      assert value.contains("X-Custom-Header-1");
+      assert value.contains("X-Custom-Header-2");
+      assert value.contains("Access-Control-Request-Headers");
     }
   }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
When doing CORS request, we can send a header("Access-Control-Request-Headers") to request specific headers.
This PR implements this additional generation in the DynamicCorsFilder

### Related issue(s)
#

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->