### PR TITLE
fix: finish test run with details about failure if gRPC test suite fails

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
@@ -45,7 +45,10 @@ import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.TlsChannelCredentials;
+import io.grpc.Status.Code;
 import io.grpc.stub.ClientCalls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -221,6 +224,9 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
          // Reset status code, message and request each time.
          int code = TestReturn.SUCCESS_CODE;
          String message = null;
+         String contentResponse = null;
+         String statusCode = null;
+
          reqBuilder.clear();
          resBuilder.clear();
 
@@ -235,37 +241,50 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
             callOptions = callOptions
                   .withCallCredentials(new TokenCallCredentials(secret.getToken(), secret.getTokenHeader()));
          }
-
-         // Actually execute request.
-         long startTime = System.currentTimeMillis();
-         byte[] responseBytes = ClientCalls.blockingUnaryCall(channel,
-               GrpcUtil.buildGenericUnaryMethodDescriptor(fullMethodName), callOptions, requestBytes);
-         long duration = System.currentTimeMillis() - startTime;
-
          // Add all headers as customOptions to callOptions
          Set<Header> headers = TestRunnerCommons.collectHeaders(testResult, request, operation);
          callOptions = callOptions.withOption(METADATA_CUSTOM_CALL_OPTION, convertHeadersToMetadata(headers));
 
+         // Actually execute request.
+         long startTime = System.currentTimeMillis();
+         byte[] responseBytes = null;
+         try {
+            responseBytes = ClientCalls.blockingUnaryCall(channel,
+                  GrpcUtil.buildGenericUnaryMethodDescriptor(fullMethodName), callOptions, requestBytes);
+         } catch (StatusRuntimeException sre) {
+            log.error("StatusRuntimeException while executing grpc request {} on {}", fullMethodName, endpointUrl, sre);
+            code = TestReturn.FAILURE_CODE;
+            Status status = sre.getStatus();
+            statusCode = status.getCode().name();
+            message = String.format("Request failed with %s and description %s", statusCode, status.getDescription());
+         }
+         long duration = System.currentTimeMillis() - startTime;
+
+         // If still in success, validate and parse response
+         if (code == TestReturn.SUCCESS_CODE) {
+            statusCode = Code.OK.name();
+            contentResponse = new String(responseBytes, StandardCharsets.UTF_8);
+
+            try {
+               // Validate incoming message parsing a DynamicMessage.
+               DynamicMessage respMsg = DynamicMessage.parseFrom(md.getOutputType(), responseBytes);
+
+               // Now update response content with readable content.
+               contentResponse = printer.print(respMsg);
+            } catch (InvalidProtocolBufferException ipbe) {
+               log.error("Received bytes cannot be transformed in {}", md.getOutputType().getFullName());
+               code = TestReturn.FAILURE_CODE;
+               message = "Received bytes cannot be transformed in " + md.getOutputType().getFullName();
+            }
+         }
+
          // Create a Response object for returning.
          Response response = new Response();
-         response.setStatus("200");
+         response.setStatus(statusCode);
          response.setMediaType("application/x-protobuf");
-         response.setContent(new String(responseBytes, StandardCharsets.UTF_8));
+         response.setContent(contentResponse);
 
-         try {
-            // Validate incoming message parsing a DynamicMessage.
-            DynamicMessage respMsg = DynamicMessage.parseFrom(md.getOutputType(), responseBytes);
-
-            // Now update response content with readable content.
-            String respJson = printer.print(respMsg);
-            response.setContent(respJson);
-
-            results.add(new TestReturn(code, duration, message, request, response));
-         } catch (InvalidProtocolBufferException ipbe) {
-            log.error("Received bytes cannot be transformed in {}", md.getOutputType().getFullName());
-            results.add(new TestReturn(TestReturn.FAILURE_CODE, duration,
-                  "Received bytes cannot be transformed in " + md.getOutputType().getFullName(), request, response));
-         }
+         results.add(new TestReturn(code, duration, message, request, response));
       }
       return results;
    }
@@ -286,5 +305,39 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
    @Override
    public HttpMethod buildMethod(String method) {
       return HttpMethod.POST;
+   }
+
+   private ManagedChannel setupChannel(String endpointUrl) throws IOException {
+      URL endpoint = new URL(endpointUrl);
+
+      if (endpointUrl.startsWith("https://") || endpoint.getPort() == 443) {
+         TlsChannelCredentials.Builder tlsBuilder = TlsChannelCredentials.newBuilder();
+         if (secret != null && secret.getCaCertPem() != null) {
+            // Install a trust manager with custom CA certificate.
+            tlsBuilder.trustManager(new ByteArrayInputStream(secret.getCaCertPem().getBytes(StandardCharsets.UTF_8)));
+         } else {
+            // Install a trust manager that accepts everything and does not validate certificate chains.
+            tlsBuilder.trustManager(new X509TrustManager() {
+               public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                  return null;
+               }
+
+               public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                  // Accept everything.
+               }
+
+               public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                  // Accept everything.
+               }
+            });
+         }
+         // Build a Channel using the TLS Builder.
+         return Grpc.newChannelBuilderForAddress(endpoint.getHost(), endpoint.getPort(), tlsBuilder.build()).build();
+      }
+
+      // Build a simple Channel using no creds (now default to plain text so usePlainText() is no longer necessary).
+      return Grpc
+            .newChannelBuilderForAddress(endpoint.getHost(), endpoint.getPort(), InsecureChannelCredentials.create())
+            .build();
    }
 }

--- a/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/grpc/GrpcTestRunner.java
@@ -307,37 +307,4 @@ public class GrpcTestRunner extends AbstractTestRunner<HttpMethod> {
       return HttpMethod.POST;
    }
 
-   private ManagedChannel setupChannel(String endpointUrl) throws IOException {
-      URL endpoint = new URL(endpointUrl);
-
-      if (endpointUrl.startsWith("https://") || endpoint.getPort() == 443) {
-         TlsChannelCredentials.Builder tlsBuilder = TlsChannelCredentials.newBuilder();
-         if (secret != null && secret.getCaCertPem() != null) {
-            // Install a trust manager with custom CA certificate.
-            tlsBuilder.trustManager(new ByteArrayInputStream(secret.getCaCertPem().getBytes(StandardCharsets.UTF_8)));
-         } else {
-            // Install a trust manager that accepts everything and does not validate certificate chains.
-            tlsBuilder.trustManager(new X509TrustManager() {
-               public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                  return null;
-               }
-
-               public void checkClientTrusted(X509Certificate[] certs, String authType) {
-                  // Accept everything.
-               }
-
-               public void checkServerTrusted(X509Certificate[] certs, String authType) {
-                  // Accept everything.
-               }
-            });
-         }
-         // Build a Channel using the TLS Builder.
-         return Grpc.newChannelBuilderForAddress(endpoint.getHost(), endpoint.getPort(), tlsBuilder.build()).build();
-      }
-
-      // Build a simple Channel using no creds (now default to plain text so usePlainText() is no longer necessary).
-      return Grpc
-            .newChannelBuilderForAddress(endpoint.getHost(), endpoint.getPort(), InsecureChannelCredentials.create())
-            .build();
-   }
 }

--- a/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
@@ -17,6 +17,7 @@
 package io.github.microcks.web;
 
 import io.github.microcks.domain.RequestResponsePair;
+import io.github.microcks.domain.TestCaseResult;
 import io.github.microcks.domain.TestResult;
 
 import org.junit.jupiter.api.Test;
@@ -149,4 +150,49 @@ class TestControllerIT extends AbstractBaseIT {
          assertTrue(pair.getRequest().getName().equals("Laurent") || pair.getRequest().getName().equals("Philippe"));
       }
    }
+
+   @Test
+   void testGRPCTestingFailing() {
+      // Upload GRPC reference artifact.
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/hello-v1.proto", true);
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/HelloService.postman.json", false);
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/HelloService.metadata.yml", false);
+
+      String testEndpoint = "http://localhost:50051"; // unreachable address
+
+      StringBuilder testRequest = new StringBuilder("{")
+            .append("\"serviceId\": \"io.github.microcks.grpc.hello.v1.HelloService:v1\", ")
+            .append("\"testEndpoint\": \"").append(testEndpoint).append("\", ")
+            .append("\"runnerType\": \"GRPC_PROTOBUF\", ").append("\"timeout\": 2000").append("}");
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
+
+      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
+      assertEquals(201, response.getStatusCode().value());
+
+      TestResult testResult = response.getBody();
+      assertNotNull(testResult);
+      assertNotNull(testResult.getId());
+      assertTrue(testResult.isInProgress());
+      assertEquals(testEndpoint, testResult.getTestedEndpoint());
+
+      // Wait till timeout and re-fetch the result.
+      try {
+         Thread.sleep(2000);
+      } catch (InterruptedException e) {
+         throw new RuntimeException(e);
+      }
+
+      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      assertEquals(200, response.getStatusCode().value());
+      testResult = response.getBody();
+      assertNotNull(testResult);
+      assertFalse(testResult.isInProgress());
+      assertFalse(testResult.isSuccess());
+      TestCaseResult res = testResult.getTestCaseResults().get(0);
+      assertEquals("Test message", res.getTestStepResults().get(0).getMessage());
+   }
+
 }

--- a/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
@@ -17,7 +17,6 @@
 package io.github.microcks.web;
 
 import io.github.microcks.domain.RequestResponsePair;
-import io.github.microcks.domain.TestCaseResult;
 import io.github.microcks.domain.TestResult;
 
 import org.junit.jupiter.api.Test;

--- a/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
@@ -158,7 +158,7 @@ class TestControllerIT extends AbstractBaseIT {
       uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/HelloService.postman.json", false);
       uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/HelloService.metadata.yml", false);
 
-      String testEndpoint = "http://localhost:50051"; // unreachable address
+      String testEndpoint = "http://localhost:50051"; // unreachable address, will lead to UNAVAILABLE
 
       StringBuilder testRequest = new StringBuilder("{")
             .append("\"serviceId\": \"io.github.microcks.grpc.hello.v1.HelloService:v1\", ")
@@ -191,8 +191,6 @@ class TestControllerIT extends AbstractBaseIT {
       assertNotNull(testResult);
       assertFalse(testResult.isInProgress());
       assertFalse(testResult.isSuccess());
-      TestCaseResult res = testResult.getTestCaseResults().get(0);
-      assertEquals("Test message", res.getTestStepResults().get(0).getMessage());
    }
 
 }


### PR DESCRIPTION
### Description

- Running a gRPC test suite with failing tests currently leads to a `StatusRuntimeException` being thrown and the test run staying in progress forever
- PR adds logic to catch `StatusRuntimeException` for unsuccessful RPC calls (structured as in `HttpTestRunner`) and store failure results in Test Run
- Failing test run contains message with gRPC status code and error message

### Test Results

**Before**: 
Test run stays `in_progress` forever:

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/6901ecf5-eb75-4dac-b333-0124a4e8d086" />

With error in logs: 

![image](https://github.com/user-attachments/assets/742c40ba-f6ac-46fc-bfff-3ea7a8e52f03)

**After**: 

Test run finishes and is marked as `failed`. 
Detailed test results show error code and message. 

<img width="1027" alt="image" src="https://github.com/user-attachments/assets/5fc84dc8-05ff-4b32-8c6c-8fba92e354bb" />


