### PR TITLE
refactor: migrating from `java-json-tools/json-schema-validator` to `networknt/json-schema-validator`

### DIFF
--- a/commons/util/pom.xml
+++ b/commons/util/pom.xml
@@ -70,6 +70,14 @@
       <artifactId>json-schema-validator</artifactId>
       <version>2.2.14</version>
     </dependency>
+
+    <!-- import for networknt/json-schema-validator -->
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>1.5.4</version>
+    </dependency>
+
     <dependency>
       <groupId>com.github.java-json-tools</groupId>
       <artifactId>jackson-coreutils</artifactId>

--- a/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidatorNetworknt.java
+++ b/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidatorNetworknt.java
@@ -1,10 +1,15 @@
 package io.github.microcks.util;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.fge.jackson.JsonLoader;
 import com.networknt.schema.*;
 import com.networknt.schema.serialization.DefaultJsonNodeReader;
+import com.networknt.schema.serialization.JsonNodeReader;
 import com.networknt.schema.serialization.node.JsonNodeFactoryFactory;
 import com.networknt.schema.utils.JsonNodeUtil;
 import com.networknt.schema.utils.JsonNodes;
@@ -14,106 +19,89 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class JsonSchemaValidatorNetworknt {
 
-  /** A commons logger for diagnostic messages. */
-  private static Logger log = LoggerFactory.getLogger(JsonSchemaValidator.class);
+   /** A commons logger for diagnostic messages. */
+   private static Logger log = LoggerFactory.getLogger(JsonSchemaValidator.class);
 
-  public static final String JSON_V4_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-04/schema#";
-  public static final String JSON_V7_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-07/schema#";
-  public static final String JSON_V12_SCHEMA_IDENTIFIER = "http://json-schema.org/draft/2020-12/schema#";
-  public static final String JSON_SCHEMA_IDENTIFIER_ELEMENT = "$schema";
+   public static final String JSON_V4_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-04/schema#";
+   public static final String JSON_V7_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-07/schema#";
+   public static final String JSON_V12_SCHEMA_IDENTIFIER = "http://json-schema.org/draft/2020-12/schema#";
+   public static final String JSON_SCHEMA_IDENTIFIER_ELEMENT = "$schema";
 
-  public static final String JSON_SCHEMA_COMPONENTS_ELEMENT = "components";
-  public static final String JSON_SCHEMA_PROPERTIES_ELEMENT = "properties";
+   public static final String JSON_SCHEMA_COMPONENTS_ELEMENT = "components";
+   public static final String JSON_SCHEMA_PROPERTIES_ELEMENT = "properties";
 
-  private JsonSchemaValidatorNetworknt(){
+   private static final ObjectMapper mapper = new ObjectMapper()
+         .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+         .enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN).enable(SerializationFeature.INDENT_OUTPUT);
 
-  }
+   private JsonSchemaValidatorNetworknt() {
 
-  public static boolean isJsonValid(String schemaText, String jsonText) throws IOException {
-    return isJsonValid(schemaText, jsonText, null);
-  }
+   }
 
-  public static boolean isJsonValid(String schemaText, String jsonText, String namespace) throws IOException {
-    try {
-      List<String> errors = validateJson(schemaText, jsonText, namespace);
-      if (!errors.isEmpty()) {
-        log.debug("Get validation errors, returning false");
-        return false;
+   public static boolean isJsonValid(String schemaText, String jsonText) throws IOException {
+      return isJsonValid(schemaText, jsonText, null);
+   }
+
+   public static boolean isJsonValid(String schemaText, String jsonText, String namespace) throws IOException {
+      try {
+         List<String> errors = validateJson(schemaText, jsonText, namespace);
+         if (!errors.isEmpty()) {
+            log.debug("Get validation errors, returning false");
+            return false;
+         }
+      } catch (Exception pe) {
+         log.debug("Got processing exception while extracting schema, returning false");
+         return false;
       }
-    } catch (Exception pe) {
-      log.debug("Got processing exception while extracting schema, returning false");
-      return false;
-    }
-    return true;
-  }
+      return true;
+   }
 
-  public static List<String> validateJson(String schemaText, String jsonText) throws IOException {
-    return validateJson(getJsonNode(schemaText), getJsonNode(jsonText), null);
-  }
+   public static List<String> validateJson(String schemaText, String jsonText) throws IOException {
+      return validateJson(getJsonNode(schemaText), getJsonNode(jsonText), null);
+   }
 
-  public static List<String> validateJson(String schemaText, String jsonText, String namespace)
-    throws IOException {
-    return validateJson(getJsonNode(schemaText), getJsonNode(jsonText), namespace);
-  }
+   public static List<String> validateJson(String schemaText, String jsonText, String namespace) throws IOException {
+      return validateJson(getJsonNode(schemaText), getJsonNode(jsonText), namespace);
+   }
 
-  public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode) {
-    return validateJson(schemaNode, jsonNode, null);
-  }
+   public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode) {
+      return validateJson(schemaNode, jsonNode, null);
+   }
 
-  public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace) {
-    List<String> errors = new ArrayList<>();
+   public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace) {
+      List<String> errors = new ArrayList<>();
 
-    final JsonSchema jsonSchemaNode = extractJsonSchemaNode(schemaNode, namespace);
+      final JsonSchema jsonSchemaNode = extractJsonSchemaNode(schemaNode, namespace);
 
-    Set<ValidationMessage> messages = jsonSchemaNode.validate(schemaNode);
+      Set<ValidationMessage> messages = jsonSchemaNode.validate(jsonNode, executionContext -> {
+         executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
+         executionContext.getExecutionConfig().setLocale(Locale.US);
+      });
 
-    if(!messages.isEmpty()) {
-      for (ValidationMessage message : messages) {
-        errors.add(message.toString());
+      if (!messages.isEmpty()) {
+         for (ValidationMessage message : messages) {
+            errors.add(message.getError());
+         }
       }
-    }
+      return errors;
+   }cl
 
-    // Ask for a deep check to get a full error report.
-//    ProcessingReport report = jsonSchemaNode.validate(jsonNode, true);
-//    if (!report.isSuccess()) {
-//      for (ProcessingMessage processingMessage : report) {
-//        errors.add(processingMessage.getMessage());
-//      }
-//    }
-    return errors;
-  }
+   public static JsonNode getJsonNode(String jsonText) throws IOException {
+      return mapper.readTree(jsonText);
+   }
 
-  public static JsonNode getJsonNode(String jsonText) throws IOException {
-    return JsonLoader.fromString(jsonText);
-  }
+   public static com.networknt.schema.JsonSchema getSchemaNode(String schemaText) throws IOException {
+      final JsonNode schemaNode = getJsonNode(schemaText);
+      return extractJsonSchemaNode(schemaNode, null);
+   }
 
-  public static com.networknt.schema.JsonSchema getSchemaNode(String schemaText) throws IOException{
-    final JsonNode schemaNode = getJsonNode(schemaText);
-    return extractJsonSchemaNode(schemaNode, null);
-  }
-
-  private static com.networknt.schema.JsonSchema extractJsonSchemaNode(JsonNode jsonNode, String namespace){
-    final JsonNode schemaIdentifier = jsonNode.get(JSON_SCHEMA_IDENTIFIER_ELEMENT);
-    if (schemaIdentifier == null) {
-      ((ObjectNode) jsonNode).put(JSON_SCHEMA_IDENTIFIER_ELEMENT, JSON_V7_SCHEMA_IDENTIFIER);
-    }
-    final com.networknt.schema.JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
-    return schemaFactory.getSchema(jsonNode);
-//    if (namespace != null) {
-//      log.debug("Setting namespace to {} in Json schema loading configuration", namespace);
-//      // Set up a loading configuration for provided namespace.
-//      final LoadingConfiguration cfg = LoadingConfiguration.newBuilder()
-//        .setURITranslatorConfiguration(URITranslatorConfiguration.newBuilder().setNamespace(namespace).freeze())
-//        .freeze();
-//      factory = JsonSchemaFactory.newBuilder().setLoadingConfiguration(cfg).freeze();
-//    } else {
-//      factory = JsonSchemaFactory.byDefault();
-//    }
-
-//    return factory.getJsonSchema(jsonNode);
-  }
+   private static com.networknt.schema.JsonSchema extractJsonSchemaNode(JsonNode jsonNode, String namespace) {
+      JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+      return jsonSchemaFactory.getSchema(jsonNode);
+   }
 }

--- a/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidatorNetworknt.java
+++ b/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidatorNetworknt.java
@@ -89,7 +89,7 @@ public class JsonSchemaValidatorNetworknt {
          }
       }
       return errors;
-   }cl
+   }
 
    public static JsonNode getJsonNode(String jsonText) throws IOException {
       return mapper.readTree(jsonText);

--- a/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidatorNetworknt.java
+++ b/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidatorNetworknt.java
@@ -1,0 +1,119 @@
+package io.github.microcks.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.fge.jackson.JsonLoader;
+import com.networknt.schema.*;
+import com.networknt.schema.serialization.DefaultJsonNodeReader;
+import com.networknt.schema.serialization.node.JsonNodeFactoryFactory;
+import com.networknt.schema.utils.JsonNodeUtil;
+import com.networknt.schema.utils.JsonNodes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class JsonSchemaValidatorNetworknt {
+
+  /** A commons logger for diagnostic messages. */
+  private static Logger log = LoggerFactory.getLogger(JsonSchemaValidator.class);
+
+  public static final String JSON_V4_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-04/schema#";
+  public static final String JSON_V7_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-07/schema#";
+  public static final String JSON_V12_SCHEMA_IDENTIFIER = "http://json-schema.org/draft/2020-12/schema#";
+  public static final String JSON_SCHEMA_IDENTIFIER_ELEMENT = "$schema";
+
+  public static final String JSON_SCHEMA_COMPONENTS_ELEMENT = "components";
+  public static final String JSON_SCHEMA_PROPERTIES_ELEMENT = "properties";
+
+  private JsonSchemaValidatorNetworknt(){
+
+  }
+
+  public static boolean isJsonValid(String schemaText, String jsonText) throws IOException {
+    return isJsonValid(schemaText, jsonText, null);
+  }
+
+  public static boolean isJsonValid(String schemaText, String jsonText, String namespace) throws IOException {
+    try {
+      List<String> errors = validateJson(schemaText, jsonText, namespace);
+      if (!errors.isEmpty()) {
+        log.debug("Get validation errors, returning false");
+        return false;
+      }
+    } catch (Exception pe) {
+      log.debug("Got processing exception while extracting schema, returning false");
+      return false;
+    }
+    return true;
+  }
+
+  public static List<String> validateJson(String schemaText, String jsonText) throws IOException {
+    return validateJson(getJsonNode(schemaText), getJsonNode(jsonText), null);
+  }
+
+  public static List<String> validateJson(String schemaText, String jsonText, String namespace)
+    throws IOException {
+    return validateJson(getJsonNode(schemaText), getJsonNode(jsonText), namespace);
+  }
+
+  public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode) {
+    return validateJson(schemaNode, jsonNode, null);
+  }
+
+  public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace) {
+    List<String> errors = new ArrayList<>();
+
+    final JsonSchema jsonSchemaNode = extractJsonSchemaNode(schemaNode, namespace);
+
+    Set<ValidationMessage> messages = jsonSchemaNode.validate(schemaNode);
+
+    if(!messages.isEmpty()) {
+      for (ValidationMessage message : messages) {
+        errors.add(message.toString());
+      }
+    }
+
+    // Ask for a deep check to get a full error report.
+//    ProcessingReport report = jsonSchemaNode.validate(jsonNode, true);
+//    if (!report.isSuccess()) {
+//      for (ProcessingMessage processingMessage : report) {
+//        errors.add(processingMessage.getMessage());
+//      }
+//    }
+    return errors;
+  }
+
+  public static JsonNode getJsonNode(String jsonText) throws IOException {
+    return JsonLoader.fromString(jsonText);
+  }
+
+  public static com.networknt.schema.JsonSchema getSchemaNode(String schemaText) throws IOException{
+    final JsonNode schemaNode = getJsonNode(schemaText);
+    return extractJsonSchemaNode(schemaNode, null);
+  }
+
+  private static com.networknt.schema.JsonSchema extractJsonSchemaNode(JsonNode jsonNode, String namespace){
+    final JsonNode schemaIdentifier = jsonNode.get(JSON_SCHEMA_IDENTIFIER_ELEMENT);
+    if (schemaIdentifier == null) {
+      ((ObjectNode) jsonNode).put(JSON_SCHEMA_IDENTIFIER_ELEMENT, JSON_V7_SCHEMA_IDENTIFIER);
+    }
+    final com.networknt.schema.JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+    return schemaFactory.getSchema(jsonNode);
+//    if (namespace != null) {
+//      log.debug("Setting namespace to {} in Json schema loading configuration", namespace);
+//      // Set up a loading configuration for provided namespace.
+//      final LoadingConfiguration cfg = LoadingConfiguration.newBuilder()
+//        .setURITranslatorConfiguration(URITranslatorConfiguration.newBuilder().setNamespace(namespace).freeze())
+//        .freeze();
+//      factory = JsonSchemaFactory.newBuilder().setLoadingConfiguration(cfg).freeze();
+//    } else {
+//      factory = JsonSchemaFactory.byDefault();
+//    }
+
+//    return factory.getJsonSchema(jsonNode);
+  }
+}

--- a/commons/util/src/main/java/io/github/microcks/util/asyncapi/AsyncAPISchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/asyncapi/AsyncAPISchemaValidator.java
@@ -16,7 +16,7 @@
 package io.github.microcks.util.asyncapi;
 
 import io.github.microcks.util.AvroUtil;
-import io.github.microcks.util.JsonSchemaValidator;
+import io.github.microcks.util.JsonSchemaValidatorNetworknt;
 import io.github.microcks.util.SchemaMap;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
@@ -39,7 +38,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static io.github.microcks.util.JsonSchemaValidator.*;
+//import static io.github.microcks.util.JsonSchemaValidator.*;
+import static io.github.microcks.util.JsonSchemaValidatorNetworknt.*;
 import static io.github.microcks.util.asyncapi.AsyncAPISchemaUtil.*;
 
 /**
@@ -93,7 +93,7 @@ public class AsyncAPISchemaValidator {
     * @throws IOException if json string representations cannot be parsed
     */
    public static List<String> validateJson(String schemaText, String jsonText) throws IOException {
-      return validateJson(getJsonNodeForSchema(schemaText), JsonSchemaValidator.getJsonNode(jsonText));
+      return validateJson(getJsonNodeForSchema(schemaText), JsonSchemaValidatorNetworknt.getJsonNode(jsonText));
    }
 
    /**
@@ -124,15 +124,7 @@ public class AsyncAPISchemaValidator {
    public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace) {
       schemaNode = convertAsyncAPISchemaToJsonSchema(schemaNode);
 
-      try {
-         return JsonSchemaValidator.validateJson(schemaNode, jsonNode, namespace);
-      } catch (ProcessingException e) {
-         log.debug("Got a ProcessingException while trying to interpret schemaNode as a real schema");
-         List<String> errors = new ArrayList<>();
-         errors.add("schemaNode does not seem to represent a valid AsyncAPI schema");
-         errors.add("root cause: " + e.getMessage());
-         return errors;
-      }
+      return JsonSchemaValidatorNetworknt.validateJson(schemaNode, jsonNode, namespace);
    }
 
    /**
@@ -280,7 +272,7 @@ public class AsyncAPISchemaValidator {
     * @throws IOException if json string representation cannot be parsed
     */
    public static JsonNode getJsonNode(String jsonText) throws IOException {
-      return JsonSchemaValidator.getJsonNode(jsonText);
+      return JsonSchemaValidatorNetworknt.getJsonNode(jsonText);
    }
 
    /**

--- a/commons/util/src/test/java/io/github/microcks/util/JsonSchemaValidatorNetworkntTest.java
+++ b/commons/util/src/test/java/io/github/microcks/util/JsonSchemaValidatorNetworkntTest.java
@@ -1,0 +1,94 @@
+package io.github.microcks.util;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonSchemaValidatorNetworkntTest {
+
+  @Test
+  void testValidateJsonSuccess() {
+    boolean valid = false;
+    String schemaText = null;
+    String jsonText = "{\"name\": \"307\", \"model\": \"Peugeot 307\", \"year\": 2003}";
+
+    try {
+      // Load schema from file.
+      schemaText = FileUtils
+        .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema.json"));
+      // Validate Json according schema.
+      valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
+    } catch (Exception e) {
+      fail("Exception should not be thrown");
+    }
+
+    // Assert Json object is valid.
+    assertTrue(valid);
+  }
+
+  @Test
+  void testValidateJsonFailure() {
+    boolean valid = true;
+    String schemaText = null;
+    String jsonText = "{\"id\": \"307\", \"model\": \"Peugeot 307\", \"year\": 2003}";
+
+    try {
+      // Load schema from file.
+      schemaText = FileUtils
+        .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema.json"));
+      // Validate Json according schema.
+      valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
+    } catch (Exception e) {
+      fail("Exception should not be thrown");
+    }
+
+    // Assert Json object is not valid.
+    assertFalse(valid);
+
+    // Now revalidate and check validation messages.
+    List<String> errors = null;
+    try {
+      errors = JsonSchemaValidatorNetworknt.validateJson(schemaText, jsonText);
+    } catch (Exception e) {
+      fail("Exception should not be thrown");
+    }
+    assertEquals(1, errors.size());
+    assertEquals("object has missing required properties ([\"name\"])", errors.get(0));
+  }
+
+  @Test
+  void testValidateJsonUnknownNodeFailure() {
+    boolean valid = true;
+    String schemaText = null;
+    String jsonText = "{\"name\": \"307\", " + "\"model\": \"Peugeot 307\", \"year\": 2003, \"energy\": \"GO\"}";
+
+    try {
+      // Load schema from file.
+      schemaText = FileUtils
+        .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema-no-addon.json"));
+      // Validate Json according schema.
+      valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
+    } catch (Exception e) {
+      fail("Exception should not be thrown");
+    }
+
+    // Assert Json object is not valid.
+    assertFalse(valid);
+
+    // Now revalidate and check validation messages.
+    List<String> errors = null;
+    try {
+      errors = JsonSchemaValidatorNetworknt.validateJson(schemaText, jsonText);
+    } catch (Exception e) {
+      fail("Exception should not be thrown");
+    }
+    assertEquals(1, errors.size());
+    assertEquals("object instance has properties which are not allowed by the schema: [\"energy\"]", errors.get(0));
+  }
+
+}

--- a/commons/util/src/test/java/io/github/microcks/util/JsonSchemaValidatorNetworkntTest.java
+++ b/commons/util/src/test/java/io/github/microcks/util/JsonSchemaValidatorNetworkntTest.java
@@ -11,84 +11,85 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JsonSchemaValidatorNetworkntTest {
 
-  @Test
-  void testValidateJsonSuccess() {
-    boolean valid = false;
-    String schemaText = null;
-    String jsonText = "{\"name\": \"307\", \"model\": \"Peugeot 307\", \"year\": 2003}";
+   @Test
+   void testValidateJsonSuccess() {
+      boolean valid = false;
+      String schemaText = null;
+      String jsonText = "{\"name\": \"307\", \"model\": \"Peugeot 307\", \"year\": 2003}";
 
-    try {
-      // Load schema from file.
-      schemaText = FileUtils
-        .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema.json"));
-      // Validate Json according schema.
-      valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
-    } catch (Exception e) {
-      fail("Exception should not be thrown");
-    }
+      try {
+         // Load schema from file.
+         schemaText = FileUtils
+               .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema.json"));
+         // Validate Json according schema.
+         valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
+      } catch (Exception e) {
+         fail("Exception should not be thrown");
+      }
 
-    // Assert Json object is valid.
-    assertTrue(valid);
-  }
+      // Assert Json object is valid.
+      assertTrue(valid);
+   }
 
-  @Test
-  void testValidateJsonFailure() {
-    boolean valid = true;
-    String schemaText = null;
-    String jsonText = "{\"id\": \"307\", \"model\": \"Peugeot 307\", \"year\": 2003}";
+   @Test
+   void testValidateJsonFailure() {
+      boolean valid = true;
+      String schemaText = null;
+      String jsonText = "{\"id\": \"307\", \"model\": \"Peugeot 307\", \"year\": 2003}";
 
-    try {
-      // Load schema from file.
-      schemaText = FileUtils
-        .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema.json"));
-      // Validate Json according schema.
-      valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
-    } catch (Exception e) {
-      fail("Exception should not be thrown");
-    }
+      try {
+         // Load schema from file.
+         schemaText = FileUtils
+               .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema.json"));
+         // Validate Json according schema.
+         valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
+      } catch (Exception e) {
+         fail("Exception should not be thrown");
+      }
 
-    // Assert Json object is not valid.
-    assertFalse(valid);
+      // Assert Json object is not valid.
+      assertFalse(valid);
 
-    // Now revalidate and check validation messages.
-    List<String> errors = null;
-    try {
-      errors = JsonSchemaValidatorNetworknt.validateJson(schemaText, jsonText);
-    } catch (Exception e) {
-      fail("Exception should not be thrown");
-    }
-    assertEquals(1, errors.size());
-    assertEquals("object has missing required properties ([\"name\"])", errors.get(0));
-  }
+      // Now revalidate and check validation messages.
+      List<String> errors = null;
+      try {
+         errors = JsonSchemaValidatorNetworknt.validateJson(schemaText, jsonText);
+      } catch (Exception e) {
+         fail("Exception should not be thrown");
+      }
+      assertEquals(1, errors.size());
+      assertEquals("required property 'name' not found", errors.get(0));
+   }
 
-  @Test
-  void testValidateJsonUnknownNodeFailure() {
-    boolean valid = true;
-    String schemaText = null;
-    String jsonText = "{\"name\": \"307\", " + "\"model\": \"Peugeot 307\", \"year\": 2003, \"energy\": \"GO\"}";
+   @Test
+   void testValidateJsonUnknownNodeFailure() {
+      boolean valid = true;
+      String schemaText = null;
+      String jsonText = "{\"name\": \"307\", " + "\"model\": \"Peugeot 307\", \"year\": 2003, \"energy\": \"GO\"}";
 
-    try {
-      // Load schema from file.
-      schemaText = FileUtils
-        .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema-no-addon.json"));
-      // Validate Json according schema.
-      valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
-    } catch (Exception e) {
-      fail("Exception should not be thrown");
-    }
+      try {
+         // Load schema from file.
+         schemaText = FileUtils
+               .readFileToString(new File("target/test-classes/io/github/microcks/util/car-schema-no-addon.json"));
+         // Validate Json according schema.
+         valid = JsonSchemaValidatorNetworknt.isJsonValid(schemaText, jsonText);
+      } catch (Exception e) {
+         fail("Exception should not be thrown");
+      }
 
-    // Assert Json object is not valid.
-    assertFalse(valid);
+      // Assert Json object is not valid.
+      assertFalse(valid);
 
-    // Now revalidate and check validation messages.
-    List<String> errors = null;
-    try {
-      errors = JsonSchemaValidatorNetworknt.validateJson(schemaText, jsonText);
-    } catch (Exception e) {
-      fail("Exception should not be thrown");
-    }
-    assertEquals(1, errors.size());
-    assertEquals("object instance has properties which are not allowed by the schema: [\"energy\"]", errors.get(0));
-  }
+      // Now revalidate and check validation messages.
+      List<String> errors = null;
+      try {
+         errors = JsonSchemaValidatorNetworknt.validateJson(schemaText, jsonText);
+      } catch (Exception e) {
+         fail("Exception should not be thrown");
+      }
+      assertEquals(1, errors.size());
+      assertEquals("property 'energy' is not defined in the schema and the schema does not allow additional properties",
+            errors.get(0));
+   }
 
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR adds code to migrate from `java-json-tools/json-schema-validator` to`networknt/json-schema-validator`

### Related issue(s)
Fixes #1396 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->