### PR TITLE
fix(search_field): fix the dropdown bug when no domain mention in entries

### DIFF
--- a/webapp/src/main/webapp/src/app/pages/services/services.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/services/services.page.ts
@@ -227,7 +227,13 @@ export class ServicesPageComponent implements OnInit {
           (label: any) => queries.push({ id: label, value: label })
         );
       }
-      this.filterConfig.fields[0].queries = queries as FilterQuery[];
+      if (queries.length === 0) {
+        this.filterConfig.fields = this.filterConfig.fields.filter(
+          (field) => field.id === 'name'
+        );
+      } else {
+        this.filterConfig.fields[0].queries = queries as FilterQuery[];
+      } 
     });
   }
 


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Fixed the bug where the dropdown was showing "For Domain" even when no domain was mentioned in the entries.
- The UI now correctly hides the "For Domain" label and the dropdown when no domain is provided.
- Ensures a cleaner and more intuitive user experience.

### Related issue(s)
![Screenshot from 2025-04-17 16-00-03](https://github.com/user-attachments/assets/705b1584-58cd-4607-b580-97f45e1c14c9)
![Screenshot from 2025-04-17 16-00-34](https://github.com/user-attachments/assets/4c98b983-0f9a-48d3-91ac-7fa2559ad440)



### Note

-  There is an option to set the "status" field, but it does not appear in the search field.  
  Not sure if this is a bug or if search by status is intentionally excluded.



Fixes #1573

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->