### PR TITLE
feat: add workflow for testing APIs

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -1,0 +1,215 @@
+name: API Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+jobs:
+  run-api-tests-uber:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        flavor: [uber-native, uber-jvm]
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up dependencies for ${{ matrix.flavor }}
+        run: |
+          case "${{ matrix.flavor }}" in
+            uber-jvm)
+              IMAGE="quay.io/microcks/microcks-uber"
+              TAG="nightly"
+              ;;
+            uber-native)
+              IMAGE="quay.io/microcks/microcks-uber"
+              TAG="nightly-native"
+              ;;
+            *)
+              echo "Unsupported flavor: ${{ matrix.flavor }}"
+              exit 1
+              ;;
+          esac
+          docker run -d \
+            -p 8585:8080 \
+            -p 9090:9090 \
+            --add-host=host.docker.internal:host-gateway \
+            --name microcks \
+            "$IMAGE:$TAG"
+          sleep 30
+
+      - name: Upload API artifacts to Microcks
+        run: |
+          docker run --rm --add-host=host.docker.internal:host-gateway \
+            -v "${{ github.workspace }}/samples:/samples" \
+            -v "${{ github.workspace }}/testsuite:/scripts" \
+            -e BASE_URL="http://host.docker.internal:8585" \
+            -e MICROCKS_TOKEN="microcks" \
+            curlimages/curl:latest sh /scripts/upload-artifacts.sh
+
+      - name: Run API tests for ${{ matrix.flavor }}
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+          HOST: host.docker.internal
+          PORT: 8585
+          GRPC_PORT: 9090
+        run: |
+          docker run --rm --user root \
+            --add-host=host.docker.internal:host-gateway \
+            -e FLAVOR=$FLAVOR \
+            -e HOST=$HOST \
+            -e PORT=$PORT \
+            -e GRPC_PORT=$GRPC_PORT \
+            -v "$PWD:/scripts" \
+            -w /scripts/testsuite \
+            grafana/k6:latest \
+            run --summary-export=summary.json api-tests.js
+
+          failed_checks=$(jq '.metrics.checks.fails' testsuite/summary.json)
+          rm testsuite/summary.json
+          echo "Failed checks: $failed_checks"
+          if [ "$failed_checks" -gt 0 ]; then
+            echo "There are failed checks. Failing the job."
+            exit 1
+          else
+            echo "All checks passed."
+          fi
+
+      - name: Teardown all containers after tests
+        if: always()
+        run: |
+          echo "Cleaning up all Docker containers..."
+          docker stop microcks
+
+  run-api-tests-regular:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        flavor: [regular-auth, regular-noauth]
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install docker-compose
+        run: |
+          sudo apt-get update && sudo apt-get install -y docker-compose
+
+      - name: Set up dependencies for ${{ matrix.flavor }}
+        run: |
+          case "${{ matrix.flavor }}" in
+            regular-auth)
+              echo "[INFO] Installing via compose in default mode"
+              ./testsuite/install-compose.sh --method docker --mode default
+              ;;
+            regular-noauth)
+              echo "[INFO] Installing via compose in devmode"
+              ./testsuite/install-compose.sh --method docker --mode devmode
+              ;;
+            *)
+              echo "Unsupported flavor: ${{ matrix.flavor }}"
+              exit 1
+              ;;
+          esac
+          sleep 30
+
+      - name: Health‑check containers
+        run: |
+          case "${{ matrix.flavor }}" in
+            regular-auth)
+              ./testsuite/check-health.sh --method docker
+              ;;
+            regular-noauth)
+              ./testsuite/check-health.sh --method docker
+              ;;
+            *)
+              echo "Unsupported flavor: ${{ matrix.flavor }}"
+              exit 1
+              ;;
+          esac
+
+      - name: Get Microcks access token
+        if: ${{ matrix.flavor == 'regular-auth' }}
+        env:
+          CLIENT_AUTH: bWljcm9ja3Mtc2VydmljZWFjY291bnQ6YWI1NGQzMjktZTQzNS00MWFlLWE5MDAtZWM2YjNmZTE1YzU0Cg=
+          TOKEN_URL: http://localhost:18080/realms/microcks/protocol/openid-connect/token
+        id: get_token
+        run: |
+          echo "Fetching access token..."
+          TOKEN_RESPONSE=$(curl -s -X POST "$TOKEN_URL" \
+            -H 'Content-Type: application/x-www-form-urlencoded' \
+            -H 'Accept: application/json' \
+            -H "Authorization: Basic $CLIENT_AUTH" \
+            -d 'grant_type=client_credentials' -k)
+
+          echo "Response: $TOKEN_RESPONSE"
+
+          ACCESS_TOKEN=$(echo "$TOKEN_RESPONSE" | jq -r '.access_token')
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" == "null" ]; then
+            echo "ERROR: Failed to get access token"
+            exit 1
+          fi
+
+          # Save as step output
+          echo "token=$ACCESS_TOKEN" >> $GITHUB_OUTPUT
+          # Also export to GitHub environment for use in later steps
+          echo "MICROCKS_TOKEN=$ACCESS_TOKEN" >> $GITHUB_ENV
+
+      - name: Set default Microcks token
+        if: ${{ matrix.flavor == 'regular-noauth' }}
+        run: echo "MICROCKS_TOKEN=whatever" >> $GITHUB_ENV
+
+      - name: Upload API artifacts to Microcks
+        env:
+          BASE_URL: http://host.docker.internal:8080
+        run: |
+          docker run --rm --add-host=host.docker.internal:host-gateway \
+            -v "${{ github.workspace }}/samples:/samples" \
+            -v "${{ github.workspace }}/testsuite:/scripts" \
+            -e BASE_URL="${BASE_URL}" \
+            -e MICROCKS_TOKEN="${MICROCKS_TOKEN}" \
+            curlimages/curl:latest sh /scripts/upload-artifacts.sh
+
+      - name: Run API tests for ${{ matrix.flavor }}
+        env:
+          FLAVOR: ${{ matrix.flavor }}
+          HOST: host.docker.internal
+          PORT: 8080
+          GRPC_PORT: 9090
+          KEYCLOAK_URL: http://host.docker.internal:18080
+        run: |
+          docker run --rm --user root \
+            --add-host=host.docker.internal:host-gateway \
+            -e FLAVOR=$FLAVOR \
+            -e HOST=$HOST \
+            -e PORT=$PORT \
+            -e KEYCLOAK_URL=$KEYCLOAK_URL \
+            -e GRPC_PORT=$GRPC_PORT \
+            -v "$PWD:/scripts" \
+            -w /scripts/testsuite \
+            grafana/k6:latest \
+            run --summary-export=summary.json api-tests.js
+
+          failed_checks=$(jq '.metrics.checks.fails' testsuite/summary.json)
+          rm testsuite/summary.json
+          echo "Failed checks: $failed_checks"
+          if [ "$failed_checks" -gt 0 ]; then
+            echo "There are failed checks. Failing the job."
+            exit 1
+          else
+            echo "All checks passed."
+          fi
+
+      - name: Teardown regular install
+        if: always()
+        run: |
+          echo "[INFO] Removing Microcks containers"
+          for c in $(docker ps -aq --filter "name=microcks"); do
+            docker rm -f $c || true
+          done

--- a/install/docker-compose/keycloak-realm/microcks-realm-sample.json
+++ b/install/docker-compose/keycloak-realm/microcks-realm-sample.json
@@ -19,6 +19,14 @@
         "account": [ "manage-account" ],
         "microcks-app": [ "user", "manager", "admin"]
       }
+    },
+    {
+      "username": "service-account-microcks-serviceaccount",
+      "enabled": true,
+      "serviceAccountClientId": "microcks-serviceaccount",
+      "clientRoles": {
+        "microcks-app": ["manager"]
+      }
     }
   ],
   "roles": {

--- a/testsuite/api-tests.js
+++ b/testsuite/api-tests.js
@@ -1,17 +1,22 @@
-import { browse, invokeRESTMocks, invokeGraphQLMocks, invokeSOAPMocks, invokeGRPCMocks, invokeREST_HelloAPIMocks, invokeREST_PetStoreAPI, ownAPIsNoAuth, ownAPIsAuth, asyncAPI_websocketMocks } from './commons.js';
+import * as tests from './commons.js';
+import { flavorConfig } from './flavor-config.js';
 import { sleep } from 'k6';
 
-// The default function runs all tests in sequence
+const FLAVOR = __ENV.FLAVOR || 'regular-auth';
+
 export default function () {
-    invokeRESTMocks();
-    invokeGraphQLMocks();
-    invokeSOAPMocks();
-    browse();
-    invokeGRPCMocks();
-    invokeREST_HelloAPIMocks();
-    invokeREST_PetStoreAPI();
-    ownAPIsNoAuth();
-    ownAPIsAuth();
-    asyncAPI_websocketMocks();
-    sleep(2);
+  const toRun = flavorConfig[FLAVOR];
+  if (!toRun) {
+    console.error(`Unknown flavor "${FLAVOR}"`);
+    return;
+  }
+  for (const fn of toRun) {
+    const testFn = tests[fn];
+    if (typeof testFn !== 'function') {
+      console.error(`Test function "${fn}" not found in commons.js`);
+      continue;
+    }
+    console.log(`Running ${fn}`);
+    testFn();
+  }
 }

--- a/testsuite/flavor-config.js
+++ b/testsuite/flavor-config.js
@@ -1,0 +1,20 @@
+const baseMocks = [
+  'invokeRESTMocks',
+  'invokeSOAPMocks',
+  'invokeGraphQLMocks',
+  'invokeGRPCMocks',
+  'invokeREST_HelloAPIMocks',
+  'invokeREST_PetStoreAPI',
+  'asyncAPI_websocketMocks',
+]
+var flavorConfig = {
+  'regular-auth': ['ownAPIsAuth'].concat(baseMocks),
+  'regular-noauth': ['ownAPIsNoAuth'].concat(baseMocks),
+  'uber-jvm': ['ownAPIsNoAuth'].concat(baseMocks),
+  'uber-native': ['ownAPIsNoAuth'].concat(
+    baseMocks.filter(function (fn) { return fn !== 'invokeSOAPMocks' &&
+    fn !== 'invokeREST_HelloAPIMocks'; })
+  ),
+  // add more flavors as needed…
+};
+export { flavorConfig };

--- a/testsuite/upload-artifacts.sh
+++ b/testsuite/upload-artifacts.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${BASE_URL:?Missing BASE_URL}"
+: "${MICROCKS_TOKEN:?Missing MICROCKS_TOKEN}"
+
+upload_file() {
+  local file_path="$1"
+  local main_artifact="${2:-false}"
+
+  if [[ ! -f "$file_path" ]]; then
+    echo "File not found: $file_path"
+    return 1
+  fi
+
+  echo "Uploading: $file_path (mainArtifact=$main_artifact)"
+
+  status_code=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "${BASE_URL}/api/artifact/upload?mainArtifact=${main_artifact}" \
+    -H "Authorization: Bearer ${MICROCKS_TOKEN}" \
+    -F "file=@${file_path}" -k)
+
+  if [[ "$status_code" -ne 201 ]]; then
+    echo "Upload failed for $file_path — HTTP status code: $status_code"
+    return 1
+  fi
+
+  echo "Upload succeeded for $file_path"
+}
+
+# Hello REST API Soapui
+upload_file "/samples/HelloAPI-soapui-project.xml" true
+
+# Hello Service gRPC
+upload_file "/samples/hello-v1.proto" true
+upload_file "/samples/HelloService.postman.json" false
+upload_file "/samples/HelloService.metadata.yml" false
+
+# HelloService Soapui API
+upload_file "/samples/HelloService-soapui-project.xml" true
+
+# Petstore API
+upload_file "/samples/PetstoreAPI-collection.json" true
+
+# User SignedUp API
+upload_file "/samples/UserSignedUpAPI-asyncapi.yml" true
+
+# GraphQL API
+upload_file "/samples/films.graphql" true
+upload_file "/samples/films-postman.json" false
+upload_file "/samples/films-metadata.yml" false
+
+# REST API
+upload_file "/samples/APIPastry-openapi.yaml" true
+
+echo "All files uploaded successfully!"


### PR DESCRIPTION
Part of: #1480

As it is now, checks related to async-minion will fail.
For `regular-auth` and `regular-noauth` flavors, I'm doing complete healthchecks, which I wonder if it's too much?

cc @lbroudoux 