### PR TITLE
Fix logging statements

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
@@ -164,7 +164,7 @@ public class AMQPProducerManager {
                      renderedHeader.setValues(Set.of(engine.getValue(firstValue)));
                      renderedHeaders.add(renderedHeader);
                   } catch (Throwable t) {
-                     logger.error("Failing at evaluating template " + firstValue, t);
+                     logger.error("Failed at evaluating template " + firstValue, t);
                      Header renderedHeader = new Header();
                      renderedHeader.setName(header.getName());
                      renderedHeader.setValues(Set.of(firstValue));

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AmazonSNSProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AmazonSNSProducerManager.java
@@ -180,7 +180,7 @@ public class AmazonSNSProducerManager {
                try {
                   finaleValue = engine.getValue(firstValue);
                } catch (Throwable t) {
-                  logger.error("Failing at evaluating template " + firstValue, t);
+                  logger.error("Failed at evaluating template " + firstValue, t);
                }
             }
             return MessageAttributeValue.builder().stringValue(finaleValue).dataType("String").build();

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AmazonSQSProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AmazonSQSProducerManager.java
@@ -169,7 +169,7 @@ public class AmazonSQSProducerManager {
                try {
                   finaleValue = engine.getValue(firstValue);
                } catch (Throwable t) {
-                  logger.error("Failing at evaluating template " + firstValue, t);
+                  logger.error("Failed at evaluating template " + firstValue, t);
                }
             }
             return MessageAttributeValue.builder().stringValue(finaleValue).dataType("String").build();

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/GooglePubSubProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/GooglePubSubProducerManager.java
@@ -161,7 +161,7 @@ public class GooglePubSubProducerManager {
                try {
                   return engine.getValue(firstValue);
                } catch (Exception e) {
-                  logger.error("Failing at evaluating template " + firstValue, e);
+                  logger.error("Failed at evaluating template " + firstValue, e);
                   return firstValue;
                }
             }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
@@ -221,7 +221,7 @@ public class KafkaProducerManager {
                try {
                   renderedHeaders.add(new RecordHeader(header.getName(), engine.getValue(firstValue).getBytes()));
                } catch (Throwable t) {
-                  logger.error("Failing at evaluating template " + firstValue, t);
+                  logger.error("Failed at evaluating template " + firstValue, t);
                   renderedHeaders.add(new RecordHeader(header.getName(), firstValue.getBytes()));
                }
             } else {

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/NATSProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/NATSProducerManager.java
@@ -125,7 +125,7 @@ public class NATSProducerManager {
                   try {
                      headerValue = Base64.getEncoder().encodeToString(engine.getValue(firstValue).getBytes());
                   } catch (Throwable t) {
-                     logger.error("Failing at evaluating template " + firstValue, t);
+                     logger.error("Failed at evaluating template " + firstValue, t);
                      headerValue = Base64.getEncoder().encodeToString(firstValue.getBytes());
                   }
                } else {

--- a/webapp/src/main/java/io/github/microcks/web/MockControllerCommons.java
+++ b/webapp/src/main/java/io/github/microcks/web/MockControllerCommons.java
@@ -263,7 +263,7 @@ public class MockControllerCommons {
       try {
          return engine.getValue(responseContent);
       } catch (Throwable t) {
-         log.error("Failing at evaluating template {}", responseContent, t);
+         log.error("Failed at evaluating template {}", responseContent, t);
       }
       return responseContent;
    }


### PR DESCRIPTION
## Description

There are a few incremental changes that want to enhance the quality of the logging statements.
This pull request addresses a minor improvement in the error logging statements. Specifically, it changes the word "failing" to "failed" to improve grammatical consistency and clarity.

### Changes Made

- Updated the logging statement from "Failing at xxx" to "Failed at xxx".

### Rationale

The previous logging statement used "failing," which implies a continuous action, whereas the context of a try-catch block indicates a completed action. Changing it to "failed" aligns the tense with the past action, making the log message clearer and more precise.
