### PR TITLE
feat: Quickjs4J demo integratio

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -24,6 +24,7 @@
     <commons-io.version>2.16.1</commons-io.version>
     <commons-codec.version>1.17.1</commons-codec.version>
     <groovy.version>4.0.26</groovy.version>
+    <quickjs4j.version>0.0.6</quickjs4j.version>
     <protobuf.version>3.25.5</protobuf.version>
     <grpc.version>1.70.0</grpc.version>
     <protoc-jar.version>3.21.8</protoc-jar.version>
@@ -162,6 +163,23 @@
     <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-dateutil</artifactId>
       <version>${groovy.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.roastedroot</groupId>
+      <artifactId>quickjs4j</artifactId>
+      <version>${quickjs4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.roastedroot</groupId>
+      <artifactId>quickjs4j-annotations</artifactId>
+      <version>${quickjs4j.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>io.roastedroot</groupId>
+        <artifactId>quickjs4j-processor</artifactId>
+        <version>${quickjs4j.version}</version>
+        <scope>compile</scope>
     </dependency>
 
     <dependency>

--- a/webapp/src/main/java/io/github/microcks/util/DispatchStyles.java
+++ b/webapp/src/main/java/io/github/microcks/util/DispatchStyles.java
@@ -33,6 +33,9 @@ public class DispatchStyles {
    /** Constant for SCRIPT dispatch style. */
    public static final String SCRIPT = "SCRIPT";
 
+   /** Constant for JS dispatch style. */
+   public static final String JS = "JS";
+
    /** Constant for SEQUENCE dispatch style. */
    public static final String SEQUENCE = "SEQUENCE";
 

--- a/webapp/src/main/java/io/github/microcks/util/script/JsScriptEngineBinder.java
+++ b/webapp/src/main/java/io/github/microcks/util/script/JsScriptEngineBinder.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.util.script;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.github.microcks.service.StateStore;
+import io.github.microcks.util.http.HttpHeadersUtil;
+import io.roastedroot.quickjs4j.annotations.Builtins;
+import io.roastedroot.quickjs4j.annotations.GuestFunction;
+import io.roastedroot.quickjs4j.annotations.HostFunction;
+import io.roastedroot.quickjs4j.annotations.Invokables;
+import io.roastedroot.quickjs4j.core.Engine;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Utility class that holds methods for creating binding environments and evaluation context for a JSR 233 ScriptEngine.
+ * @author laurent
+ */
+public class JsScriptEngineBinder {
+
+   /** A simple logger for diagnostic messages. */
+   private static final Logger log = LoggerFactory.getLogger(JsScriptEngineBinder.class);
+
+   /** Private constructor to hide the implicit public one. */
+   private JsScriptEngineBinder() {
+   }
+
+   public static Engine buildEvaluationContext(String requestContent, Map<String, Object> requestContext,
+         StateStore stateStore, HttpServletRequest request) {
+      StringToStringsMap headers = HttpHeadersUtil.extractFromHttpServletRequest(request);
+      return buildEvaluationContext(requestContent, requestContext, stateStore, headers, request);
+   }
+
+   public static Engine buildEvaluationContext(String requestContent, Map<String, Object> requestContext,
+         StateStore stateStore, HttpServletRequest request, Map<String, String> uriParameters) {
+      StringToStringsMap headers = HttpHeadersUtil.extractFromHttpServletRequest(request);
+      return buildEvaluationContext(requestContent, requestContext, stateStore, headers, request, uriParameters);
+   }
+
+   public static Engine buildEvaluationContext(String requestContent, Map<String, Object> requestContext,
+         StateStore stateStore, StringToStringsMap headers, HttpServletRequest request) {
+      return buildEvaluationContext(requestContent, requestContext, stateStore, headers, request, null);
+   }
+
+   private static final ObjectMapper mapper = new ObjectMapper();
+
+   @Builtins("log")
+   public static final class LogContext {
+      @HostFunction
+      public void info(String str) {
+         log.info(str);
+      }
+
+      @HostFunction
+      public void debug(String str) {
+         log.debug(str);
+      }
+
+      @HostFunction
+      public void warn(String str) {
+         log.warn(str);
+      }
+
+      @HostFunction
+      public void error(String str) {
+         log.error(str);
+      }
+   }
+
+   @Builtins("store")
+   public final static class StoreApi {
+      private final StateStore delegate;
+
+      public StoreApi(StateStore store) {
+         this.delegate = store;
+      }
+
+      @HostFunction
+      public String get(String key) {
+         return this.delegate.get(key);
+      }
+
+      @HostFunction
+      public void put(String key, String value) {
+         this.delegate.put(key, value);
+      }
+
+      @HostFunction
+      public void delete(String key) {
+         this.delegate.delete(key);
+      }
+   }
+
+   @Builtins("requestContext")
+   public final static class RequestContextApi {
+      private final Map<String, Object> delegate;
+
+
+      public RequestContextApi(Map<String, Object> requestContext) {
+         this.delegate = requestContext;
+      }
+
+      @HostFunction
+      public JsonNode get(String key) {
+         return mapper.convertValue(delegate.get(key), JsonNode.class);
+      }
+
+      @HostFunction
+      public void set(String key, Object value) {
+         delegate.put(key, value);
+      }
+   }
+
+   @Builtins("mockRequest")
+   public final static class MockRequestApi {
+      private final FakeScriptMockRequest delegate;
+      private final ObjectMapper mapper = new ObjectMapper();
+
+      public MockRequestApi(FakeScriptMockRequest mockRequest) {
+         this.delegate = mockRequest;
+      }
+
+      @HostFunction
+      public String requestContent() {
+         return this.delegate.getRequestContent();
+      }
+
+      @HostFunction
+      public JsonNode getRequestHeader(String key) {
+         ArrayNode arr = mapper.createArrayNode();
+         StringToStringsMap reqHeaders = this.delegate.getRequestHeaders();
+         for (String str : reqHeaders.get(key)) {
+            arr.add(str);
+         }
+         return arr;
+      }
+
+      @HostFunction
+      public String getURIParameter(String key) {
+         if (this.delegate.getURIParameters() == null) {
+            return null;
+         }
+         return this.delegate.getURIParameters().get(key);
+      }
+   }
+
+   @Invokables("js")
+   public interface JsApi {
+      @GuestFunction
+      String process();
+   }
+
+   public static Engine buildEvaluationContext(String requestContent, Map<String, Object> requestContext,
+         StateStore stateStore, StringToStringsMap headers, HttpServletRequest request,
+         Map<String, String> uriParameters) {
+
+      // Build a fake request container.
+      FakeScriptMockRequest mockRequest = new FakeScriptMockRequest(requestContent, headers);
+      mockRequest.setRequest(request);
+      mockRequest.setURIParameters(uriParameters);
+
+      // Create bindings and put content according to SoapUI binding environment.
+      Engine engine = Engine.builder().addInvokables(JsApi_Invokables.toInvokables())
+            .addBuiltins(LogContext_Builtins.toBuiltins(new LogContext()))
+            .addBuiltins(StoreApi_Builtins.toBuiltins(new StoreApi(stateStore)))
+            .addBuiltins(RequestContextApi_Builtins.toBuiltins(new RequestContextApi(requestContext)))
+            .addBuiltins(MockRequestApi_Builtins.toBuiltins(new MockRequestApi(mockRequest))).build();
+
+      return engine;
+   }
+
+   public static String wrapIntoFunction(String script) {
+      return "function process() { " + script + "}";
+   }
+}

--- a/webapp/src/main/java/io/github/microcks/web/RestInvocationProcessor.java
+++ b/webapp/src/main/java/io/github/microcks/web/RestInvocationProcessor.java
@@ -36,8 +36,12 @@ import io.github.microcks.util.dispatcher.JsonExpressionEvaluator;
 import io.github.microcks.util.dispatcher.JsonMappingException;
 import io.github.microcks.util.dispatcher.ProxyFallbackSpecification;
 import io.github.microcks.util.el.EvaluableRequest;
+import io.github.microcks.util.script.JsApi_Invokables;
+import io.github.microcks.util.script.JsScriptEngineBinder;
 import io.github.microcks.util.script.ScriptEngineBinder;
 
+import io.roastedroot.quickjs4j.core.Engine;
+import io.roastedroot.quickjs4j.core.Runner;
 import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
@@ -270,6 +274,31 @@ public class RestInvocationProcessor {
                   dispatchCriteria = (String) scriptEngine.eval(script, scriptContext);
                } catch (Exception e) {
                   log.error("Error during Script evaluation", e);
+               }
+               break;
+            case DispatchStyles.JS:
+               requestContext = new HashMap<>();
+               Map<String, String> jsUriParameters = DispatchCriteriaHelper.extractMapFromURIPattern(uriPattern,
+                     resourcePath);
+               Runner runner = null;
+               try {
+                  // Evaluating request with script coming from operation dispatcher rules.
+                  String script = JsScriptEngineBinder.wrapIntoFunction(dispatcherRules);
+                  Engine scriptContext = JsScriptEngineBinder.buildEvaluationContext(body, requestContext,
+                        new ServiceStateStore(serviceStateRepository, service.getId()), request, jsUriParameters);
+                  runner = Runner.builder().withEngine(scriptContext).build();
+                  JsScriptEngineBinder.JsApi jsApi = JsApi_Invokables.create(script, runner);
+                  dispatchCriteria = jsApi.process();
+               } catch (Exception e) {
+                  log.error("Error during JS evaluation", e);
+                  if (runner != null) {
+                     log.error("script stdout: " + runner.stdout());
+                     log.error("script stderr: " + runner.stderr());
+                  }
+               } finally {
+                  if (runner != null) {
+                     runner.close();
+                  }
                }
                break;
             case DispatchStyles.URI_PARAMS:

--- a/webapp/src/main/webapp/angular.json
+++ b/webapp/src/main/webapp/angular.json
@@ -108,5 +108,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/webapp/src/main/webapp/src/app/pages/services/{serviceId}/operation/operation-override.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/services/{serviceId}/operation/operation-override.page.ts
@@ -74,6 +74,7 @@ export class OperationOverridePageComponent implements OnInit {
       { value: 'URI_ELEMENTS', label: 'URI ELEMENTS' },
       { value: 'QUERY_HEADER', label: 'QUERY HEADER' },
       { value: 'SCRIPT', label: 'SCRIPT' },
+      { value: 'JS', label: 'JS' },
       { value: 'JSON_BODY', label: 'JSON BODY' },
       { value: 'PROXY', label: 'PROXY' },
       { value: 'FALLBACK', label: 'FALLBACK' },

--- a/webapp/src/test/java/io/github/microcks/util/script/JsScriptEngineBinderTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/script/JsScriptEngineBinderTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.util.script;
+
+import io.github.microcks.service.StateStore;
+import io.roastedroot.quickjs4j.core.Engine;
+import io.roastedroot.quickjs4j.core.Runner;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * This is a test case for class JsScriptEngineBinder class.
+ */
+class JsScriptEngineBinderTest {
+
+   @Test
+   void testRequestContentIsBound() {
+      String script = JsScriptEngineBinder.wrapIntoFunction("""
+            return mockRequest.requestContent();
+            """);
+
+      String body = "content";
+
+      try {
+         // Evaluating request with script coming from operation dispatcher rules.
+         Engine engine = JsScriptEngineBinder.buildEvaluationContext(body, null, null, null);
+         Runner runner = Runner.builder().withEngine(engine).build();
+         JsScriptEngineBinder.JsApi jsApi = JsApi_Invokables.create(script, runner);
+
+         String result = jsApi.process();
+
+         assertEquals(body, result);
+      } catch (Exception e) {
+         fail("Exception should no be thrown");
+      }
+   }
+
+   @Test
+   void testRequestContentHeadersAreBound() {
+      String script = JsScriptEngineBinder.wrapIntoFunction("""
+            const fooHeader = mockRequest.getRequestHeader("foo");
+            log.info("header: " + fooHeader[0]);
+            return fooHeader[0];
+            """);
+
+      String body = "content";
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("foo", "bar");
+
+      try {
+         // Evaluating request with script coming from operation dispatcher rules.
+         Engine engine = JsScriptEngineBinder.buildEvaluationContext(body, null, null, request);
+         Runner runner = Runner.builder().withEngine(engine).build();
+         JsScriptEngineBinder.JsApi jsApi = JsApi_Invokables.create(script, runner);
+
+         String result = jsApi.process();
+
+         assertEquals("bar", result);
+      } catch (Exception e) {
+         fail("Exception should no be thrown");
+      }
+   }
+
+   @Test
+   void testUriParametersAreBound() {
+      String script = JsScriptEngineBinder.wrapIntoFunction("""
+            const fooParam = mockRequest.getURIParameter("foo");
+            log.info("uri parameter: " + fooParam);
+            return fooParam ?? "null";
+            """);
+
+      String body = "content";
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      Map<String, String> uriParameters = new HashMap<>();
+      uriParameters.put("foo", "bar");
+
+      try {
+         Engine engine = JsScriptEngineBinder.buildEvaluationContext(body, null, null, request, uriParameters);
+         Runner runner = Runner.builder().withEngine(engine).build();
+         JsScriptEngineBinder.JsApi jsApi = JsApi_Invokables.create(script, runner);
+
+         String result = jsApi.process();
+
+         assertEquals("bar", result);
+      } catch (Exception e) {
+         fail("Exception should no be thrown");
+      }
+   }
+
+   @Test
+   void testRequestContextIsModified() {
+      String script = JsScriptEngineBinder.wrapIntoFunction("""
+            requestContext.set("foo", "bar");
+            return mockRequest.requestContent();
+            """);
+
+      Map<String, Object> context = new HashMap<>();
+      String body = "content";
+
+      try {
+         Engine engine = JsScriptEngineBinder.buildEvaluationContext(body, context, null, null);
+         Runner runner = Runner.builder().withEngine(engine).build();
+         JsScriptEngineBinder.JsApi jsApi = JsApi_Invokables.create(script, runner);
+
+         String result = jsApi.process();
+
+         assertEquals(body, result);
+         assertTrue(context.containsKey("foo"));
+         assertEquals("bar", context.get("foo"));
+      } catch (Exception e) {
+         fail("Exception should no be thrown");
+      }
+   }
+
+   @Test
+   void testStateStoreIsBoundAndAccessed() {
+      String script = JsScriptEngineBinder.wrapIntoFunction("""
+            const foo = store.get("foo");
+            store.put("bar", "barValue");
+            store.delete("baz");
+            return foo;
+            """);
+
+      StateStore store = new StateStore() {
+         private final Map<String, String> map = new HashMap<>();
+
+         @Override
+         public void put(String key, String value) {
+            map.put(key, value);
+         }
+
+         @Override
+         public void put(String key, String value, int secondsTTL) {
+            map.put(key, value);
+         }
+
+         @Nullable
+         @Override
+         public String get(String key) {
+            return map.get(key);
+         }
+
+         @Override
+         public void delete(String key) {
+            map.remove(key);
+         }
+      };
+
+      Map<String, Object> context = new HashMap<>();
+      store.put("foo", "fooValue");
+      store.put("baz", "bazValue");
+
+      try {
+         Engine engine = JsScriptEngineBinder.buildEvaluationContext("body", context, store, null);
+         Runner runner = Runner.builder().withEngine(engine).build();
+         JsScriptEngineBinder.JsApi jsApi = JsApi_Invokables.create(script, runner);
+
+         String result = jsApi.process();
+
+         assertEquals("fooValue", result);
+         assertEquals("barValue", store.get("bar"));
+         assertNull(store.get("baz"));
+      } catch (Exception e) {
+         fail("Exception should no be thrown");
+      }
+   }
+}


### PR DESCRIPTION
### Description

This is a POC to demonstrate one possible approach to have a JavaScript engine to evaluate the script in dispatch.
The current implementation is for demo purposes, early questions:
- do we expect people to(only) upload little snippets? In Quickjs4J we invested in the DX to provide the script [as a "library"](https://github.com/roastedroot/quickjs4j/tree/main/core/src/test/resources/)
- I added a `DispatchStyle` but I'm unsure it's a good idea, any preference on how to roll this forward?
- is the proposed `JsApi` reasonable? any specific preference for accessing fields etc.? or high level guidance like: "should be as familiar as possible to JS/TS devs"
- the current script doesn't have access to FileSystem/Network and similar, so, it fall short on calling external APIs, do you want to make it possible dynamically in the script? Would it be ok to provide a bespoke HTTP invocation API?
- ... I have more questions, but let's iterate :slightly_smiling_face: 

Happy to hear feedback!

### Related issue(s)

See also #1559 