### PR TITLE
Fix: AsyncAPI tests cannot handle contentType `any`

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
@@ -296,11 +296,6 @@ public class AsyncAPITestManager {
          if (messageNode.has("contentType")) {
             contentType = messageNode.path("contentType").asText();
          }
-         if (messageNode.has("payload")) {
-            String payload = messageNode.path("payload").asText();
-            if (payload.isEmpty() || payload.equals("null"))
-               contentType = "any";
-         }
          return contentType;
       }
 

--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
@@ -281,14 +281,25 @@ public class AsyncAPITestManager {
          // Get message real content type if defined.
          String contentType = defaultContentType;
          JsonNode messageNode = specificationNode.at(messagePathPointer);
+
+         // messageNode will be an array of messages
+         if (messageNode.isArray() && messageNode.size() > 0) {
+            messageNode = messageNode.get(0);
+         }
+
          // If it's a $ref, then navigate to it.
-         if (messageNode.has("$ref")) {
+         while (messageNode.has("$ref")) {
             // $ref: '#/components/messages/lightMeasured'
             String ref = messageNode.path("$ref").asText();
-            messageNode = messageNode.at(ref.substring(1));
+            messageNode = specificationNode.at(ref.substring(1));
          }
          if (messageNode.has("contentType")) {
             contentType = messageNode.path("contentType").asText();
+         }
+         if (messageNode.has("payload")) {
+            String payload = messageNode.path("payload").asText();
+            if (payload.isEmpty() || payload.equals("null"))
+               contentType = "any";
          }
          return contentType;
       }

--- a/minions/async/src/test/java/io/github/microcks/minion/async/AsyncAPITestManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/AsyncAPITestManagerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.microcks.util.asyncapi.AsyncAPISchemaUtil;
+import io.github.microcks.util.asyncapi.AsyncAPISchemaValidator;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+@Slf4j
+public class AsyncAPITestManagerTest {
+
+   private static final String ASYNC_API_2_SCHEMA_TEXT1 = """
+         asyncapi: '2.0.0'
+         info:
+           title: Example
+           version: '1.0.0'
+           description: Example YAML
+         channels:
+           sendMessage:
+             description: Example YAML
+             publish:
+               summary: Example YAML
+               operationId: sendMessage
+               message:
+                 $ref: '#/components/messages/send'
+         components:
+           messages:
+             send:
+               summary: Example message
+               contentType: text/plain
+         """;
+
+   @Test
+   void testGetExpectedContentType() {
+      JsonNode specificationNode = null;
+      try {
+         specificationNode = AsyncAPISchemaValidator.getJsonNodeForSchema(ASYNC_API_2_SCHEMA_TEXT1);
+      } catch (IOException e) {
+         Assertions.fail("Exception should not be thrown");
+      }
+      String messagePathPointer = AsyncAPISchemaUtil.findMessagePathPointer(specificationNode, "SEND sendMessage");
+      Assertions.assertNotNull(messagePathPointer);
+      Assertions.assertTrue(messagePathPointer.contains("/channels/sendMessage/publish/message"));
+      String expectedContentType = getExpectedContentType(specificationNode, messagePathPointer);
+      Assertions.assertTrue(expectedContentType.contains("text/plain"));
+   }
+
+   /** Retrieve the expected content type for an AsyncAPI message. */
+   private String getExpectedContentType(JsonNode specificationNode, String messagePathPointer) {
+      // Retrieve default content type, defaulting to application/json.
+      String defaultContentType = specificationNode.path("defaultContentType").asText("application/json");
+      // Get message real content type if defined.
+      String contentType = defaultContentType;
+      JsonNode messageNode = specificationNode.at(messagePathPointer);
+      // messageNode will be an array of messages
+      if (messageNode.isArray() && messageNode.size() > 0) {
+         messageNode = messageNode.get(0);
+      }
+      // If it's a $ref, then navigate to it.
+      while (messageNode.has("$ref")) {
+         // $ref: '#/components/messages/lightMeasured'
+         String ref = messageNode.path("$ref").asText();
+         messageNode = specificationNode.at(ref.substring(1));
+      }
+      if (messageNode.has("contentType")) {
+         contentType = messageNode.path("contentType").asText();
+      }
+      return contentType;
+   }
+}

--- a/minions/async/src/test/resources/io/github/microcks/minion/async/send-message-asyncapi-3.0.yaml
+++ b/minions/async/src/test/resources/io/github/microcks/minion/async/send-message-asyncapi-3.0.yaml
@@ -1,0 +1,48 @@
+asyncapi: '3.0.0'
+info:
+  title: Message Sender API
+  version: '1.0.0'
+  description: |
+    This AsyncAPI specification defines a channel `sendMessage`
+    that allows sending messages with any type of payload.
+
+servers:
+  echoServer:
+    host: echo-websocket.hoppscotch.io
+    protocol: wss
+
+channels:
+  echo:
+    description: >
+      The single channel where messages are sent to and echoed back.
+    address: /
+    messages:
+      echo:
+        $ref: '#/components/messages/echo'
+
+operations:
+  sendEchoMessage:
+    action: send
+    channel:
+      $ref: '#/channels/echo'
+    summary: Send a message to the echo server.
+    messages:
+      - $ref: '#/channels/echo/messages/echo'
+
+components:
+  messages:
+    echo:
+      summary: A message exchanged with the echo server.
+      contentType: text/plain
+      examples:
+        - name: string
+          payload: test
+        - name: boolean
+          payload: true
+        - name: number
+          payload: 123
+        - name: object
+          payload:
+            test: test text
+
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
- This PR adds support for handling `contentType : <any>` at message level for AsyncAPI tests. 
- Previously, it was expecting `application/json`.

### What was the issue?
- `io.github.microcks.minion.async.AsyncAPITestManager.AsyncAPITestThread.getExpectedContentType()` was not able to determine message level content type because we were not following `$ref` recursively to identify the actual message node. 
- That's why it was returning `application/json` as content type because it's a default one. 

### Related issue(s)
Fixes #1561 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->