### PR TITLE
#feat: 1418 support headers in grpc tests

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
@@ -33,9 +33,6 @@ import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import com.google.rpc.Code;
-import com.google.rpc.Status;
-
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
@@ -48,7 +45,6 @@ import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
-import io.grpc.StatusRuntimeException;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.ClientCalls;
 import org.slf4j.Logger;
@@ -63,7 +59,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -93,11 +88,10 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
             public void start(Listener<RespT> responseListener, Metadata headers) {
                // Extract custom headers from CallOptions
                Metadata customHeaders = callOptions.getOption(METADATA_CUSTOM_CALL_OPTION);
-               log.info("Adding headers to client request: {}", customHeaders.keys()); // TODO: change to debug mode
+               log.debug("Adding headers to client request: {}", customHeaders.keys());
                if (customHeaders != null) {
                   headers.merge(customHeaders);
                }
-               // The headers are passed through custom Call Options
                super.start(responseListener, headers);
             }
          };

--- a/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
@@ -15,6 +15,7 @@
  */
 package io.github.microcks.util.grpc;
 
+import io.github.microcks.domain.Header;
 import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Request;
 import io.github.microcks.domain.Resource;
@@ -26,16 +27,28 @@ import io.github.microcks.domain.TestResult;
 import io.github.microcks.domain.TestReturn;
 import io.github.microcks.repository.ResourceRepository;
 import io.github.microcks.util.test.AbstractTestRunner;
+import io.github.microcks.util.test.TestRunnerCommons;
 
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
+import com.google.rpc.Code;
+import com.google.rpc.Status;
+
 import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ClientInterceptors;
 import io.grpc.Deadline;
+import io.grpc.ForwardingClientCall;
 import io.grpc.Grpc;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.StatusRuntimeException;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.ClientCalls;
 import org.slf4j.Logger;
@@ -50,7 +63,9 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -59,6 +74,37 @@ import java.util.concurrent.TimeUnit;
  * @author laurent
  */
 public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
+
+   /* Call Option used to pass gRPC Metadata from client invocation to header client interceptor */
+   public static final CallOptions.Key<Metadata> METADATA_CUSTOM_CALL_OPTION = CallOptions.Key
+         .createWithDefault("request-metadata", null);
+
+   class HeaderInterceptor implements ClientInterceptor {
+
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method,
+            CallOptions callOptions, Channel next) {
+         return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
+            /**
+             * Extension of the AttachHeadersInterceptor by allowing custom headers on each request, passed through via
+             * custom CallOption.
+             */
+            @Override
+            public void start(Listener<RespT> responseListener, Metadata headers) {
+               // Extract custom headers from CallOptions
+               Metadata customHeaders = callOptions.getOption(METADATA_CUSTOM_CALL_OPTION);
+               log.info("Adding headers to client request: {}", customHeaders.keys()); // TODO: change to debug mode
+               if (customHeaders != null) {
+                  headers.merge(customHeaders);
+               }
+               // The headers are passed through custom Call Options
+               super.start(responseListener, headers);
+            }
+         };
+
+      }
+
+   }
 
    /** A simple logger for diagnostic messages. */
    private final static Logger log = LoggerFactory.getLogger(GrpcTestRunner.class);
@@ -112,7 +158,7 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
       // Build a new GRPC Channel from endpoint URL.
       URL endpoint = new URL(endpointUrl);
 
-      ManagedChannel channel;
+      ManagedChannel originChannel;
       if (endpointUrl.startsWith("https://") || endpoint.getPort() == 443) {
          TlsChannelCredentials.Builder tlsBuilder = TlsChannelCredentials.newBuilder();
          if (secret != null && secret.getCaCertPem() != null) {
@@ -135,13 +181,18 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
             });
          }
          // Build a Channel using the TLS Builder.
-         channel = Grpc.newChannelBuilderForAddress(endpoint.getHost(), endpoint.getPort(), tlsBuilder.build()).build();
+         originChannel = Grpc.newChannelBuilderForAddress(endpoint.getHost(), endpoint.getPort(), tlsBuilder.build())
+               .build();
       } else {
          // Build a simple Channel using no creds (now default to plain text so usePlainText() is no longer necessary).
-         channel = Grpc
+         originChannel = Grpc
                .newChannelBuilderForAddress(endpoint.getHost(), endpoint.getPort(), InsecureChannelCredentials.create())
                .build();
       }
+      // Add a custom header interceptor which adds the request-specific headers to
+      // every operation
+      ClientInterceptor headerInterceptor = new HeaderInterceptor();
+      Channel channel = ClientInterceptors.intercept(originChannel, headerInterceptor);
 
       // In order to produce outgoing byte array, we need the Protobuf binary descriptor that should
       // have been processed while importing the .proto schema for the service.
@@ -196,6 +247,10 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
                GrpcUtil.buildGenericUnaryMethodDescriptor(fullMethodName), callOptions, requestBytes);
          long duration = System.currentTimeMillis() - startTime;
 
+         // Add all headers as customOptions to callOptions
+         Set<Header> headers = TestRunnerCommons.collectHeaders(testResult, request, operation);
+         callOptions = callOptions.withOption(METADATA_CUSTOM_CALL_OPTION, convertHeadersToMetadata(headers));
+
          // Create a Response object for returning.
          Response response = new Response();
          response.setStatus("200");
@@ -218,6 +273,17 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
          }
       }
       return results;
+   }
+
+   private static Metadata convertHeadersToMetadata(Set<Header> headers) {
+      Metadata metadata = new Metadata();
+      for (Header header : headers) {
+         log.info("Adding header {} to request", header.getName());
+         for (String value : header.getValues()) {
+            metadata.put(Metadata.Key.of(header.getName(), Metadata.ASCII_STRING_MARSHALLER), value);
+         }
+      }
+      return metadata;
    }
 
    /**

--- a/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
@@ -71,8 +71,9 @@ import java.util.concurrent.TimeUnit;
 public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
 
    /* Call Option used to pass gRPC Metadata from client invocation to header client interceptor */
+   public static final String CUSTOM_CALL_OPTION_NAME = "request-metadata";
    public static final CallOptions.Key<Metadata> METADATA_CUSTOM_CALL_OPTION = CallOptions.Key
-         .createWithDefault("request-metadata", null);
+         .createWithDefault(CUSTOM_CALL_OPTION_NAME, null);
 
    class HeaderInterceptor implements ClientInterceptor {
 

--- a/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
@@ -88,8 +88,8 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
             public void start(Listener<RespT> responseListener, Metadata headers) {
                // Extract custom headers from CallOptions
                Metadata customHeaders = callOptions.getOption(METADATA_CUSTOM_CALL_OPTION);
-               log.debug("Adding headers to client request: {}", customHeaders.keys());
                if (customHeaders != null) {
+                  log.debug("Adding headers to client request: {}", customHeaders.keys());
                   headers.merge(customHeaders);
                }
                super.start(responseListener, headers);
@@ -272,7 +272,6 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
    private static Metadata convertHeadersToMetadata(Set<Header> headers) {
       Metadata metadata = new Metadata();
       for (Header header : headers) {
-         log.info("Adding header {} to request", header.getName());
          for (String value : header.getValues()) {
             metadata.put(Metadata.Key.of(header.getName(), Metadata.ASCII_STRING_MARSHALLER), value);
          }

--- a/webapp/src/main/java/io/github/microcks/util/postman/PostmanTestStepsRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/postman/PostmanTestStepsRunner.java
@@ -28,6 +28,7 @@ import io.github.microcks.domain.TestReturn;
 import io.github.microcks.repository.ResourceRepository;
 import io.github.microcks.util.URIBuilder;
 import io.github.microcks.util.test.AbstractTestRunner;
+import io.github.microcks.util.test.TestRunnerCommons;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -164,19 +165,7 @@ public class PostmanTestStepsRunner extends AbstractTestRunner<HttpMethod> {
          }
          // Set headers to request if any. Start with those coming from request itself.
          // Add or override existing headers with test specific ones for operation and globals.
-         Set<Header> headers = new HashSet<>();
-
-         if (request.getHeaders() != null) {
-            headers.addAll(request.getHeaders());
-         }
-         if (testResult.getOperationsHeaders() != null) {
-            if (testResult.getOperationsHeaders().getGlobals() != null) {
-               headers.addAll(testResult.getOperationsHeaders().getGlobals());
-            }
-            if (testResult.getOperationsHeaders().get(operation.getName()) != null) {
-               headers.addAll(testResult.getOperationsHeaders().get(operation.getName()));
-            }
-         }
+         Set<Header> headers = TestRunnerCommons.collectHeaders(testResult, request, operation);
          if (!headers.isEmpty()) {
             ArrayNode jsonHeaders = buildHeaders(headers);
             jsonRequest.set("headers", jsonHeaders);

--- a/webapp/src/main/java/io/github/microcks/util/test/HttpTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/test/HttpTestRunner.java
@@ -187,21 +187,8 @@ public class HttpTestRunner extends AbstractTestRunner<HttpMethod> {
     */
    protected Set<Header> prepareRequestHeaders(Operation operation, ClientHttpRequest httpRequest, Request request,
          TestResult testResult) {
-      Set<Header> headers = new HashSet<>();
+      Set<Header> headers = TestRunnerCommons.collectHeaders(testResult, request, operation);
 
-      // Set headers to request if any. Start with those coming from request itself.
-      if (request.getHeaders() != null) {
-         headers.addAll(request.getHeaders());
-      }
-      // Add or override existing headers with test specific ones for operation and globals.
-      if (testResult.getOperationsHeaders() != null) {
-         if (testResult.getOperationsHeaders().getGlobals() != null) {
-            headers.addAll(testResult.getOperationsHeaders().getGlobals());
-         }
-         if (testResult.getOperationsHeaders().get(operation.getName()) != null) {
-            headers.addAll(testResult.getOperationsHeaders().get(operation.getName()));
-         }
-      }
       if (!headers.isEmpty()) {
          for (Header header : headers) {
             log.debug("Adding header {} to request", header.getName());

--- a/webapp/src/main/java/io/github/microcks/util/test/TestRunnerCommons.java
+++ b/webapp/src/main/java/io/github/microcks/util/test/TestRunnerCommons.java
@@ -16,8 +16,10 @@
 package io.github.microcks.util.test;
 
 import io.github.microcks.domain.Header;
+import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Parameter;
 import io.github.microcks.domain.Request;
+import io.github.microcks.domain.TestResult;
 import io.github.microcks.util.el.EvaluableRequest;
 import io.github.microcks.util.el.TemplateEngine;
 import io.github.microcks.util.el.TemplateEngineFactory;
@@ -26,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -76,5 +79,34 @@ public class TestRunnerCommons {
          }
       }
       return request.getContent();
+   }
+
+   /**
+    * Construct set of headers given specification of request, operations and testResult. TestResult operation-specific
+    * headers overrule testResult global headers which overrule request headers.
+    * @param testResult The configured test run containing global and operation-specific headers.
+    * @param request    The example request with headers.
+    * @param operation  The operation to be run.
+    * @return A set of headers for the given operation
+    */
+   public static Set<Header> collectHeaders(TestResult testResult, Request request, Operation operation) {
+      Set<Header> headers = new HashSet<>();
+
+      // Set headers to request if any. Start with those coming from request itself.
+      if (request.getHeaders() != null) {
+         headers.addAll(request.getHeaders());
+      }
+
+      // Add or override existing headers with test specific ones for operation and globals.
+      if (testResult.getOperationsHeaders() != null) {
+         if (testResult.getOperationsHeaders().getGlobals() != null) {
+            headers.addAll(testResult.getOperationsHeaders().getGlobals());
+         }
+         if (testResult.getOperationsHeaders().get(operation.getName()) != null) {
+            headers.addAll(testResult.getOperationsHeaders().get(operation.getName()));
+         }
+      }
+
+      return headers;
    }
 }


### PR DESCRIPTION
### Description

- Add headers specified in Requests and Test Run to test invocations

### Related issue(s)

Resolves #1418 

### Notes
During the implementation, I noticed that all test runners share the same code to collect the headers and refactored it into one method in `TestRunnerCommons`. If that is not wanted, let me know and I can revert this change. 