### PR TITLE
fix: disable dropdown and info when in unauthenticated mode

### DIFF
--- a/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.html
+++ b/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.html
@@ -29,7 +29,7 @@
           </li>
         </ul>
       </li>
-      <li class="dropdown">
+      <li class="dropdown" *ngIf="isAuthEnabled()">
         <button class="btn btn-link dropdown-toggle nav-item-iconic" id="dropdownMenu2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
           <span title="Username" class="fa pficon-user"></span>
           <span class="dropdown-title">
@@ -44,7 +44,7 @@
     </ul>
   </nav>
 </nav>
-  
+
 <div class="nav-pf-vertical nav-pf-vertical-with-sub-menus">
   <ul class="list-group">
     <li class="list-group-item">

--- a/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.ts
+++ b/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.ts
@@ -153,7 +153,7 @@ export class VerticalNavComponent implements OnInit, AfterViewInit {
    * @returns  Returns true if authentication is enabled, false otherwise.
    */
   public isAuthEnabled(): boolean {
-    return this.authService.constructor.name !== AnonymousAuthenticationService.name;
+    return this.config.authType() !== 'anonymous';
   }
 
   public logout(): void {

--- a/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.ts
+++ b/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.ts
@@ -145,10 +145,7 @@ export class VerticalNavComponent implements OnInit, AfterViewInit {
     return this.authService.getAuthenticatedUser();
   }
   /**
-   * Checks if authentication is enabled.
-   *
-   * This method checks if the current authentication service is not an instance of AnonymousAuthenticationService.
-   * If it is not, it means that some form of authentication is enabled.
+   * Checks if authentication is enabled using the configurationService.
    *
    * @returns  Returns true if authentication is enabled, false otherwise.
    */

--- a/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.ts
+++ b/webapp/src/main/webapp/src/app/components/vertical-nav/vertical-nav.component.ts
@@ -35,6 +35,7 @@ import { IAuthenticationService } from '../../services/auth.service';
 import { VersionInfoService } from '../../services/versioninfo.service';
 import { User } from '../../models/user.model';
 import { ConfigService } from 'src/app/services/config.service';
+import {AnonymousAuthenticationService} from '../../services/auth-anonymous.service';
 
 // Thanks to https://github.com/onokumus/metismenu/issues/110#issuecomment-317254128
 // import * as $ from 'jquery';
@@ -142,6 +143,17 @@ export class VerticalNavComponent implements OnInit, AfterViewInit {
 
   public user(): Observable<User> {
     return this.authService.getAuthenticatedUser();
+  }
+  /**
+   * Checks if authentication is enabled.
+   *
+   * This method checks if the current authentication service is not an instance of AnonymousAuthenticationService.
+   * If it is not, it means that some form of authentication is enabled.
+   *
+   * @returns  Returns true if authentication is enabled, false otherwise.
+   */
+  public isAuthEnabled(): boolean {
+    return this.authService.constructor.name !== AnonymousAuthenticationService.name;
   }
 
   public logout(): void {


### PR DESCRIPTION
### Description

- Checks when Microcks is using Auth by checking the config service
- If Microcks is not using Auth it removes the user Info with the dropdown
- else if Microcks is using auth it show the user Info

Not using Auth:
![image](https://github.com/microcks/microcks/assets/60534691/f86126ed-8f4b-45c1-b119-8f56ef5e5f89)
Using Auth:
![image](https://github.com/microcks/microcks/assets/60534691/89dd41b9-aac8-4eaf-8390-78d6ebbc8e3b)

### Related issue(s)
#1138 

### Issues Found (Not fixed in this pr)
- Preferences points to empty url "http://localhost:8080/#0"
![image](https://github.com/microcks/microcks/assets/60534691/e893632e-0548-4401-a1f2-f3bd30a411c5)
- When Keycloak user has no "first Name" or "last Name". Microcks doesn't show a user. 
![image](https://github.com/microcks/microcks/assets/60534691/57679fb1-5513-40dd-a053-7a1565967f90)
We could use "prefered_username" in this case
