### PR TITLE
Add escape character on dynamic response

### DIFF
--- a/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
@@ -88,7 +88,7 @@ public class ExpressionParser {
                throw new ParseException(template, prefixIndex, "No expression defined within delimiter '"
                      + expressionPrefix + expressionSuffix + "' at character " + prefixIndex);
             }
-            if (expr.charAt(0) == '{' || expr.charAt(0) == '(' || expr.charAt(0) == '[' || expr.charAt(0) == '#') {
+            if (expr.charAt(0) == '{') {
                expressions.add(new LiteralExpression(expr.substring(0, 1)));
                expressions.add(doParseExpression(expr.substring(1, expr.length() - 1), context));
                expressions.add(new LiteralExpression(expr.substring(expr.length() - 1)));

--- a/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
@@ -88,7 +88,12 @@ public class ExpressionParser {
                throw new ParseException(template, prefixIndex, "No expression defined within delimiter '"
                      + expressionPrefix + expressionSuffix + "' at character " + prefixIndex);
             }
-            expressions.add(doParseExpression(expr, context));
+            if (expr.charAt(0) == '{' || expr.charAt(0) == '(' || expr.charAt(0) == '[' || expr.charAt(0) == '#') {
+               expressions.add(new LiteralExpression(expr.substring(0, 1)));
+               expressions.add(doParseExpression(expr.substring(1, expr.length() - 1), context));
+               expressions.add(new LiteralExpression(expr.substring(expr.length() - 1)));
+            } else
+               expressions.add(doParseExpression(expr, context));
             startIdx = suffixIndex + expressionSuffix.length();
             log.debug("Expression accumulated. Pursuing with index {} on {}", startIdx, template.length());
          } else {
@@ -106,6 +111,18 @@ public class ExpressionParser {
       if (nextSuffix == -1) {
          return -1; // the suffix is missing
       }
+
+      // Check if there are more closing curly braces after the found "}}"
+      int lastIndexOfSuffix = nextSuffix + expressionSuffix.length();
+      while (lastIndexOfSuffix < template.length() && template.charAt(lastIndexOfSuffix) == '}') {
+         lastIndexOfSuffix++;
+      }
+
+      // If we found extra closing curly braces, return the position of the first two "}}"
+      if (lastIndexOfSuffix > nextSuffix + expressionSuffix.length()) {
+         return lastIndexOfSuffix - expressionSuffix.length();
+      }
+
       return nextSuffix;
    }
 

--- a/commons/util-el/src/test/java/io/github/microcks/util/el/ExpressionParserTest.java
+++ b/commons/util-el/src/test/java/io/github/microcks/util/el/ExpressionParserTest.java
@@ -20,7 +20,9 @@ import io.github.microcks.util.el.function.PutInContextELFunction;
 import io.github.microcks.util.el.function.UUIDELFunction;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 /**
  * A TestCase for ExpressionParser class.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR adds support for escape character, which are provided in response example of specification file.
- This PR modifies `skipToCorrectEndSuffix()` method of `ExpressionParser` which now will now return index of last '}}'.
- I will enable us to wrap values inside the wrapper like `{}`, `()`, `##`, `[]` in response body.

### Behavior After Changes 

- Now Microcks will be able to parse escape characters which are provided in response example of specification file like given below:

```
{
   "id": "{{{uuid()}}}",
    "name": "#{{ request.body/name }}#"
}
```
- This will generate result like given below:
```
{
  "id": "{570e8c11-cac6-42e1-ab3a-6f4e6d9a10a2}",
  "name": "#Rusty#"
}
```

**it will support wrappers like '{}', '()', '[]' '##' only.

### Related issue(s)
Fixes #1353 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->