### PR TITLE
Migrate AsyncAPI `/samples` to 3.0

### DIFF
--- a/samples/UserSignedUpAPI-asyncapi-googlepubsub.yml
+++ b/samples/UserSignedUpAPI-asyncapi-googlepubsub.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.0.0'
+asyncapi: 3.0.0
 id: 'urn:io.microcks.example.user-signedup'
 info:
   title: User signed-up API
@@ -6,15 +6,10 @@ info:
   description: Sample AsyncAPI for user signedup events
 defaultContentType: application/json
 channels:
-  user/signedup:
-    description: The topic on which user signed up events may be consumed
-    bindings:
-      googlepubsub:
-        topic: projects/my-project/topics/my-topic
-    subscribe:
-      summary: Receive informations about user signed up
-      operationId: receivedUserSignedUp
-      message:
+  userSignedUpChannel:
+    address: user/signedup
+    messages:
+      receivedUserSignedUp.message:
         description: An event describing that a user just signed up.
         traits:
           - $ref: '#/components/messageTraits/commonHeaders'
@@ -35,22 +30,38 @@ channels:
               type: integer
               minimum: 18
         examples:
-          - laurent:
-              summary: Example for Laurent user
-              headers: |-
-                {"my-app-header": 23}
-              payload: |-
-                {"id": "{{randomString(32)}}", "sendAt": "{{now()}}", "fullName": "Laurent Broudoux", "email": "laurent@microcks.io", "age": 41}
-          - john:
-              summary: Example for John Doe user
-              headers:
-                my-app-header: 24
-              payload:
-                id: '{{randomString(32)}}'
-                sendAt: '{{now()}}'
-                fullName: John Doe
-                email: john@microcks.io
-                age: 36
+          - name: laurent
+            summary: Example for Laurent user
+            headers:
+              {"my-app-header": 23}
+            payload:
+              {"id": "{{randomString(32)}}", "sendAt": "{{now()}}",
+              "fullName": "Laurent Broudoux", "email": "laurent@microcks.io",
+              "age": 41}
+          - name: john
+            summary: Example for John Doe user
+            headers:
+              my-app-header: 24
+            payload:
+              id: '{{randomString(32)}}'
+              sendAt: '{{now()}}'
+              fullName: John Doe
+              email: john@microcks.io
+              age: 36
+    description: The topic on which user signed up events may be consumed
+    bindings:
+      googlepubsub:
+        schemaSettings:
+          encoding: json
+          name: projects/my-project/topics/my-topic
+operations:
+  receivedUserSignedUp:
+    action: receive
+    channel:
+      $ref: '#/channels/userSignedUpChannel'
+    summary: Receive informations about user signed up
+    messages:
+      - $ref: '#/channels/userSignedUpChannel/messages/receivedUserSignedUp.message'
 components:
   messageTraits:
     commonHeaders:

--- a/samples/UserSignedUpAPI-asyncapi-nats.yml
+++ b/samples/UserSignedUpAPI-asyncapi-nats.yml
@@ -1,7 +1,7 @@
 asyncapi: 3.0.0
 id: 'urn:io.microcks.example.user-signedup-v3'
 info:
-  title: User signed-up API v3
+  title: User signed-up API
   version: 0.1.30
   description: Sample AsyncAPI for user signedup events
 defaultContentType: application/json

--- a/samples/UserSignedUpAPI-asyncapi-nats.yml
+++ b/samples/UserSignedUpAPI-asyncapi-nats.yml
@@ -1,20 +1,15 @@
-asyncapi: '2.0.0'
-id: 'urn:io.microcks.example.user-signedup'
+asyncapi: 3.0.0
+id: 'urn:io.microcks.example.user-signedup-v3'
 info:
-  title: User signed-up API
+  title: User signed-up API v3
   version: 0.1.30
   description: Sample AsyncAPI for user signedup events
 defaultContentType: application/json
 channels:
-  user/signedup:
-    description: The topic on which user signed up events may be consumed
-    subscribe:
-      summary: Receive informations about user signed up
-      operationId: receivedUserSignedUp
-      bindings:
-        nats:
-          queue: my-nats-queue
-      message:
+  userSignedUpChannel:
+    address: user/signedup
+    messages:
+      receivedUserSignedUp.message:
         description: An event describing that a user just signed up.
         traits:
           - $ref: '#/components/messageTraits/commonHeaders'
@@ -35,22 +30,36 @@ channels:
               type: integer
               minimum: 18
         examples:
-          - laurent:
-              summary: Example for Laurent user
-              headers: |-
-                {"my-app-header": 23}
-              payload: |-
-                {"id": "{{randomString(32)}}", "sendAt": "{{now()}}", "fullName": "Laurent Broudoux", "email": "laurent@microcks.io", "age": 41}
-          - john:
-              summary: Example for John Doe user
-              headers:
-                my-app-header: 24
-              payload:
-                id: '{{randomString(32)}}'
-                sendAt: '{{now()}}'
-                fullName: John Doe
-                email: john@microcks.io
-                age: 36
+          - name: laurent
+            summary: Example for Laurent user
+            headers:
+              {"my-app-header": 23}
+            payload:
+              {"id": "{{randomString(32)}}", "sendAt": "{{now()}}",
+              "fullName": "Laurent Broudoux", "email": "laurent@microcks.io",
+              "age": 41}
+          - name: john
+            summary: Example for John Doe user
+            headers:
+              my-app-header: 24
+            payload:
+              id: '{{randomString(32)}}'
+              sendAt: '{{now()}}'
+              fullName: John Doe
+              email: john@microcks.io
+              age: 36
+    description: The topic on which user signed up events may be consumed
+operations:
+  receivedUserSignedUp:
+    action: receive
+    bindings:
+      nats:
+        queue: my-nats-queue
+    channel:
+      $ref: '#/channels/userSignedUpChannel'
+    summary: Receive informations about user signed up
+    messages:
+      - $ref: '#/channels/userSignedUpChannel/messages/receivedUserSignedUp.message'
 components:
   messageTraits:
     commonHeaders:

--- a/samples/UserSignedUpAPI-asyncapi-sns.yml
+++ b/samples/UserSignedUpAPI-asyncapi-sns.yml
@@ -6,7 +6,7 @@ info:
   description: Sample AsyncAPI for user signedup events
 defaultContentType: application/json
 channels:
-  user/signedup:
+  userSignedUpChannel:
     address: user/signedup
     messages:
       receivedUserSignedUp.message:
@@ -53,10 +53,10 @@ operations:
   receivedUserSignedUp:
     action: receive
     channel:
-      $ref: '#/channels/user~1signedup'
+      $ref: '#/channels/userSignedUpChannel'
     summary: Receive informations about user signed up
     messages:
-      - $ref: '#/channels/user~1signedup/messages/receivedUserSignedUp.message'
+      - $ref: '#/channels/userSignedUpChannel/messages/receivedUserSignedUp.message'
     bindings:
       sns:
         topic:

--- a/samples/UserSignedUpAPI-asyncapi-sns.yml
+++ b/samples/UserSignedUpAPI-asyncapi-sns.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.0.0'
+asyncapi: 3.0.0
 id: 'urn:io.microcks.example.user-signedup'
 info:
   title: User signed-up API
@@ -7,15 +7,9 @@ info:
 defaultContentType: application/json
 channels:
   user/signedup:
-    description: The topic on which user signed up events may be consumed
-    subscribe:
-      summary: Receive informations about user signed up
-      operationId: receivedUserSignedUp
-      bindings:
-        sns:
-          topic:
-            name: my-sns-topic
-      message:
+    address: user/signedup
+    messages:
+      receivedUserSignedUp.message:
         description: An event describing that a user just signed up.
         traits:
           - $ref: '#/components/messageTraits/commonHeaders'
@@ -36,22 +30,42 @@ channels:
               type: integer
               minimum: 18
         examples:
-          - laurent:
-              summary: Example for Laurent user
-              headers: |-
-                {"my-app-header": 23}
-              payload: |-
-                {"id": "{{randomString(32)}}", "sendAt": "{{now()}}", "fullName": "Laurent Broudoux", "email": "laurent@microcks.io", "age": 41}
-          - john:
-              summary: Example for John Doe user
-              headers:
-                my-app-header: 24
-              payload:
-                id: '{{randomString(32)}}'
-                sendAt: '{{now()}}'
-                fullName: John Doe
-                email: john@microcks.io
-                age: 36
+          - name: laurent
+            summary: Example for Laurent user
+            headers:
+              {"my-app-header": 23}
+            payload:
+              {"id": "{{randomString(32)}}", "sendAt": "{{now()}}",
+              "fullName": "Laurent Broudoux", "email": "laurent@microcks.io",
+              "age": 41}
+          - name: john
+            summary: Example for John Doe user
+            headers:
+              my-app-header: 24
+            payload:
+              id: '{{randomString(32)}}'
+              sendAt: '{{now()}}'
+              fullName: John Doe
+              email: john@microcks.io
+              age: 36
+    description: The topic on which user signed up events may be consumed
+operations:
+  receivedUserSignedUp:
+    action: receive
+    channel:
+      $ref: '#/channels/user~1signedup'
+    summary: Receive informations about user signed up
+    messages:
+      - $ref: '#/channels/user~1signedup/messages/receivedUserSignedUp.message'
+    bindings:
+      sns:
+        topic:
+          name: my-sns-topic
+        consumers:
+          - protocol: http
+            endpoint:
+              url: http://my-endpoint
+            rawMessageDelivery: true
 components:
   messageTraits:
     commonHeaders:

--- a/samples/UserSignedUpAPI-asyncapi-sqs.yml
+++ b/samples/UserSignedUpAPI-asyncapi-sqs.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.0.0'
+asyncapi: 3.0.0
 id: 'urn:io.microcks.example.user-signedup'
 info:
   title: User signed-up API
@@ -6,16 +6,10 @@ info:
   description: Sample AsyncAPI for user signedup events
 defaultContentType: application/json
 channels:
-  user/signedup:
-    description: The topic on which user signed up events may be consumed
-    subscribe:
-      summary: Receive informations about user signed up
-      operationId: receivedUserSignedUp
-      bindings:
-        sqs:
-          queue:
-            name: my-sqs-queue
-      message:
+  userSignedUpChannel:
+    address: user/signedup
+    messages:
+      receivedUserSignedUp.message:
         description: An event describing that a user just signed up.
         traits:
           - $ref: '#/components/messageTraits/commonHeaders'
@@ -36,22 +30,37 @@ channels:
               type: integer
               minimum: 18
         examples:
-          - laurent:
-              summary: Example for Laurent user
-              headers: |-
-                {"my-app-header": 23}
-              payload: |-
-                {"id": "{{randomString(32)}}", "sendAt": "{{now()}}", "fullName": "Laurent Broudoux", "email": "laurent@microcks.io", "age": 41}
-          - john:
-              summary: Example for John Doe user
-              headers:
-                my-app-header: 24
-              payload:
-                id: '{{randomString(32)}}'
-                sendAt: '{{now()}}'
-                fullName: John Doe
-                email: john@microcks.io
-                age: 36
+          - name: laurent
+            summary: Example for Laurent user
+            headers:
+              {"my-app-header": 23}
+            payload:
+              {"id": "{{randomString(32)}}", "sendAt": "{{now()}}",
+              "fullName": "Laurent Broudoux", "email": "laurent@microcks.io",
+              "age": 41}
+          - name: john
+            summary: Example for John Doe user
+            headers:
+              my-app-header: 24
+            payload:
+              id: '{{randomString(32)}}'
+              sendAt: '{{now()}}'
+              fullName: John Doe
+              email: john@microcks.io
+              age: 36
+    description: The topic on which user signed up events may be consumed
+operations:
+  receivedUserSignedUp:
+    action: receive
+    channel:
+      $ref: '#/channels/userSignedUpChannel'
+    summary: Receive informations about user signed up
+    bindings:
+      sqs:
+        queues:
+          - name: my-sqs-queue
+    messages:
+      - $ref: '#/channels/userSignedUpChannel/messages/receivedUserSignedUp.message'
 components:
   messageTraits:
     commonHeaders:

--- a/samples/UserSignedUpAPI-asyncapi.yml
+++ b/samples/UserSignedUpAPI-asyncapi.yml
@@ -1,4 +1,4 @@
-asyncapi: '2.0.0'
+asyncapi: 3.0.0
 id: 'urn:io.microcks.example.user-signedup'
 info:
   title: User signed-up API
@@ -6,12 +6,11 @@ info:
   description: Sample AsyncAPI for user signedup events
 defaultContentType: application/json
 channels:
-  user/signedup:
+  userSignedUpChannel:
+    address: user/signedup
     description: The topic on which user signed up events may be consumed
-    subscribe:
-      summary: Receive informations about user signed up
-      operationId: receivedUserSignedUp
-      message:
+    messages:
+      receivedUserSignedUp.message:
         description: An event describing that a user just signed up.
         traits:
           - $ref: '#/components/messageTraits/commonHeaders'
@@ -32,22 +31,32 @@ channels:
               type: integer
               minimum: 18
         examples:
-          - laurent:
-              summary: Example for Laurent user
-              headers: |-
-                {"my-app-header": 23}
-              payload: |-
-                {"id": "{{randomString(32)}}", "sendAt": "{{now()}}", "fullName": "Laurent Broudoux", "email": "laurent@microcks.io", "age": 41}
-          - john:
-              summary: Example for John Doe user
-              headers:
-                my-app-header: 24
-              payload:
-                id: '{{randomString(32)}}'
-                sendAt: '{{now()}}'
-                fullName: John Doe
-                email: john@microcks.io
-                age: 36
+          - name: laurent
+            summary: Example for Laurent user
+            headers:
+              {"my-app-header": 23}
+            payload:
+              {"id": "{{randomString(32)}}", "sendAt": "{{now()}}",
+              "fullName": "Laurent Broudoux", "email": "laurent@microcks.io",
+              "age": 41}
+          - name: john
+            summary: Example for John Doe user
+            headers:
+              my-app-header: 24
+            payload:
+              id: '{{randomString(32)}}'
+              sendAt: '{{now()}}'
+              fullName: John Doe
+              email: john@microcks.io
+              age: 36
+operations:
+  consumeUserSignedUp:
+    action: receive
+    channel:
+      $ref: '#/channels/userSignedUpChannel'
+    summary: Receive information about user signed up
+    messages:
+      - $ref: '#/channels/userSignedUpChannel/messages/receivedUserSignedUp.message'
 components:
   messageTraits:
     commonHeaders:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Migrate AsyncAPI examples in `/samples` to 3.0.0.
 - I used a combination of `asyncapi convert` and `asyncapi validate` to convert the examples to 3.0.

To test/validate these changes, I...
1. Converted using `asyncapi convert`.
2. Validated using `asyncapi validate`, and made any updates needed to resolve any issues caught.
3. Compared information side-by-side for the v2 and v4 versions using a local setup of Microcks.
    1. Followed the instructions in `CONTRIBUTING.md` to spin up + login.
    2. Imported v2 and v3 version of the apis to compare visually. Looked at the mocks + documentation page.
    3. Not sure if anything else I could do to validate they _work_ as expected. I’m _assuming_ these aren’t actually testable as they are samples.


### Related issue(s)
Resolves #1152