### PR TITLE
Add missing guard on jsonNode schema path access

### DIFF
--- a/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
@@ -210,6 +210,10 @@ public class OpenAPISchemaValidator {
       // Build a schema object with responseNode schema as root and by importing
       // all the common parts that may be referenced by references.
       JsonNode schemaNode = messageNode.path("schema").deepCopy();
+      if (schemaNode == null || schemaNode.isMissingNode()) {
+         log.debug("schema for {} cannot be found into OpenAPI specification", messageNode);
+         return List.of("schemaPathPointer does not represent an existing JSON Pointer in OpenAPI specification");
+      }
       ((ObjectNode) schemaNode).set(JSON_SCHEMA_COMPONENTS_ELEMENT,
             specificationNode.path(JSON_SCHEMA_COMPONENTS_ELEMENT).deepCopy());
 


### PR DESCRIPTION
### Description

add a guard on the jsonNode schema path access to prevent testing staying in pending state.

### Related issue(s)

Fixes #1293