### PR TITLE
refactor: run setTimeout and setInterval outside Angular

### DIFF
--- a/webapp/src/main/webapp/src/app/pages/importers/importers.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/importers/importers.page.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangeDetectorRef, Component, OnInit, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit, TemplateRef, ViewChild, ViewEncapsulation, NgZone } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
@@ -55,7 +55,8 @@ export class ImportersPageComponent implements OnInit {
   constructor(private importersSvc: ImportersService, private servicesSvc: ServicesService,
               private modalService: BsModalService, private notificationService: NotificationService,
               protected authService: IAuthenticationService, private config: ConfigService,
-              private route: ActivatedRoute, private router: Router, private ref: ChangeDetectorRef) { }
+              private route: ActivatedRoute, private router: Router, private ref: ChangeDetectorRef,
+              private ngZone: NgZone) { }
 
   ngOnInit() {
     this.notifications = this.notificationService.getNotifications();
@@ -302,10 +303,11 @@ export class ImportersPageComponent implements OnInit {
           this.notificationService.message(NotificationType.SUCCESS,
               job.name, 'Import job has been forced', false, null, null);
           console.log('ImportJobs in 2 secs');
-          // TODO run this outsize NgZone using zone.runOutsideAngular() : https://angular.io/api/core/NgZone
-          setTimeout(() => {
-            this.getImportJobs();
-          }, 2000);
+          this.ngZone.runOutsideAngular(() => {
+            setTimeout(() => {
+              this.getImportJobs();
+            }, 2000);
+          });
         },
         error: err => {
           this.notificationService.message(NotificationType.DANGER,

--- a/webapp/src/main/webapp/src/app/services/auth-keycloak.service.ts
+++ b/webapp/src/main/webapp/src/app/services/auth-keycloak.service.ts
@@ -18,6 +18,7 @@ import { Observable, BehaviorSubject } from 'rxjs';
 import { User } from '../models/user.model';
 import { ConfigService } from './config.service';
 import { HttpClient } from '@angular/common/http';
+import { NgZone } from '@angular/core';
 
 /**
  * A version of the authentication service that uses keycloak.js to provide
@@ -36,7 +37,7 @@ export class KeycloakAuthenticationService extends IAuthenticationService {
   /**
    * Constructor.
    */
-  constructor(private http: HttpClient, private config: ConfigService) {
+  constructor(private http: HttpClient, private config: ConfigService, private ngZone: NgZone) {
     super();
     const w: any = window;
     this.keycloak = w.keycloak;
@@ -54,10 +55,11 @@ export class KeycloakAuthenticationService extends IAuthenticationService {
     this.authenticatedUser.next(user);
 
     // Periodically refresh
-    // TODO run this outsize NgZone using zone.runOutsideAngular() : https://angular.io/api/core/NgZone
-    setInterval(() => {
-      this.keycloak.updateToken(30);
-    }, 30000);
+    this.ngZone.runOutsideAngular(() => {
+      setInterval(() => {
+        this.keycloak.updateToken(30);
+      }, 30000);
+    });
   }
 
   /**

--- a/webapp/src/main/webapp/src/app/services/auth.service.provider.ts
+++ b/webapp/src/main/webapp/src/app/services/auth.service.provider.ts
@@ -18,13 +18,14 @@ import { ConfigService } from './config.service';
 import { KeycloakAuthenticationService } from './auth-keycloak.service';
 import { AnonymousAuthenticationService } from './auth-anonymous.service';
 import { HttpClient } from '@angular/common/http';
+import { NgZone } from '@angular/core';
 
 
-export function AuthenticationServiceFactory(http: HttpClient, config: ConfigService): IAuthenticationService {
+export function AuthenticationServiceFactory(http: HttpClient, config: ConfigService, ngZone: NgZone): IAuthenticationService {
   console.info('[AuthenticationServiceFactory] Creating AuthenticationService...');
   if (config.authType() === 'keycloakjs') {
     console.info('[AuthenticationServiceFactory] Creating keycloak.js auth service.');
-    return new KeycloakAuthenticationService(http, config);
+    return new KeycloakAuthenticationService(http, config, ngZone);
   } else if (config.authType() === 'anonymous') {
     console.info('[AuthenticationServiceFactory] Creating Anonymous auth service.');
     return new AnonymousAuthenticationService(http, config);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Use the NgZone API to run setTimeout and setInterval outside Angular.
- Angular's change detection is not triggered for the affected code, improving performance.