### PR TITLE
fix: enable micrometer instrumentation to get the micrometer metrics

### DIFF
--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -99,6 +99,7 @@ otel.logs.exporter=none
 otel.exporter.otlp.endpoint=http://o11y_otel:4317
 otel.exporter.otlp.protocol=grpc
 otel.instrumentation.annotations.enabled=true
+otel.instrumentation.micrometer.enabled=true
 
 # Sampling configuration
 otel.traces.sampler=parentbased_traceidratio


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
Enable micrometer instrumentation to get the metrics of the actuator that are needed for the grafana dashboard

### Related issue(s)

This is a part of #1728
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->