### PR TITLE
chore: #1481 Use await() instead of Thread.sleep() in TestControllerIT

### DIFF
--- a/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
@@ -30,8 +30,10 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 /**
  * Test case for the Test controller.
@@ -76,11 +78,7 @@ class TestControllerIT extends AbstractBaseIT {
       assertEquals(testEndpoint, testResult.getTestedEndpoint());
 
       // Wait till timeout and re-fetch the result.
-      try {
-         Thread.sleep(2000);
-      } catch (InterruptedException e) {
-         throw new RuntimeException(e);
-      }
+      await().during(2000, TimeUnit.MILLISECONDS).until(() -> true);
 
       response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
       assertEquals(200, response.getStatusCode().value());
@@ -126,11 +124,7 @@ class TestControllerIT extends AbstractBaseIT {
       assertEquals(testEndpoint, testResult.getTestedEndpoint());
 
       // Wait till timeout and re-fetch the result.
-      try {
-         Thread.sleep(2000);
-      } catch (InterruptedException e) {
-         throw new RuntimeException(e);
-      }
+      await().during(2000, TimeUnit.MILLISECONDS).until(() -> true);
 
       response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
       assertEquals(200, response.getStatusCode().value());
@@ -178,11 +172,7 @@ class TestControllerIT extends AbstractBaseIT {
       assertEquals(testEndpoint, testResult.getTestedEndpoint());
 
       // Wait till timeout and re-fetch the result.
-      try {
-         Thread.sleep(2000);
-      } catch (InterruptedException e) {
-         throw new RuntimeException(e);
-      }
+      await().during(2000, TimeUnit.MILLISECONDS).until(() -> true);
 
       response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
       assertEquals(200, response.getStatusCode().value());


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- This PR removes the usage of `Thread.sleep()` in `TestControllerIT` and replaces it with `await()`, as suggested by Sonar.

### Related issue(s)
Fixes #1481 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->