### PR TITLE
Add escape character on dynamic response

### DIFF
--- a/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
@@ -89,7 +89,12 @@ public class ExpressionParser {
                throw new ParseException(template, prefixIndex, "No expression defined within delimiter '"
                      + expressionPrefix + expressionSuffix + "' at character " + prefixIndex);
             }
-            expressions.add(doParseExpression(expr, context));
+            if (expr.charAt(0) == '{' || expr.charAt(0) == '(' || expr.charAt(0) == '[' || expr.charAt(0) == '#') {
+               expressions.add(new LiteralExpression(expr.substring(0, 1)));
+               expressions.add(doParseExpression(expr.substring(1, expr.length() - 1), context));
+               expressions.add(new LiteralExpression(expr.substring(expr.length() - 1)));
+            } else
+               expressions.add(doParseExpression(expr, context));
             startIdx = suffixIndex + expressionSuffix.length();
             log.debug("Expression accumulated. Pursuing with index {} on {}", startIdx, template.length());
          } else {
@@ -107,6 +112,18 @@ public class ExpressionParser {
       if (nextSuffix == -1) {
          return -1; // the suffix is missing
       }
+
+      // Check if there are more closing curly braces after the found "}}"
+      int lastIndexOfSuffix = nextSuffix + expressionSuffix.length();
+      while (lastIndexOfSuffix < template.length() && template.charAt(lastIndexOfSuffix) == '}') {
+         lastIndexOfSuffix++;
+      }
+
+      // If we found extra closing curly braces, return the position of the first two "}}"
+      if (lastIndexOfSuffix > nextSuffix + expressionSuffix.length()) {
+         return lastIndexOfSuffix - expressionSuffix.length();
+      }
+
       return nextSuffix;
    }
 

--- a/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
@@ -55,6 +55,7 @@ public class ExpressionParser {
     */
    public static Expression[] parseExpressions(String template, EvaluationContext context, String expressionPrefix,
          String expressionSuffix) throws ParseException {
+      template = template.replace("\\{", "ESCAPED_OPEN_BRACE").replace("\\}", "ESCAPED_CLOSE_BRACE");
       // Prepare an array for results.
       List<Expression> expressions = new ArrayList<>();
       int startIdx = 0;
@@ -134,6 +135,11 @@ public class ExpressionParser {
     * Depending on expression string, try to guess if it's a Literal, a Function or a VariableReference expression.
     */
    private static Expression doParseSimpleExpression(String expressionString, EvaluationContext context) {
+      boolean hasEscapeBraces = expressionString.contains("ESCAPED_OPEN_BRACE");
+      if (hasEscapeBraces) {
+         expressionString = expressionString.replace("ESCAPED_OPEN_BRACE", "");
+         expressionString = expressionString.replace("ESCAPED_CLOSE_BRACE", "");
+      }
       int argsStart = expressionString.indexOf('(');
       int argsEnd = expressionString.indexOf(')');
       int variableStart = expressionString.indexOf('.');
@@ -187,7 +193,7 @@ public class ExpressionParser {
             log.error("Exception while instantiating the functionClazz " + functionClazz, e);
             return new LiteralExpression("");
          }
-         return new FunctionExpression(function, args);
+         return new FunctionExpression(function, args, hasEscapeBraces);
       }
 
       log.info("No ELFunction or complex VariableReference expressions found... Returning simple VariableReference");

--- a/commons/util-el/src/main/java/io/github/microcks/util/el/FunctionExpression.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/FunctionExpression.java
@@ -25,19 +25,24 @@ public class FunctionExpression implements Expression {
 
    private final ELFunction function;
    private final String[] functionArgs;
+   private final boolean hasEscapeBraces;
 
    /**
     * Build a new function expression with a function and its invocation arguments.
     * @param function     The ELFunction associated to this expression
     * @param functionArgs The invocation arguments of this function
     */
-   public FunctionExpression(ELFunction function, String[] functionArgs) {
+   public FunctionExpression(ELFunction function, String[] functionArgs, boolean hasEscapeBraces) {
       this.function = function;
       this.functionArgs = functionArgs;
+      this.hasEscapeBraces = hasEscapeBraces;
    }
 
    @Override
    public String getValue(EvaluationContext context) {
+      if (hasEscapeBraces) {
+         return "{" + function.evaluate(context, functionArgs) + "}";
+      }
       return function.evaluate(context, functionArgs);
    }
 
@@ -47,5 +52,9 @@ public class FunctionExpression implements Expression {
 
    public String[] getFunctionArgs() {
       return functionArgs;
+   }
+
+   public boolean hasEscapeBraces() {
+      return hasEscapeBraces;
    }
 }

--- a/commons/util-el/src/main/java/io/github/microcks/util/el/RedirectExpression.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/RedirectExpression.java
@@ -45,7 +45,7 @@ public class RedirectExpression implements Expression {
                String[] clonedArgs = Arrays.copyOf(functionExp.getFunctionArgs(),
                      functionExp.getFunctionArgs().length + 1);
                clonedArgs[clonedArgs.length - 1] = result;
-               FunctionExpression clonedExp = new FunctionExpression(functionExp.getFunction(), clonedArgs);
+               FunctionExpression clonedExp = new FunctionExpression(functionExp.getFunction(), clonedArgs, false);
                clonedExp.getValue(context);
             }
          }

--- a/commons/util-el/src/test/java/io/github/microcks/util/el/RedirectExpressionTest.java
+++ b/commons/util-el/src/test/java/io/github/microcks/util/el/RedirectExpressionTest.java
@@ -40,7 +40,7 @@ class RedirectExpressionTest {
       EvaluationContext context = new EvaluationContext();
 
       Expression[] expressions = new Expression[] { new LiteralExpression("hello"),
-            new FunctionExpression(new PutInContextELFunction(), new String[] { "greeting" }) };
+            new FunctionExpression(new PutInContextELFunction(), new String[] { "greeting" }, false) };
 
       RedirectExpression exp = new RedirectExpression(expressions);
       String result = exp.getValue(context);
@@ -53,8 +53,8 @@ class RedirectExpressionTest {
       EvaluationContext context = new EvaluationContext();
 
       Expression[] expressions = new Expression[] { new LiteralExpression("hello"),
-            new FunctionExpression(new PutInContextELFunction(), new String[] { "greeting1" }),
-            new FunctionExpression(new PutInContextELFunction(), new String[] { "greeting2" }) };
+            new FunctionExpression(new PutInContextELFunction(), new String[] { "greeting1" }, false),
+            new FunctionExpression(new PutInContextELFunction(), new String[] { "greeting2" }, false) };
 
       RedirectExpression exp = new RedirectExpression(expressions);
       String result = exp.getValue(context);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR adds support for escape character, which are provided in response example of specification file.
- This PR modifies `skipToCorrectEndSuffix()` method of `ExpressionParser` which now will now return index of last '}}'.
- I will enable us to wrap values inside the wrapper like `{}`, `()`, `##`, `[]` in response body.

### Behavior After Changes 

- Now Microcks will be able to parse escape characters which are provided in response example of specification file like given below:

```
{
   "id": "{{{uuid()}}}",
    "name": "{{ #request.body/name# }}"
}
```
- This will generate result like given below:
```
{
  "id": "{570e8c11-cac6-42e1-ab3a-6f4e6d9a10a2}",
  "name": "#Rusty#"
}
```

**it will support wrappers like '{}', '()', '[]' '##' only.

### Related issue(s)
Fixes #1353 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->