### PR TITLE
feat: Add proxy support for the graphql controller

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/RestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/RestController.java
@@ -91,6 +91,7 @@ public class RestController {
     * @param serviceRepository  The repository to access services definitions
     * @param responseRepository The repository to access responses definitions
     * @param applicationContext The Spring application context
+    * @param proxyService       The proxy to external URLs or services
     */
    public RestController(ServiceRepository serviceRepository, ResponseRepository responseRepository,
          ApplicationContext applicationContext, ProxyService proxyService) {

--- a/webapp/src/main/java/io/github/microcks/web/SoapController.java
+++ b/webapp/src/main/java/io/github/microcks/web/SoapController.java
@@ -103,6 +103,7 @@ public class SoapController {
     * @param responseRepository The repository to access responses definitions
     * @param resourceRepository The repository to access resources artifacts
     * @param applicationContext The Spring application context
+    * @param proxyService       The proxy to external URLs or services
     */
    public SoapController(ServiceRepository serviceRepository, ResponseRepository responseRepository,
          ResourceRepository resourceRepository, ApplicationContext applicationContext, ProxyService proxyService) {

--- a/webapp/src/main/webapp/src/app/pages/services/{serviceId}/operation/operation-override.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/services/{serviceId}/operation/operation-override.page.ts
@@ -73,7 +73,9 @@ export class OperationOverridePageComponent implements OnInit {
       {"value": "QUERY_ARGS", "label": "QUERY_ARGS"},
       {"value": "JSON_BODY", "label": "JSON BODY"},
       {"value": "SCRIPT", "label": "SCRIPT"},
-      {"value": "FALLBACK", "label": "FALLBACK"}
+      {"value": "PROXY", "label": "PROXY"},
+      {"value": "FALLBACK", "label": "FALLBACK"},
+      {"value": "PROXY_FALLBACK", "label": "PROXY FALLBACK"}
     ]
   }
 

--- a/webapp/src/test/java/io/github/microcks/web/AbstractBaseIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/AbstractBaseIT.java
@@ -42,6 +42,8 @@ import org.testcontainers.utility.DockerImageName;
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Base class for Integration tests using Http layers as well as testcontainers for MongoDB persistence.
@@ -102,5 +104,11 @@ public abstract class AbstractBaseIT {
 
       assertEquals(201, response.getStatusCode().value());
       log.info("Just uploaded: " + response.getBody());
+   }
+
+   protected void assertResponseIsOkAndContains(ResponseEntity<String> response, String substring) {
+      assertEquals(200, response.getStatusCode().value());
+      assertNotNull(response.getBody());
+      assertTrue(response.getBody().contains(substring));
    }
 }

--- a/webapp/src/test/java/io/github/microcks/web/SoapControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/SoapControllerIT.java
@@ -228,10 +228,4 @@ public class SoapControllerIT extends AbstractBaseIT {
             name);
       return new HttpEntity<>(request, headers);
    }
-
-   private void assertResponseIsOkAndContains(ResponseEntity<String> response, String substring) {
-      assertEquals(200, response.getStatusCode().value());
-      assertNotNull(response.getBody());
-      assertTrue(response.getBody().contains(substring));
-   }
 }

--- a/webapp/src/test/resources/io/github/microcks/util/graphql/films-to-test-proxy-postman.json
+++ b/webapp/src/test/resources/io/github/microcks/util/graphql/films-to-test-proxy-postman.json
@@ -1,0 +1,98 @@
+{
+	"info": {
+		"_postman_id": "7c00b563-d454-421a-a3b0-17c4e3254cb9",
+		"name": "Movie Graph Original API",
+		"description": "version=1.0 - A simple Graph API for testing proxy",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "queries",
+			"item": [
+				{
+					"name": "film",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "graphql",
+							"graphql": {
+								"query": "query film ($id: String) {\n    film (id: $id) {\n        id\n        title\n        episodeID\n        director\n        starCount\n        rating\n    }\n}",
+								"variables": "{\n  \"id\": \"\"\n}"
+							}
+						},
+						"url": {
+							"raw": "http://film",
+							"protocol": "http",
+							"host": [
+								"film"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "film ZmlsbXM6Mg==",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "query film ($id: String) {\n    film (id: $id) {\n        id\n        title\n        episodeID\n        director\n        starCount\n        rating\n        comment\n    }\n}",
+										"variables": "{\n  \"id\": \"ZmlsbXM6Mg==\"\n}"
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": null,
+							"cookie": [],
+							"body": "{\n    \"data\": {\n        \"film\": {\n            \"id\": \"ZmlsbXM6Mg==\",\n            \"title\": \"The Empire Strikes Back\",\n            \"episodeID\": 5,\n            \"director\": \"Irvin Kershner\",\n            \"starCount\": 433,\n            \"rating\": 4.3,\n            \"comment\": \"Original!!!\"\n        }\n    }\n}"
+						},
+						{
+							"name": "film ZmlsbXM6MA==",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "query film ($id: String) {\n    film (id: $id) {\n        id\n        title\n        episodeID\n        director\n        starCount\n        rating\n        comment\n    }\n}",
+										"variables": "{\n  \"id\": \"ZmlsbXM6MA==\"\n}"
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": null,
+							"cookie": [],
+							"body": "{\n    \"data\": {\n        \"film\": {\n            \"id\": \"ZmlsbXM6MA==\",\n            \"title\": \"The Force Awakens\",\n            \"episodeID\": 7,\n            \"director\": \"J. J. Abrams\",\n            \"starCount\": 200,\n            \"rating\": 3.0,\n            \"comment\": \"Original!!!\"\n        }\n    }\n}"
+						}
+					]
+				}
+			]
+		}
+	],
+	"variable": [
+		{
+			"key": "url",
+			"value": "",
+			"type": "any",
+			"description": "URL for the request."
+		}
+	]
+}

--- a/webapp/src/test/resources/io/github/microcks/util/graphql/films-to-test-proxy.graphql
+++ b/webapp/src/test/resources/io/github/microcks/util/graphql/films-to-test-proxy.graphql
@@ -1,0 +1,18 @@
+# microcksId: Movie Graph Original API : 1.0
+schema {
+    query: Query
+}
+type Film {
+    id: String!
+    title: String!
+    episodeID: Int!
+    director: String!
+    starCount: Int!
+    rating: Float!
+    comment: String!
+}
+
+type Query {
+    film(id: String): Film
+}
+


### PR DESCRIPTION
### Description

- Reuse the Rest controller proxy logic for the GraphQL Controller.

### Related issue(s)

[#1134](https://github.com/microcks/microcks/issues/1134)