### PR TITLE
feat: Make token issuer validation optional

### DIFF
--- a/install/kubernetes/microcks/templates/configmap.yaml
+++ b/install/kubernetes/microcks/templates/configmap.yaml
@@ -76,7 +76,9 @@ data:
     spring.security.oauth2.client.registration.keycloak.scope=openid,profile
     spring.security.oauth2.client.provider.keycloak.issuer-uri=${KEYCLOAK_URL}/realms/${keycloak.realm}
     spring.security.oauth2.client.provider.keycloak.user-name-attribute=preferred_username
+    {{- if .Values.keycloak.validateIssuerUri }}
     spring.security.oauth2.resourceserver.jwt.issuer-uri=${sso.public-url}/realms/${keycloak.realm}
+    {{- end }}
     {{- if hasKey .Values.keycloak "privateUrl" }}
     spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${KEYCLOAK_URL}/realms/${keycloak.realm}/protocol/openid-connect/certs
     {{- end }}
@@ -489,7 +491,7 @@ data:
         {{- if .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
     %kube.kafka.sasl.login.callback.handler.class={{ .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
         {{- end }}
-    
+
     %kube.mp.messaging.incoming.microcks-services-updates.security.protocol=SASL_SSL
       {{- if .Values.features.async.kafka.authentication.truststoreSecretRef }}
     %kube.mp.messaging.incoming.microcks-services-updates.ssl.truststore.location=/deployments/config/kafka/truststore/{{ .Values.features.async.kafka.authentication.truststoreSecretRef.storeKey }}

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -81,6 +81,7 @@ keycloak:
   # If you use an older external Keycloak instance, url must include the '/auth' path
   url: keycloak-microcks.192.168.99.100.nip.io
   #privateUrl: http://microcks-keycloak.microcks.svc.cluster.local:8080
+  validateIssuerUri: true
   #ingressSecretRef: my-secret-for-keycloak-ingress
   #ingressAnnotations:
     #cert-manager.io/issuer: my-cert-issuer

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -37,7 +37,7 @@ spring.security.oauth2.client.registration.keycloak.authorization-grant-type=aut
 spring.security.oauth2.client.registration.keycloak.scope=openid,profile
 spring.security.oauth2.client.provider.keycloak.issuer-uri=${KEYCLOAK_URL:http://localhost:8180}/realms/${keycloak.realm}
 spring.security.oauth2.client.provider.keycloak.user-name-attribute=preferred_username
-spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_URL:http://localhost:8180}/realms/${keycloak.realm}
+#spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_URL:http://localhost:8180}/realms/${keycloak.realm}
 
 # Keycloak adapter configuration properties
 keycloak.enabled=${KEYCLOAK_ENABLED:true}


### PR DESCRIPTION
### Description

Make `spring.security.oauth2.resourceserver.jwt.issuer-uri` optional

- Comment property in `application.properties`
- Add on/off switch to the kube config

### Related issue(s)

- <a href="https://github.com/microcks/microcks/issues/1095">#1095</a>