### PR TITLE
fix: add a null check before asserting on mediatype of the test http …

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPITestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPITestRunner.java
@@ -131,7 +131,8 @@ public class OpenAPITestRunner extends HttpTestRunner {
                return TestReturn.FAILURE_CODE;
             }
 
-            if (expectedResponse.getMediaType() != null && !expectedResponse.getMediaType().equalsIgnoreCase(contentType)) {
+            if (expectedResponse.getMediaType() != null
+                  && !expectedResponse.getMediaType().equalsIgnoreCase(contentType)) {
                log.debug("Response Content-Type does not match expected one, returning failure");
                lastValidationErrors = List
                      .of(String.format("Response Content-Type does not match expected one. Expecting %s but got %s",

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPITestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPITestRunner.java
@@ -131,7 +131,7 @@ public class OpenAPITestRunner extends HttpTestRunner {
                return TestReturn.FAILURE_CODE;
             }
 
-            if (!expectedResponse.getMediaType().equalsIgnoreCase(contentType)) {
+            if (expectedResponse.getMediaType() != null && !expectedResponse.getMediaType().equalsIgnoreCase(contentType)) {
                log.debug("Response Content-Type does not match expected one, returning failure");
                lastValidationErrors = List
                      .of(String.format("Response Content-Type does not match expected one. Expecting %s but got %s",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Add a null check before asserting on media type in case of not having a return value from http call

### Related issue(s)
fixes #1140 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->