### PR TITLE
Allow JSON pointers to array and object contents in templates

### DIFF
--- a/commons/util-el/src/main/java/io/github/microcks/util/el/VariableReferenceExpression.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/VariableReferenceExpression.java
@@ -196,7 +196,8 @@ public class VariableReferenceExpression implements Expression {
          // Retrieve evaluated node within JSON tree.
          JsonNode evaluatedNode = rootNode.at(jsonPointerExp);
          // Return serialized array if array type node is referenced by JsonPointer, text value otherwise
-         return evaluatedNode.isArray() || evaluatedNode.isObject() ? mapper.writeValueAsString(evaluatedNode) : evaluatedNode.asText();
+         return evaluatedNode.isArray() || evaluatedNode.isObject() ? mapper.writeValueAsString(evaluatedNode)
+               : evaluatedNode.asText();
       } catch (Exception e) {
          log.warn("Exception while parsing Json text", e);
          return null;

--- a/commons/util-el/src/main/java/io/github/microcks/util/el/VariableReferenceExpression.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/VariableReferenceExpression.java
@@ -193,14 +193,14 @@ public class VariableReferenceExpression implements Expression {
       try {
          ObjectMapper mapper = new ObjectMapper();
          rootNode = mapper.readTree(new StringReader(jsonText));
+         // Retrieve evaluated node within JSON tree.
+         JsonNode evaluatedNode = rootNode.at(jsonPointerExp);
+         // Return serialized array if array type node is referenced by JsonPointer, text value otherwise
+         return evaluatedNode.isArray() || evaluatedNode.isObject() ? mapper.writeValueAsString(evaluatedNode) : evaluatedNode.asText();
       } catch (Exception e) {
          log.warn("Exception while parsing Json text", e);
          return null;
       }
-
-      // Retrieve evaluated node within JSON tree.
-      JsonNode evaluatedNode = rootNode.at(jsonPointerExp);
-      return evaluatedNode.asText();
    }
 
    /** Extract a value from XML using a XPath expression. */

--- a/commons/util-el/src/test/java/io/github/microcks/util/el/VariableReferenceExpressionTest.java
+++ b/commons/util-el/src/test/java/io/github/microcks/util/el/VariableReferenceExpressionTest.java
@@ -49,6 +49,16 @@ public class VariableReferenceExpressionTest {
       VariableReferenceExpression exp = new VariableReferenceExpression(request, "body/books/1/author");
       String result = exp.getValue(new EvaluationContext());
       assertEquals("John Doe", result);
+
+      // Test extraction of Array by JSON Pointer path
+     VariableReferenceExpression expArray = new VariableReferenceExpression(request, "body/books");
+     String resultArray = expArray.getValue(new EvaluationContext());
+     assertEquals("[{\"title\":\"Title 1\",\"author\":\"Jane Doe\"},{\"title\":\"Title 2\",\"author\":\"John Doe\"}]", resultArray);
+
+     // Test extraction of Object by JSON Pointer path
+     VariableReferenceExpression expObj = new VariableReferenceExpression(request, "body/books/1");
+     String resultObj = expObj.getValue(new EvaluationContext());
+     assertEquals("{\"title\":\"Title 2\",\"author\":\"John Doe\"}", resultObj);
    }
 
    @Test

--- a/commons/util-el/src/test/java/io/github/microcks/util/el/VariableReferenceExpressionTest.java
+++ b/commons/util-el/src/test/java/io/github/microcks/util/el/VariableReferenceExpressionTest.java
@@ -51,14 +51,15 @@ public class VariableReferenceExpressionTest {
       assertEquals("John Doe", result);
 
       // Test extraction of Array by JSON Pointer path
-     VariableReferenceExpression expArray = new VariableReferenceExpression(request, "body/books");
-     String resultArray = expArray.getValue(new EvaluationContext());
-     assertEquals("[{\"title\":\"Title 1\",\"author\":\"Jane Doe\"},{\"title\":\"Title 2\",\"author\":\"John Doe\"}]", resultArray);
+      VariableReferenceExpression expArray = new VariableReferenceExpression(request, "body/books");
+      String resultArray = expArray.getValue(new EvaluationContext());
+      assertEquals("[{\"title\":\"Title 1\",\"author\":\"Jane Doe\"},{\"title\":\"Title 2\",\"author\":\"John Doe\"}]",
+            resultArray);
 
-     // Test extraction of Object by JSON Pointer path
-     VariableReferenceExpression expObj = new VariableReferenceExpression(request, "body/books/1");
-     String resultObj = expObj.getValue(new EvaluationContext());
-     assertEquals("{\"title\":\"Title 2\",\"author\":\"John Doe\"}", resultObj);
+      // Test extraction of Object by JSON Pointer path
+      VariableReferenceExpression expObj = new VariableReferenceExpression(request, "body/books/1");
+      String resultObj = expObj.getValue(new EvaluationContext());
+      assertEquals("{\"title\":\"Title 2\",\"author\":\"John Doe\"}", resultObj);
    }
 
    @Test


### PR DESCRIPTION
### Description
This PR allows the usage of JSON pointers to array and object contents in templates. These node's contents will be returned as JSON serialized strings and can be used in JSON responses. Also exception handling has been improved to catch exceptions on accessing the JsonNode referenced and returning null in case of an error.

This allows this request:
```
{
  "library": "My Personal Library",
  "books": [
            { "title":"Title 1", "author":"Jane Doe" },
            { "title":"Title 2", "author":"John Doe" }
    ]
}
```

to reply with this mock template:

```
{
  "allBooks": {{ request.body/books }},
  "firstBook": {{ request.body/0 }}
}
```

and will return this response body:

```
{
  "allBooks": [{ "title":"Title 1", "author":"Jane Doe" },{ "title":"Title 2", "author":"John Doe" }],
  "firstBook": { "title":"Title 1", "author":"Jane Doe" }
}
```