### PR TITLE
APIExample doesn't provide a default status

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/metadata/ExamplesImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/metadata/ExamplesImporter.java
@@ -223,6 +223,8 @@ public class ExamplesImporter implements MockRepositoryImporter {
          // Initialize and complete the response.
          Response response = new Response();
          response.setName(exampleName);
+         // Default response status
+         response.setStatus("200");
 
          if (responseNode.has(HEADERS_NODE)) {
             completeWithHeaders(response, responseNode.get(HEADERS_NODE));

--- a/webapp/src/test/java/io/github/microcks/util/metadata/ExamplesImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/metadata/ExamplesImporterTest.java
@@ -81,7 +81,7 @@ class ExamplesImporterTest {
       assertTrue(operation.getResourcePaths().contains("/pastry/{name}"));
 
       assertNotNull(exchanges);
-      assertEquals(2, exchanges.size());
+      assertEquals(3, exchanges.size());
 
       for (Exchange exchange : exchanges) {
          if (exchange instanceof RequestResponsePair pair) {
@@ -112,6 +112,16 @@ class ExamplesImporterTest {
                      + "  <description>Delicieux Eclair au Chocolat pas calorique du tout</description>\n"
                      + "  <size>M</size>\n" + "  <price>2.5</price>\n" + "  <status>unknown</status>\n" + "</pastry>",
                      pair.getResponse().getContent());
+            } else if ("Eclair Chocolat Empty Status".equals(pair.getRequest().getName())) {
+               assertEquals("Eclair Chocolat", parameter.getValue());
+
+               // Check that content has been transformed in JSON.
+               assertEquals("application/json", pair.getResponse().getMediaType());
+               assertEquals(
+                     "{\"name\":\"Eclair Chocolat\",\"description\":\"Delicieux Eclair Chocolat pas calorique du tout\",\"size\":\"M\",\"price\":2.5}",
+                     pair.getResponse().getContent());
+               // Check that default status value has got set
+               assertEquals("200", pair.getResponse().getStatus());
             }
          } else {
             fail("Unknown extracted exchange type");

--- a/webapp/src/test/resources/io/github/microcks/util/metadata/APIPastry-2.0-examples.yml
+++ b/webapp/src/test/resources/io/github/microcks/util/metadata/APIPastry-2.0-examples.yml
@@ -31,3 +31,14 @@ operations:
             <price>2.5</price>
             <status>unknown</status>
           </pastry>
+    Eclair Chocolat Empty Status:
+      request:
+        parameters:
+          name: Eclair Chocolat
+      response:
+        mediaType: application/json
+        body:
+          name: Eclair Chocolat
+          description: Delicieux Eclair Chocolat pas calorique du tout
+          size: M
+          price: 2.5


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR fixes default status issue of APIExample file.
- Initialized response in `ExampleImporter` with default status `200`, so if there is no mention of status in `APIExample` file default status will be used.

### Related issue(s)
Fixes #1439 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->