### PR TITLE
feat: Add support for object query parameters

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -303,9 +303,9 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                   for (JsonNode current : (ArrayNode) exampleValue) {
                      exampleParams.put(parameterName, getValueString(current));
                   }
-               } else if(PARAMETERS_QUERY_VALUE.equals(parameterType) && exampleValue.isObject()){
+               } else if (PARAMETERS_QUERY_VALUE.equals(parameterType) && exampleValue.isObject()) {
                   final var fieldsIterator = ((ObjectNode) exampleValue).fields();
-                  while(fieldsIterator.hasNext()){
+                  while (fieldsIterator.hasNext()) {
                      var current = fieldsIterator.next();
                      exampleParams.put(current.getKey(), getValueString(current.getValue()));
                   }
@@ -651,11 +651,11 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
             if (params.length() > 0) {
                params.append(" && ");
             }
-            if(parameterType.equals("object")){
-               params.append(StreamSupport
-                       .stream(Spliterators.spliteratorUnknownSize(followRefIfAny(parameter.path("schema")).path("properties").fieldNames(),
-                               Spliterator.ORDERED), false).collect(Collectors.joining(" && ")));
-            }else{
+            if (parameterType.equals("object")) {
+               params.append(StreamSupport.stream(Spliterators.spliteratorUnknownSize(
+                     followRefIfAny(parameter.path("schema")).path("properties").fieldNames(), Spliterator.ORDERED),
+                     false).collect(Collectors.joining(" && ")));
+            } else {
                params.append(parameter.path("name").asText());
             }
          }

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -15,6 +15,7 @@
  */
 package io.github.microcks.util.openapi;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.microcks.domain.Exchange;
 import io.github.microcks.domain.Header;
 import io.github.microcks.domain.Metadata;
@@ -45,16 +46,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * An implementation of MockRepositoryImporter that deals with OpenAPI v3.x.x specification file ; whether encoding into
@@ -308,6 +303,13 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                   for (JsonNode current : (ArrayNode) exampleValue) {
                      exampleParams.put(parameterName, getValueString(current));
                   }
+               } else if(PARAMETERS_QUERY_VALUE.equals(parameterType) && exampleValue.isObject()){
+                  final var fieldsIterator = ((ObjectNode) exampleValue).fields();
+                  while(fieldsIterator.hasNext()){
+                     var current = fieldsIterator.next();
+                     exampleParams.put(current.getKey(), getValueString(current.getValue()));
+                  }
+
                } else {
                   exampleParams.put(parameterName, getValueString(exampleValue));
                }
@@ -643,13 +645,19 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
       Iterator<JsonNode> parameters = operation.path(PARAMETERS_NODE).elements();
       while (parameters.hasNext()) {
          JsonNode parameter = followRefIfAny(parameters.next());
-
          String parameterIn = parameter.path("in").asText();
+         String parameterType = followRefIfAny(parameter.path("schema")).path("type").asText();
          if (!"path".equals(parameterIn)) {
             if (params.length() > 0) {
                params.append(" && ");
             }
-            params.append(parameter.path("name").asText());
+            if(parameterType.equals("object")){
+               params.append(StreamSupport
+                       .stream(Spliterators.spliteratorUnknownSize(followRefIfAny(parameter.path("schema")).path("properties").fieldNames(),
+                               Spliterator.ORDERED), false).collect(Collectors.joining(" && ")));
+            }else{
+               params.append(parameter.path("name").asText());
+            }
          }
       }
       return params.toString();

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
@@ -1914,11 +1914,13 @@ public class OpenAPIImporterTest {
          }
       }
    }
+
    @Test
    public void testSImpleOpenAPIWithObjectQUeryParam() {
       OpenAPIImporter importer = null;
       try {
-         importer = new OpenAPIImporter("target/test-classes/io/github/microcks/util/openapi/object-query-params.yaml", null);
+         importer = new OpenAPIImporter("target/test-classes/io/github/microcks/util/openapi/object-query-params.yaml",
+               null);
       } catch (IOException ioe) {
          fail("Exception should not be thrown");
       }

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
@@ -1914,4 +1914,41 @@ public class OpenAPIImporterTest {
          }
       }
    }
+   @Test
+   public void testSImpleOpenAPIWithObjectQUeryParam() {
+      OpenAPIImporter importer = null;
+      try {
+         importer = new OpenAPIImporter("target/test-classes/io/github/microcks/util/openapi/object-query-params.yaml", null);
+      } catch (IOException ioe) {
+         fail("Exception should not be thrown");
+      }
+
+      // Check that basic service properties are there.
+      List<Service> services = null;
+      try {
+         services = importer.getServiceDefinitions();
+      } catch (MockRepositoryImportException e) {
+         fail("Exception should not be thrown");
+      }
+      assertEquals(1, services.size());
+      Service service = services.get(0);
+
+      // Check that operations and input/output have been found.
+      assertEquals(1, service.getOperations().size());
+      for (Operation operation : service.getOperations()) {
+         if ("GET /messiah".equals(operation.getName())) {
+            // Check that messages have been correctly found.
+            List<Exchange> exchanges = null;
+            try {
+               exchanges = importer.getMessageDefinitions(service, operation);
+            } catch (Exception e) {
+               fail("No exception should be thrown when importing message definitions.");
+            }
+            assertEquals(1, exchanges.size());
+            assertEquals("GET", operation.getMethod());
+            assertEquals(DispatchStyles.URI_PARAMS, operation.getDispatcher());
+            assertEquals("lastName && firstName", operation.getDispatcherRules());
+         }
+      }
+   }
 }

--- a/webapp/src/test/resources/io/github/microcks/util/openapi/object-query-params.yaml
+++ b/webapp/src/test/resources/io/github/microcks/util/openapi/object-query-params.yaml
@@ -1,0 +1,48 @@
+---
+openapi: 3.0.3
+info:
+  title: Object query param API
+  description: Description for Object query param API
+  license:
+    name: MIT License
+    url: https://opensource.org/licenses/MIT
+  version: 1.0.0
+paths:
+  /messiah:
+    get:
+      summary: Get the messiah name for a given person
+      description: Use object in query param
+      operationId: getMessiah
+      parameters:
+        - in: query
+          name: irrelevantHere
+          schema:
+            $ref: '#/components/schemas/Person'
+          examples:
+            dune:
+              value:
+                lastName: Atreides
+                firstName: Paul
+      responses:
+        200:
+          description: The messiah name
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messiahName:
+                    type: string
+              examples:
+                dune:
+                  value:
+                    messiahName: Lisan Al Gaib
+components:
+  schemas:
+    Person:
+      type: object
+      properties:
+        lastName:
+          type: string
+        firstName:
+          type: string


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Add support for object query parameters as the openAPI specs describe https://swagger.io/docs/specification/serialization/
this only support the default configuration for handling query parameters with `style: form` and `explode: true`

### Related issue(s)
Resolves #1143 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->