### PR TITLE
Add "select all" & "deselect all" actions for operations list on test create page

### DIFF
--- a/webapp/src/main/webapp/src/app/pages/tests/create/test-create.page.css
+++ b/webapp/src/main/webapp/src/app/pages/tests/create/test-create.page.css
@@ -56,3 +56,8 @@
   padding-bottom: 5px;
   color: #333;
 }
+
+.filter-toolbar {
+  display: flex;
+  gap: 5px;
+}

--- a/webapp/src/main/webapp/src/app/pages/tests/create/test-create.page.html
+++ b/webapp/src/main/webapp/src/app/pages/tests/create/test-create.page.html
@@ -175,6 +175,10 @@
             <div class="control-group" *ngIf="service.type != 'EVENT'">
               <label class="control-label required-pf" for="filteredOperationsNames">Operations</label>
               <div class="controls">
+                <div class="filter-toolbar">
+                  <button class="btn btn-link" (click)="resetOperations([])">Select All</button>
+                  <button class="btn btn-link" (click)="resetOperations()">Delesect All</button>
+                </div>
                 <ul>
                   <li *ngFor="let operation of service.operations">
                     <label class="checkbox">

--- a/webapp/src/main/webapp/src/app/pages/tests/create/test-create.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/tests/create/test-create.page.ts
@@ -24,7 +24,7 @@ import { Notification, NotificationEvent, NotificationService, NotificationType 
 import { ServicesService } from '../../../services/services.service';
 import { TestsService } from '../../../services/tests.service';
 import { SecretsService } from '../../../services/secrets.service';
-import { Service } from '../../../models/service.model';
+import { Operation, Service } from '../../../models/service.model';
 import { TestRunnerType, OAuth2ClientContext } from "../../../models/test.model";
 import { Secret } from '../../../models/secret.model';
 
@@ -166,6 +166,13 @@ export class TestCreatePageComponent implements OnInit {
     } else {
       this.removedOperationsNames.push(operationName);
     }
+  }
+
+  public resetOperations(
+    operations: Operation[] = this.resolvedService &&
+      this.resolvedService.operations
+  ): void {
+    this.removedOperationsNames = operations.map((op) => op.name);
   }
 
   public addHeaderValue(operationName: string) {

--- a/webapp/src/main/webapp/src/app/pages/tests/create/tests.page.spec.ts
+++ b/webapp/src/main/webapp/src/app/pages/tests/create/tests.page.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { async, ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { CommonModule } from "@angular/common";
+import { HttpClientModule } from "@angular/common/http";
+import { FormsModule } from "@angular/forms";
+import { ActivatedRoute, Params, Router, RouterModule } from "@angular/router";
+import { HighlightModule } from "ngx-highlightjs";
+import {
+  NotificationService,
+  ToastNotificationListModule,
+} from "patternfly-ng/notification";
+import { of } from "rxjs";
+import { Operation, Service } from "src/app/models/service.model";
+import { ServicesService } from "src/app/services/services.service";
+import { TestsService } from "src/app/services/tests.service";
+import { TestCreatePageComponent } from "./test-create.page";
+
+describe("ServicesPageComponent", () => {
+  let component: TestCreatePageComponent;
+  let fixture: ComponentFixture<TestCreatePageComponent>;
+  let servicesSvcMock: jasmine.SpyObj<ServicesService>;
+  let testsSvcMock: jasmine.SpyObj<TestsService>;
+  let notificationsSvcMock: jasmine.SpyObj<NotificationService>;
+  let activatedRouteMock: ActivatedRoute;
+  let routerMock: jasmine.SpyObj<Router>;
+
+  beforeEach(async(() => {
+    servicesSvcMock = jasmine.createSpyObj("ServicesService", ["getService"]);
+    testsSvcMock = jasmine.createSpyObj("TestsService", [
+      "listByServiceId",
+      "countryByServiceId",
+    ]);
+    notificationsSvcMock = jasmine.createSpyObj("NotificationService", [
+      "addNotification",
+      "getNotifications",
+    ]);
+    notificationsSvcMock.getNotifications.and.returnValue([]);
+    activatedRouteMock = {
+      paramMap: of({
+        get: () => "mockServiceId",
+        has: () => false,
+      }) as Partial<Params> as Params,
+    } as Partial<ActivatedRoute> as ActivatedRoute;
+
+    TestBed.configureTestingModule({
+      imports: [
+        ToastNotificationListModule,
+        RouterModule,
+        FormsModule,
+        HighlightModule,
+        CommonModule,
+        HttpClientModule,
+      ],
+      declarations: [TestCreatePageComponent],
+      providers: [
+        {
+          provide: ServicesService,
+          useValue: servicesSvcMock,
+        },
+        {
+          provide: TestsService,
+          useValue: testsSvcMock,
+        },
+        {
+          provide: NotificationService,
+          useValue: notificationsSvcMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRouteMock,
+        },
+        {
+          provide: Router,
+          useValue: routerMock,
+        },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TestCreatePageComponent);
+    component = fixture.componentInstance;
+    servicesSvcMock.getService.and.returnValue(of(undefined));
+
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+    expect(component.removedOperationsNames).toEqual([]);
+  });
+
+  describe("on init", () => {
+    beforeEach(async () => {
+      notificationsSvcMock.getNotifications.and.returnValue([]);
+
+      component.ngOnInit();
+      await fixture.whenStable();
+    });
+
+    it("should define notifications", () => {
+      notificationsSvcMock.getNotifications.and.returnValue([]);
+
+      expect(component.notifications).toEqual([]);
+    });
+  });
+
+  describe("resetOperations", () => {
+    beforeEach(() => {
+      component.removedOperationsNames = ["operationN"];
+      component.resolvedService = {
+        operations: [{ name: "operation1" }],
+      } as Partial<Service> as Service;
+    });
+
+    [
+      { input: [], expected: [] },
+      {
+        input: [{ name: "operation1" }, { name: "operation2" }],
+        expected: ["operation1", "operation2"],
+      },
+      { input: undefined, expected: ["operation1"] },
+    ].forEach((testCase) => {
+      it(`should filter operations ${
+        testCase.expected || "from resolvedService"
+      } when input is ${JSON.stringify(testCase.input)}`, () => {
+        component.resetOperations(
+          testCase.input as Partial<Operation>[] as Operation[]
+        );
+        expect(component.removedOperationsNames).toEqual(testCase.expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

Create a 'select all' & 'deselect all' buttons 

<img width="460" alt="image" src="https://github.com/microcks/microcks/assets/10682798/83b7fc3a-ff33-43ae-8e15-664e066b0ec7">

### Related issue(s)
Resolves #1153

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->