### PR TITLE
Prefix named helm templates with microcks

### DIFF
--- a/install/kubernetes/microcks/templates/_helpers.tpl
+++ b/install/kubernetes/microcks/templates/_helpers.tpl
@@ -31,7 +31,7 @@ tls.key: {{ $cert.Key | b64enc }}
 {{/*
 Generate certificates for keycloak ingress
 */}}
-{{- define "keycloak-ingress.gen-certs" -}}
+{{- define "microcks.keycloak-ingress.gen-certs" -}}
 {{- $cert := genSelfSignedCert .Values.keycloak.url nil (list .Values.keycloak.url) 365 -}}
 tls.crt: {{ $cert.Cert | b64enc }}
 tls.key: {{ $cert.Key | b64enc }}
@@ -77,7 +77,7 @@ Generate common annotations
 Create image name value
 ( dict "imageRoot" .Values.path.to.image "context" $ )
 */}}
-{{- define "renderImage" -}}
+{{- define "microcks.renderImage" -}}
 {{- $ref := join "/" (compact (list .imageRoot.registry .imageRoot.repository)) -}}
 {{- join "" (compact (list $ref (ternary ":" "@" (empty .imageRoot.digest)) (default .imageRoot.tag .imageRoot.digest))) -}}
 {{- end -}}
@@ -86,40 +86,40 @@ Create image name value
 Compute microcks image full name
 */}}
 {{- define "microcks.image" -}}
-{{- include "renderImage" ( dict "imageRoot" .Values.microcks.image "context" $ ) -}}
+{{- include "microcks.renderImage" ( dict "imageRoot" .Values.microcks.image "context" $ ) -}}
 {{- end -}}
 
 {{/*
 Compute postman image full name
 */}}
-{{- define "postman.image" -}}
-{{- include "renderImage" ( dict "imageRoot" .Values.postman.image "context" $ ) -}}
+{{- define "microcks.postman.image" -}}
+{{- include "microcks.renderImage" ( dict "imageRoot" .Values.postman.image "context" $ ) -}}
 {{- end -}}
 
 {{/*
 Compute mongodb image full name
 */}}
-{{- define "mongodb.image" -}}
-{{- include "renderImage" ( dict "imageRoot" .Values.mongodb.image "context" $ ) -}}
+{{- define "microcks.mongodb.image" -}}
+{{- include "microcks.renderImage" ( dict "imageRoot" .Values.mongodb.image "context" $ ) -}}
 {{- end -}}
 
 {{/*
 Compute keycloak image full name
 */}}
-{{- define "keycloak.image" -}}
-{{- include "renderImage" ( dict "imageRoot" .Values.keycloak.image "context" $ ) -}}
+{{- define "microcks.keycloak.image" -}}
+{{- include "microcks.renderImage" ( dict "imageRoot" .Values.keycloak.image "context" $ ) -}}
 {{- end -}}
 
 {{/*
 Compute keycloak postgres image full name
 */}}
-{{- define "keycloakPostgres.image" -}}
-{{- include "renderImage" ( dict "imageRoot" .Values.keycloak.postgresImage "context" $ ) -}}
+{{- define "microcks.keycloakPostgres.image" -}}
+{{- include "microcks.renderImage" ( dict "imageRoot" .Values.keycloak.postgresImage "context" $ ) -}}
 {{- end -}}
 
 {{/*
 Compute async-minion image full name
 */}}
-{{- define "async-minion.image" -}}
-{{- include "renderImage" ( dict "imageRoot" .Values.features.async.image "context" $ ) -}}
+{{- define "microcks.async-minion.image" -}}
+{{- include "microcks.renderImage" ( dict "imageRoot" .Values.features.async.image "context" $ ) -}}
 {{- end -}}

--- a/install/kubernetes/microcks/templates/deployment.yaml
+++ b/install/kubernetes/microcks/templates/deployment.yaml
@@ -230,7 +230,7 @@ spec:
     spec:
       containers:
       - name: postman-runtime
-        image: {{ include "postman.image" . }}
+        image: {{ include "microcks.postman.image" . }}
         ports:
         - containerPort: 3000
           protocol: TCP
@@ -308,7 +308,7 @@ spec:
       {{- end }}
       containers:
       - name: mongodb
-        image: {{ include "mongodb.image" . }}
+        image: {{ include "microcks.mongodb.image" . }}
         args: ["--dbpath","/var/lib/mongodb/data"]
         ports:
         - containerPort: 27017
@@ -415,7 +415,7 @@ spec:
     spec:
       containers:
       - name: keycloak-server
-        image: {{ include "keycloak.image" . }}
+        image: {{ include "microcks.keycloak.image" . }}
         resources:
           {{- toYaml .Values.keycloak.resources | nindent 10 }}
         ports:
@@ -562,7 +562,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: keycloak-postgresql
-        image: {{ include "keycloakPostgres.image" . }}
+        image: {{ include "microcks.keycloakPostgres.image" . }}
         args: ["-c", "max_connections=100", "-c", "shared_buffers=12MB"]
         imagePullPolicy: IfNotPresent
         ports:
@@ -646,7 +646,7 @@ spec:
     spec:
       containers:
       - name: async-minion
-        image: {{ include "async-minion.image" . }}
+        image: {{ include "microcks.async-minion.image" . }}
         imagePullPolicy: IfNotPresent
         env:
           - name: QUARKUS_PROFILE

--- a/install/kubernetes/microcks/templates/secret.yaml
+++ b/install/kubernetes/microcks/templates/secret.yaml
@@ -63,7 +63,7 @@ metadata:
     {{- include "microcks-common-annotations" . | nindent 4 }}
 type: kubernetes.io/tls
 data:
-{{ ( include "keycloak-ingress.gen-certs" . ) | indent 2 }}
+{{ ( include "microcks.keycloak-ingress.gen-certs" . ) | indent 2 }}
 {{- end }}
 {{- if (not .Values.keycloak.secretRef) }}
 ---


### PR DESCRIPTION
### Description

In an umbrella chart, all named templates of all sub-charts are merged, which can cause unexpected conflicts.
Thus add microcks prefix to prevent conflicts with other sub-charts.

### Related issue(s)

Fixes #1263