### PR TITLE
fix: ui alignment for dropdown

### DIFF
--- a/webapp/src/main/webapp/src/lib/patternfly-ng.css
+++ b/webapp/src/main/webapp/src/lib/patternfly-ng.css
@@ -787,9 +787,6 @@
   margin-right: 5px;
 }
 /* stylelint-disable */
-.input-group-btn{
-  display: table-cell !important;
-}
 .input-group .input-group-btn .dropdown-menu > .selected > a {
   background-color: #0088ce !important;
   border-color: #0088ce !important;

--- a/webapp/src/main/webapp/src/lib/patternfly-ng.css
+++ b/webapp/src/main/webapp/src/lib/patternfly-ng.css
@@ -787,6 +787,9 @@
   margin-right: 5px;
 }
 /* stylelint-disable */
+.input-group-btn{
+  display: table-cell !important;
+}
 .input-group .input-group-btn .dropdown-menu > .selected > a {
   background-color: #0088ce !important;
   border-color: #0088ce !important;

--- a/webapp/src/main/webapp/src/styles.css
+++ b/webapp/src/main/webapp/src/styles.css
@@ -302,6 +302,10 @@ pre.hljs {
   padding-right: 10px !important;
 }
 
+.input-group-btn{
+  display: table-cell !important;
+}
+
 /* Angular material icons for the stepper */
 @font-face {
   font-family: 'Material Icons';
@@ -358,3 +362,4 @@ pre.hljs {
   font-family: "Open Sans", Helvetica, Arial, sans-serif;
   font-size: 16px;
 }
+


### PR DESCRIPTION
This PR resolves the UI misalignment issue caused by the unnecessary addition of the `show` class when the dropdown is opened. The `show` class was overriding the default styling (`display: table-cell`) applied to the `.input-group-btn` component, resulting in a broken layout with child elements appearing on multiple lines.


![Screenshot from 2025-04-23 21-02-56](https://github.com/user-attachments/assets/32e1ca81-8a8c-4e9d-a1dc-7260f32390b6)

Issue #1584 
