### PR TITLE
Fix path to mount secrets on microcks deployments

### DIFF
--- a/install/kubernetes/microcks/templates/deployment.yaml
+++ b/install/kubernetes/microcks/templates/deployment.yaml
@@ -162,8 +162,7 @@ spec:
           {{- end }}
           {{- if .Values.microcks.customSecretRef }}
           - name: "{{ .Values.microcks.customSecretRef.secret }}"
-            mountPath: "/deployments/config/custom/secret/{{ .Values.microcks.customSecretRef.key }}"
-            subPath: "{{ .Values.microcks.customSecretRef.key }}"
+            mountPath: "/deployments/config/custom/secret"
           {{- end}}
         terminationMessagePath: "/dev/termination-log"
       volumes:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
HELM CHART Update:
Avoid double directory when adding secrets in Microcks deployment.

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->