### PR TITLE
GraphQL schema instrospection not working on native distribution

### DIFF
--- a/distro/uber/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/distro/uber/src/main/resources/META-INF/native-image/reflect-config.json
@@ -326,5 +326,10 @@
   {
     "name":"com.github.fge.jsonschema.messages.JsonSchemaValidationBundle",
     "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "name": "graphql.ExecutionResult",
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
   }
 ]


### PR DESCRIPTION

### Description
- Registered `graphql.ExecutionResult` class to used by reflection in r`eflect-config.json`.
- After this, we are able to content in response of graphql introspection query

### Related issue(s)
- Fixes #1235 