### PR TITLE
Disable not working sonar check on forks

### DIFF
--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -12,6 +12,7 @@ on:
 permissions: read-all
 jobs:
   build:
+    if: github.repository_owner == 'microcks'
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
At best of my understanding Sonar requires access to the `SONAR_TOKEN` secret which is not available on forks for security reasons.

I noticed that some CI jobs are already disabled and made the exclusion consistent with them.