### PR TITLE
fix: swagger import fail because body parameter is not exist

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/ParameterLocation.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/ParameterLocation.java
@@ -24,5 +24,6 @@ public enum ParameterLocation {
    query,
    header,
    cookie,
-   formData
+   formData,
+   body
 }

--- a/webapp/src/main/webapp/src/app/models/service.model.ts
+++ b/webapp/src/main/webapp/src/app/models/service.model.ts
@@ -97,6 +97,7 @@ export enum ParameterLocation {
   header,
   cookie,
   formData,
+  body,
 }
 
 export type Contract = {


### PR DESCRIPTION
### Description

Adding body as a valid parameter location in both Java and TypeScript enums, preventing IllegalArgumentException when importing Swagger specs with `body` parameters.

### Related issue(s)

Fixes microcks#1763