### PR TITLE
Feat/add live traces component

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/TracingController.java
+++ b/webapp/src/main/java/io/github/microcks/web/TracingController.java
@@ -74,7 +74,7 @@ public class TracingController {
    }
 
    @GetMapping("/operations")
-   public ResponseEntity<List<List<ReadableSpan>>> getTracesForOperation(
+   public ResponseEntity<List<List<SpanData>>> getTracesForOperation(
          @RequestParam("serviceName") String serviceName, @RequestParam("operationName") String operationName,
          @RequestParam(value = "clientAddress", defaultValue = ".*") String clientAddress) {
       List<String> traceIds = spanStorageService.queryTraceIdsByPatterns(serviceName, operationName, clientAddress);
@@ -82,7 +82,8 @@ public class TracingController {
          return ResponseEntity.notFound().build();
       }
 
-      List<List<ReadableSpan>> spansByTraceId = traceIds.stream().map(spanStorageService::getSpansForTrace).toList();
+      List<List<SpanData>> spansByTraceId = traceIds.stream().map(spanStorageService::getSpansForTrace)
+            .map(spans -> spans.stream().map(ReadableSpan::toSpanData).toList()).toList();
 
       return ResponseEntity.ok(spansByTraceId);
    }

--- a/webapp/src/main/java/io/github/microcks/web/TracingController.java
+++ b/webapp/src/main/java/io/github/microcks/web/TracingController.java
@@ -74,8 +74,8 @@ public class TracingController {
    }
 
    @GetMapping("/operations")
-   public ResponseEntity<List<List<SpanData>>> getTracesForOperation(
-         @RequestParam("serviceName") String serviceName, @RequestParam("operationName") String operationName,
+   public ResponseEntity<List<List<SpanData>>> getTracesForOperation(@RequestParam("serviceName") String serviceName,
+         @RequestParam("operationName") String operationName,
          @RequestParam(value = "clientAddress", defaultValue = ".*") String clientAddress) {
       List<String> traceIds = spanStorageService.queryTraceIdsByPatterns(serviceName, operationName, clientAddress);
       if (traceIds.isEmpty()) {

--- a/webapp/src/main/webapp/src/app/app.routes.ts
+++ b/webapp/src/main/webapp/src/app/app.routes.ts
@@ -14,6 +14,7 @@ import { HubPageComponent } from './pages/hub/hub.page';
 import { HubPackagePageComponent } from './pages/hub/package/package.page';
 import { HubAPIVersionPageComponent } from './pages/hub/package/apiVersion/apiVersion.page';
 import { AdminPageComponent } from './pages/admin/admin.page';
+import { LiveTracesComponent } from './components/live-traces/live-traces.component';
 
 export const routes: Routes = [
   {
@@ -71,5 +72,10 @@ export const routes: Routes = [
   {
     path: 'admin',
     component: AdminPageComponent
+  },
+  {
+    path: 'traces',
+    component: LiveTracesComponent,
+    data: { allowCustomization: true }
   }
 ];

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.css
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.css
@@ -8,7 +8,7 @@
 
 .live-traces .count {
   margin-left: 6px;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .live-traces .form-inline {

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.css
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.css
@@ -1,0 +1,39 @@
+.live-traces .controls {
+  margin-bottom: 10px;
+}
+
+.live-traces .status {
+  margin-left: 10px;
+}
+
+.live-traces .count {
+  margin-left: 6px;
+  color: #666;
+}
+
+.live-traces .form-inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.live-traces .form-inline label {
+  margin: 0;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.live-traces .form-inline .form-control-sm {
+  display: inline-block;
+  width: auto;
+  min-width: 150px;
+}
+
+.live-traces .button-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.html
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.html
@@ -62,7 +62,7 @@
       <button
         class="btn btn-default btn-sm"
         (click)="clear()"
-        [disabled]="traceGroups.length === 0"
+        [disabled]="traces.length === 0"
       >
         <span class="fa fa-trash"></span> Clear
       </button>
@@ -80,5 +80,5 @@
     <div *ngIf="error" class="text-danger">{{ error }}</div>
   </div>
 
-  <app-trace-group-list [traces]="traceGroups"></app-trace-group-list>
+  <app-trace-group-list [traces]="traces"></app-trace-group-list>
 </div>

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.html
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.html
@@ -1,0 +1,84 @@
+<div class="live-traces">
+  <div class="controls">
+    <div class="form-inline">
+      <label for="serviceName" *ngIf="allowCustomization">Service:</label>
+      <input
+        *ngIf="allowCustomization"
+        id="serviceName"
+        type="text"
+        class="form-control form-control-sm"
+        [(ngModel)]="serviceName"
+        placeholder="Service name"
+        [disabled]="connected"
+      />
+      <label for="operationName" *ngIf="allowCustomization">Operation:</label>
+      <input
+        *ngIf="allowCustomization"
+        id="operationName"
+        type="text"
+        class="form-control form-control-sm"
+        [(ngModel)]="operationName"
+        placeholder="Operation name"
+        [disabled]="connected"
+      />
+      <label for="clientIpFilter">Client IP:</label>
+      <input
+        id="clientIpFilter"
+        type="text"
+        class="form-control form-control-sm"
+        [(ngModel)]="clientIpFilter"
+        placeholder="IP filter (regex)"
+        [disabled]="connected"
+      />
+    </div>
+    <div class="button-group">
+      <button
+        class="btn btn-default btn-sm"
+        (click)="connect()"
+        [disabled]="connected || !serviceName || !operationName"
+      >
+        <span class="fa fa-play"></span> Connect
+      </button>
+      <button
+        class="btn btn-default btn-sm"
+        (click)="disconnect()"
+        [disabled]="!connected"
+      >
+        <span class="fa fa-stop"></span> Disconnect
+      </button>
+      <button
+        class="btn btn-default btn-sm"
+        (click)="prefill()"
+        [disabled]="isLoading || !serviceName || !operationName"
+      >
+        <span
+          class="fa"
+          [class.fa-download]="!isLoading"
+          [class.fa-spinner]="isLoading"
+          [class.fa-spin]="isLoading"
+        ></span>
+        {{ isLoading ? "Loading..." : "Prefill" }}
+      </button>
+      <button
+        class="btn btn-default btn-sm"
+        (click)="clear()"
+        [disabled]="traceGroups.length === 0"
+      >
+        <span class="fa fa-trash"></span> Clear
+      </button>
+      <span
+        class="status"
+        [class.text-success]="connected"
+        [class.text-muted]="!connected"
+      >
+        {{ connected ? "Connected" : "Disconnected" }}
+      </span>
+      <span class="count" *ngIf="totalEvents">
+        | {{ totalEvents }} event(s)</span
+      >
+    </div>
+    <div *ngIf="error" class="text-danger">{{ error }}</div>
+  </div>
+
+  <app-trace-group-list [traces]="traceGroups"></app-trace-group-list>
+</div>

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
@@ -85,7 +85,6 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (spans) => {
           if (spans && spans.length > 0) {
-            console.log("Received spans", spans);
             // Get trace ID from first span
             const traceId = spans[0]?.spanContext()?.traceId;
             if (traceId && !this.seenTraceIds.has(traceId)) {
@@ -102,9 +101,6 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
                   }
                 }
               }
-              console.log("Trace groups now", this.traceGroups.length);
-            } else {
-              console.log("Duplicate trace ignored", traceId);
             }
           }
         },
@@ -115,7 +111,6 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
         },
         complete: () => {
           this.connected = false;
-          console.log("Stream completed");
         },
       });
   }
@@ -137,7 +132,6 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         next: (traces) => {
-          console.log("Prefilled traces", traces);
           if (traces && traces.length > 0) {
             // Filter out traces we've already seen
             const newTraces = traces.filter((traceGroup) => {
@@ -171,11 +165,6 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
                   }
                 });
               }
-              console.log(
-                `Added ${newTraces.length} new traces, ${traces.length - newTraces.length} duplicates ignored`,
-              );
-            } else {
-              console.log("No new traces, all were duplicates");
             }
           }
           this.isLoading = false;

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
@@ -243,14 +243,4 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
       0,
     );
   }
-
-  // Helpers to compare HrTime
-  // Kept for the component's own time formatting etc; store has its own copies as well.
-  private toNanos(t?: HrTime): bigint {
-    if (!t) return -1n;
-    const [s, ns] = t;
-    if (!Number.isFinite(s) || !Number.isFinite(ns) || (s === 0 && ns === 0))
-      return -1n;
-    return BigInt(Math.trunc(s)) * 1_000_000_000n + BigInt(Math.trunc(ns));
-  }
 }

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
@@ -198,43 +198,6 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
     this.error = "";
   }
 
-  trackBySpan(index: number, s: ReadableSpan): string {
-    const ctx = s.spanContext();
-    return `${ctx.traceId}/${ctx.spanId}`;
-  }
-
-  trackByTrace(index: number, g: { traceId: string }): string {
-    return g.traceId;
-  }
-
-  trackByEvent(
-    index: number,
-    e: { traceId: string; spanId: string; name: string; time?: HrTime },
-  ): string {
-    const t = e.time ? `${e.time[0]}-${e.time[1]}` : "no-time";
-    return `${e.traceId}/${e.spanId}/${e.name}/${t}`;
-  }
-
-  getEventTitle(e: { name: string; attributes?: Attributes }): string {
-    const raw = (e.attributes as any)?.["message"];
-    if (raw === undefined || raw === null) return e.name;
-    if (typeof raw === "string") return raw;
-    try {
-      return JSON.stringify(raw);
-    } catch {
-      return String(raw);
-    }
-  }
-
-  hasNonMessageAttributes(attrs?: Attributes): boolean {
-    if (!attrs) return false;
-    for (const k in attrs) {
-      if (Object.prototype.hasOwnProperty.call(attrs, k) && k !== "message")
-        return true;
-    }
-    return false;
-  }
-
   get totalEvents(): number {
     return this.traces.reduce(
       (acc, g) =>

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
@@ -234,24 +234,6 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
     return false;
   }
 
-  formatHrTime(t?: HrTime): string {
-    if (!t) return "";
-    const [sec, nsec] = t;
-    if (
-      !Number.isFinite(sec) ||
-      !Number.isFinite(nsec) ||
-      (sec === 0 && nsec === 0)
-    )
-      return "";
-    const msEpoch = sec * 1000 + Math.floor(nsec / 1_000_000);
-    const d = new Date(msEpoch);
-    const hh = String(d.getHours()).padStart(2, "0");
-    const mm = String(d.getMinutes()).padStart(2, "0");
-    const ss = String(d.getSeconds()).padStart(2, "0");
-    const ms = String(d.getMilliseconds()).padStart(3, "0");
-    return `${hh}:${mm}:${ss}.${ms}`;
-  }
-
   get totalEvents(): number {
     return this.traceGroups.reduce(
       (acc, g) =>
@@ -269,25 +251,5 @@ export class LiveTracesComponent implements OnInit, OnDestroy {
     if (!Number.isFinite(s) || !Number.isFinite(ns) || (s === 0 && ns === 0))
       return -1n;
     return BigInt(Math.trunc(s)) * 1_000_000_000n + BigInt(Math.trunc(ns));
-  }
-  private minHrTime(
-    a: HrTime | undefined,
-    b: HrTime | undefined,
-  ): HrTime | undefined {
-    const an = this.toNanos(a);
-    const bn = this.toNanos(b);
-    if (an < 0n) return b;
-    if (bn < 0n) return a;
-    return an <= bn ? a : b;
-  }
-  private maxHrTime(
-    a: HrTime | undefined,
-    b: HrTime | undefined,
-  ): HrTime | undefined {
-    const an = this.toNanos(a);
-    const bn = this.toNanos(b);
-    if (an < 0n) return b;
-    if (bn < 0n) return a;
-    return an >= bn ? a : b;
   }
 }

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
@@ -1,0 +1,304 @@
+import { Component, Input, OnDestroy, OnInit } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { FormsModule } from "@angular/forms";
+import { ActivatedRoute } from "@angular/router";
+import { TraceGroupListComponent } from "./trace-group-list/trace-group-list.component";
+import { ReadableSpan, TimedEvent } from "@opentelemetry/sdk-trace-base";
+import { Attributes, HrTime, SpanStatusCode } from "@opentelemetry/api";
+import { Subscription } from "rxjs";
+import { TracingService } from "../../services/tracing.service";
+
+@Component({
+  selector: "app-live-traces",
+  standalone: true,
+  imports: [CommonModule, FormsModule, TraceGroupListComponent],
+  templateUrl: "./live-traces.component.html",
+  styleUrls: ["./live-traces.component.css"],
+})
+export class LiveTracesComponent implements OnInit, OnDestroy {
+  @Input() set initialServiceName(value: string) {
+    if (value) this.serviceName = value;
+  }
+  @Input() set initialOperationName(value: string) {
+    if (value) this.operationName = value;
+  }
+  @Input() autoConnect = false;
+  @Input() maxItems = 200;
+  @Input() allowCustomization = false; // Controls whether service/operation names are editable
+
+  serviceName = "";
+  operationName = "";
+  connected = false;
+  error = "";
+  spans: ReadableSpan[] = [];
+  // View of groups comes from service
+  traceGroups: ReadableSpan[][] = [];
+  clientIpFilter = ".*";
+  isLoading = false;
+
+  private sub?: Subscription;
+  private groupsSub?: Subscription;
+  private seenKeys = new Set<string>();
+  private seenTraceIds = new Set<string>();
+
+  constructor(
+    private tracing: TracingService,
+    private route: ActivatedRoute,
+  ) {}
+
+  ngOnInit(): void {
+    // Check if allowCustomization is set in route data
+    this.route.data.subscribe((data) => {
+      if (data["allowCustomization"] !== undefined) {
+        this.allowCustomization = data["allowCustomization"];
+      }
+    });
+
+    if (this.autoConnect) {
+      this.connect();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.disconnect();
+  }
+
+  connect(): void {
+    if (this.connected) return;
+    if (!this.serviceName || !this.operationName) {
+      this.error = "Service name and operation name are required";
+      return;
+    }
+    this.connected = true;
+    this.error = "";
+    this.spans = [];
+    this.seenKeys.clear();
+    this.traceGroups = [];
+    this.seenTraceIds.clear();
+    // Subscribe to groups store for this service/op with client IP filter
+    const subscription = this.tracing
+      .streamSpans(
+        this.serviceName,
+        this.operationName,
+        this.clientIpFilter || ".*",
+      )
+      .subscribe({
+        next: (spans) => {
+          if (spans && spans.length > 0) {
+            console.log("Received spans", spans);
+            // Get trace ID from first span
+            const traceId = spans[0]?.spanContext()?.traceId;
+            if (traceId && !this.seenTraceIds.has(traceId)) {
+              this.seenTraceIds.add(traceId);
+              this.traceGroups.unshift(spans);
+              // Trim to max items
+              if (this.traceGroups.length > this.maxItems) {
+                const removed = this.traceGroups.pop();
+                // Remove the trace ID of the removed group
+                if (removed && removed[0]) {
+                  const removedTraceId = removed[0].spanContext()?.traceId;
+                  if (removedTraceId) {
+                    this.seenTraceIds.delete(removedTraceId);
+                  }
+                }
+              }
+              console.log("Trace groups now", this.traceGroups.length);
+            } else {
+              console.log("Duplicate trace ignored", traceId);
+            }
+          }
+        },
+        error: (err) => {
+          this.error = `Stream error: ${err.message || err}`;
+          console.error("Stream error", err);
+          this.connected = false;
+        },
+        complete: () => {
+          this.connected = false;
+          console.log("Stream completed");
+        },
+      });
+  }
+
+  prefill(): void {
+    if (this.isLoading) return;
+    if (!this.serviceName || !this.operationName) {
+      this.error = "Service name and operation name are required";
+      return;
+    }
+    this.isLoading = true;
+    this.error = "";
+
+    this.tracing
+      .getTracesForOperation(
+        this.serviceName,
+        this.operationName,
+        this.clientIpFilter || ".*",
+      )
+      .subscribe({
+        next: (traces) => {
+          console.log("Prefilled traces", traces);
+          if (traces && traces.length > 0) {
+            // Filter out traces we've already seen
+            const newTraces = traces.filter((traceGroup) => {
+              if (traceGroup && traceGroup.length > 0) {
+                const traceId = traceGroup[0]?.spanContext()?.traceId;
+                if (traceId && !this.seenTraceIds.has(traceId)) {
+                  this.seenTraceIds.add(traceId);
+                  return true;
+                }
+              }
+              return false;
+            });
+
+            if (newTraces.length > 0) {
+              // Add new prefilled traces to the beginning
+              this.traceGroups = [...newTraces, ...this.traceGroups];
+              // Trim to max items
+              if (this.traceGroups.length > this.maxItems) {
+                const toRemove = this.traceGroups.length - this.maxItems;
+                const removed = this.traceGroups.splice(
+                  this.maxItems,
+                  toRemove,
+                );
+                // Remove trace IDs of removed groups
+                removed.forEach((group) => {
+                  if (group && group[0]) {
+                    const removedTraceId = group[0].spanContext()?.traceId;
+                    if (removedTraceId) {
+                      this.seenTraceIds.delete(removedTraceId);
+                    }
+                  }
+                });
+              }
+              console.log(
+                `Added ${newTraces.length} new traces, ${traces.length - newTraces.length} duplicates ignored`,
+              );
+            } else {
+              console.log("No new traces, all were duplicates");
+            }
+          }
+          this.isLoading = false;
+        },
+        error: (err) => {
+          this.error = `Prefill error: ${err.message || err}`;
+          console.error("Prefill error", err);
+          this.isLoading = false;
+        },
+      });
+  }
+
+  disconnect(): void {
+    if (this.sub) {
+      this.sub.unsubscribe();
+      this.sub = undefined;
+    }
+    if (this.groupsSub) {
+      this.groupsSub.unsubscribe();
+      this.groupsSub = undefined;
+    }
+    this.connected = false;
+  }
+
+  clear(): void {
+    this.spans = [];
+    this.seenKeys.clear();
+    this.traceGroups = [];
+    this.seenTraceIds.clear();
+    this.error = "";
+  }
+
+  trackBySpan(index: number, s: ReadableSpan): string {
+    const ctx = s.spanContext();
+    return `${ctx.traceId}/${ctx.spanId}`;
+  }
+
+  trackByTrace(index: number, g: { traceId: string }): string {
+    return g.traceId;
+  }
+
+  trackByEvent(
+    index: number,
+    e: { traceId: string; spanId: string; name: string; time?: HrTime },
+  ): string {
+    const t = e.time ? `${e.time[0]}-${e.time[1]}` : "no-time";
+    return `${e.traceId}/${e.spanId}/${e.name}/${t}`;
+  }
+
+  getEventTitle(e: { name: string; attributes?: Attributes }): string {
+    const raw = (e.attributes as any)?.["message"];
+    if (raw === undefined || raw === null) return e.name;
+    if (typeof raw === "string") return raw;
+    try {
+      return JSON.stringify(raw);
+    } catch {
+      return String(raw);
+    }
+  }
+
+  hasNonMessageAttributes(attrs?: Attributes): boolean {
+    if (!attrs) return false;
+    for (const k in attrs) {
+      if (Object.prototype.hasOwnProperty.call(attrs, k) && k !== "message")
+        return true;
+    }
+    return false;
+  }
+
+  formatHrTime(t?: HrTime): string {
+    if (!t) return "";
+    const [sec, nsec] = t;
+    if (
+      !Number.isFinite(sec) ||
+      !Number.isFinite(nsec) ||
+      (sec === 0 && nsec === 0)
+    )
+      return "";
+    const msEpoch = sec * 1000 + Math.floor(nsec / 1_000_000);
+    const d = new Date(msEpoch);
+    const hh = String(d.getHours()).padStart(2, "0");
+    const mm = String(d.getMinutes()).padStart(2, "0");
+    const ss = String(d.getSeconds()).padStart(2, "0");
+    const ms = String(d.getMilliseconds()).padStart(3, "0");
+    return `${hh}:${mm}:${ss}.${ms}`;
+  }
+
+  get totalEvents(): number {
+    return this.traceGroups.reduce(
+      (acc, g) =>
+        acc +
+        (g.reduce((count, span) => count + (span.events?.length || 0), 0) || 0),
+      0,
+    );
+  }
+
+  // Helpers to compare HrTime
+  // Kept for the component's own time formatting etc; store has its own copies as well.
+  private toNanos(t?: HrTime): bigint {
+    if (!t) return -1n;
+    const [s, ns] = t;
+    if (!Number.isFinite(s) || !Number.isFinite(ns) || (s === 0 && ns === 0))
+      return -1n;
+    return BigInt(Math.trunc(s)) * 1_000_000_000n + BigInt(Math.trunc(ns));
+  }
+  private minHrTime(
+    a: HrTime | undefined,
+    b: HrTime | undefined,
+  ): HrTime | undefined {
+    const an = this.toNanos(a);
+    const bn = this.toNanos(b);
+    if (an < 0n) return b;
+    if (bn < 0n) return a;
+    return an <= bn ? a : b;
+  }
+  private maxHrTime(
+    a: HrTime | undefined,
+    b: HrTime | undefined,
+  ): HrTime | undefined {
+    const an = this.toNanos(a);
+    const bn = this.toNanos(b);
+    if (an < 0n) return b;
+    if (bn < 0n) return a;
+    return an >= bn ? a : b;
+  }
+}

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces.component.ts
@@ -3,8 +3,7 @@ import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
 import { ActivatedRoute } from "@angular/router";
 import { TraceGroupListComponent } from "./trace-group-list/trace-group-list.component";
-import { ReadableSpan, TimedEvent } from "@opentelemetry/sdk-trace-base";
-import { Attributes, HrTime, SpanStatusCode } from "@opentelemetry/api";
+import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 import { Subscription } from "rxjs";
 import { TracingService } from "../../services/tracing.service";
 

--- a/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.css
+++ b/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.css
@@ -1,5 +1,5 @@
 .traces .trace {
-  border: 1px solid #e5e5e5;
+  border: 1px solid var(--surface-border);
   border-radius: 4px;
   margin-bottom: 8px;
 }
@@ -7,21 +7,21 @@
 .traces .trace-header {
   cursor: pointer;
   padding: 6px 8px;
-  background: #fafafa;
-  border-bottom: 1px solid #eee;
+  background: var(--surface-offwhite);
+  border-bottom: 1px solid var(--divider);
 }
 
 .traces .trace.error .trace-header {
-  background: #fff5f5;
-  border-color: #f5c2c7;
+  background: var(--danger-tint);
+  border-color: var(--status-danger);
 }
 
 .traces .trace.error .trace-header strong {
-  color: #b02a37;
+  color: var(--status-danger);
 }
 
 .traces .trace-header .muted {
-  color: #777;
+  color: var(--text-muted-2);
   margin-left: 6px;
 }
 
@@ -33,7 +33,7 @@
   vertical-align: middle;
   border-top: 6px solid transparent;
   border-bottom: 6px solid transparent;
-  border-left: 6px solid #444;
+  border-left: 6px solid var(--text-default);
 }
 
 .traces .trace-header .caret.open {
@@ -62,12 +62,12 @@
 }
 
 .traces ul.kv .k {
-  color: #333;
+  color: var(--text-dark);
   margin-right: 4px;
 }
 
 .traces ul.kv .v {
-  color: #0a5;
+  color: var(--status-success);
 }
 
 .traces ul.events {
@@ -79,7 +79,7 @@
 .traces ul.events li {
   margin: 6px 0;
   padding: 6px 0;
-  border-bottom: 1px dashed #eee;
+  border-bottom: 1px dashed var(--divider);
 }
 
 .traces ul.events li:last-child {
@@ -88,7 +88,7 @@
 
 .traces .evt-time {
   margin-right: 6px;
-  color: #888;
+  color: var(--axis-text);
 }
 
 .traces .evt-name {
@@ -97,6 +97,6 @@
 }
 
 .traces .evt-span {
-  color: #555;
+  color: var(--text-default);
   margin-left: 6px;
 }

--- a/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.css
+++ b/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.css
@@ -1,0 +1,102 @@
+.traces .trace {
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.traces .trace-header {
+  cursor: pointer;
+  padding: 6px 8px;
+  background: #fafafa;
+  border-bottom: 1px solid #eee;
+}
+
+.traces .trace.error .trace-header {
+  background: #fff5f5;
+  border-color: #f5c2c7;
+}
+
+.traces .trace.error .trace-header strong {
+  color: #b02a37;
+}
+
+.traces .trace-header .muted {
+  color: #777;
+  margin-left: 6px;
+}
+
+.traces .trace-header .caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-right: 6px;
+  vertical-align: middle;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 6px solid #444;
+}
+
+.traces .trace-header .caret.open {
+  transform: rotate(90deg);
+}
+
+.traces .trace-body {
+  padding: 6px 8px;
+}
+
+.traces .section-title {
+  font-weight: 600;
+  margin: 6px 0 4px;
+}
+
+.traces ul.kv {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.traces ul.kv li {
+  font-family: monospace;
+  font-size: 12px;
+  padding: 1px 0;
+}
+
+.traces ul.kv .k {
+  color: #333;
+  margin-right: 4px;
+}
+
+.traces ul.kv .v {
+  color: #0a5;
+}
+
+.traces ul.events {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.traces ul.events li {
+  margin: 6px 0;
+  padding: 6px 0;
+  border-bottom: 1px dashed #eee;
+}
+
+.traces ul.events li:last-child {
+  border-bottom: 0;
+}
+
+.traces .evt-time {
+  margin-right: 6px;
+  color: #888;
+}
+
+.traces .evt-name {
+  font-weight: 600;
+  margin-right: 8px;
+}
+
+.traces .evt-span {
+  color: #555;
+  margin-left: 6px;
+}

--- a/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.html
+++ b/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.html
@@ -1,0 +1,45 @@
+<div class="traces" *ngIf="traces.length">
+  <div
+    class="trace"
+    *ngFor="let trace of traces; trackBy: trackByTrace"
+    [class.error]="getTraceError(trace)"
+  >
+    <div class="trace-header" (click)="toggleTrace(trace)">
+      <span class="caret" [class.open]="isTraceOpen(trace)"></span>
+      <strong>Trace {{ getTraceId(trace) }}</strong>
+      <small *ngIf="getStartTime(trace) || getEndTime(trace)">
+        ({{ formatHrTime(getStartTime(trace)) }} →
+        {{ formatHrTime(getEndTime(trace)) }})</small
+      >
+      <span class="muted"> — {{ getEvents(trace).length }} event(s)</span>
+      <span *ngIf="getTraceError(trace)" class="text-danger">
+        — {{ getTraceError(trace) }}</span
+      >
+    </div>
+    <div class="trace-body" *ngIf="isTraceOpen(trace)">
+      <ul class="events">
+        <li
+          class="event"
+          *ngFor="let e of getEvents(trace); trackBy: trackByEvent"
+        >
+          <div class="event-line">
+            <code class="evt-time">{{ formatHrTime(e.event.time) }}</code>
+            <span class="evt-name">{{ getEventTitle(e.event) }}</span>
+            <span class="evt-span"
+              >in <code>{{ e.spanId }}</code> • {{ e.spanName }}</span
+            >
+          </div>
+          <ul class="kv" *ngIf="hasNonMessageAttributes(e.event.attributes)">
+            <li
+              *ngFor="let kv of e.event.attributes | keyvalue"
+              [hidden]="kv.key === 'message'"
+            >
+              <span class="k">{{ kv.key }}</span>
+              <span class="v">{{ kv.value | json }}</span>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.ts
@@ -42,9 +42,7 @@ export class TraceGroupListComponent {
     }
   }
 
-  getEvents(
-    trace: ReadableSpan[],
-  ): {
+  getEvents(trace: ReadableSpan[]): {
     event: TimedEvent;
     spanId: string;
     spanName: string;

--- a/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.ts
@@ -1,0 +1,195 @@
+import { Component, Input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { Attributes, HrTime } from "@opentelemetry/api";
+import { OnInit } from "@angular/core";
+import { ReadableSpan, TimedEvent } from "@opentelemetry/sdk-trace-base";
+
+@Component({
+  selector: "app-trace-group-list",
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: "./trace-group-list.component.html",
+  styleUrls: ["./trace-group-list.component.css"],
+})
+export class TraceGroupListComponent {
+  @Input() traces: ReadableSpan[][] = [];
+
+  openedTraces = new Set<string>();
+
+  trackByTrace(index: number, trace: ReadableSpan[]): string {
+    return trace[0].spanContext().traceId;
+  }
+
+  trackByEvent(
+    index: number,
+    e: { event: TimedEvent; spanId: string; spanName: string; traceId: string },
+  ): string {
+    const t = e.event.time
+      ? `${e.event.time[0]}-${e.event.time[1]}`
+      : "no-time";
+
+    return `${e.traceId}/${e.spanId}/${e.event.name}/${t}`;
+  }
+
+  getEventTitle(e: TimedEvent): string {
+    const raw = (e.attributes as any)?.["message"];
+    if (raw === undefined || raw === null) return e.name;
+    if (typeof raw === "string") return raw;
+    try {
+      return JSON.stringify(raw);
+    } catch {
+      return String(raw);
+    }
+  }
+
+  getEvents(
+    trace: ReadableSpan[],
+  ): {
+    event: TimedEvent;
+    spanId: string;
+    spanName: string;
+    traceId: string;
+  }[] {
+    const events: {
+      event: TimedEvent;
+      spanId: string;
+      spanName: string;
+      traceId: string;
+    }[] = [];
+    console.log("Extracting events from trace:", trace);
+    for (const span of trace) {
+      for (const event of span.events || []) {
+        events.push({
+          event,
+          spanId: span.spanContext().spanId,
+          spanName: span.name,
+          traceId: span.spanContext().traceId,
+        });
+      }
+    }
+    console.log("Unsorted events:", events);
+    // Sort events by time
+    events.sort((a, b) => {
+      if (!a.event.time && !b.event.time) return 0;
+      if (!a.event.time) return -1;
+      if (!b.event.time) return 1;
+      if (a.event.time[0] !== b.event.time[0])
+        return a.event.time[0] - b.event.time[0];
+      return a.event.time[1] - b.event.time[1];
+    });
+    console.log("Extracted events:", events);
+    return events;
+  }
+
+  hasNonMessageAttributes(attrs?: Attributes): boolean {
+    if (!attrs) return false;
+    for (const k in attrs) {
+      if (Object.prototype.hasOwnProperty.call(attrs, k) && k !== "message")
+        return true;
+    }
+    return false;
+  }
+
+  formatHrTime(t?: HrTime): string {
+    if (!t) return "";
+    const [sec, nsec] = t;
+    if (
+      !Number.isFinite(sec) ||
+      !Number.isFinite(nsec) ||
+      (sec === 0 && nsec === 0)
+    )
+      return "";
+    const msEpoch = sec * 1000 + Math.floor(nsec / 1_000_000);
+    const d = new Date(msEpoch);
+    const hh = String(d.getHours()).padStart(2, "0");
+    const mm = String(d.getMinutes()).padStart(2, "0");
+    const ss = String(d.getSeconds()).padStart(2, "0");
+    const ms = String(d.getMilliseconds()).padStart(3, "0");
+    return `${hh}:${mm}:${ss}.${ms}`;
+  }
+
+  getEventSpanId(trace: ReadableSpan[], e: TimedEvent): string {
+    console.log("Finding span ID for event:", e, trace);
+    for (const span of trace) {
+      if (span.events?.includes(e)) {
+        return span.spanContext().spanId;
+      }
+    }
+    return "";
+  }
+
+  getEventSpanName(trace: ReadableSpan[], e: TimedEvent): string {
+    for (const span of trace) {
+      if (span.events?.includes(e)) {
+        return span.name;
+      }
+    }
+    return "";
+  }
+
+  getTraceError(trace: ReadableSpan[]): string | null {
+    for (const span of trace) {
+      if (span.status && span.status.code === 2) {
+        // 2 = ERROR
+        return span.status.message || "Error";
+      }
+    }
+    return null;
+  }
+
+  isTraceOpen(trace: ReadableSpan[]): boolean {
+    const traceId = trace[0].spanContext().traceId;
+    return this.openedTraces.has(traceId);
+  }
+  openTrace(trace: ReadableSpan[]): void {
+    const traceId = trace[0].spanContext().traceId;
+    this.openedTraces.add(traceId);
+  }
+  closeTrace(trace: ReadableSpan[]): void {
+    const traceId = trace[0].spanContext().traceId;
+    this.openedTraces.delete(traceId);
+  }
+  toggleTrace(trace: ReadableSpan[]): void {
+    const traceId = trace[0].spanContext().traceId;
+    if (this.openedTraces.has(traceId)) {
+      this.closeTrace(trace);
+    } else {
+      this.openTrace(trace);
+    }
+  }
+
+  getStartTime(trace: ReadableSpan[]): HrTime {
+    if (!trace || trace.length === 0) return [0, 0];
+    let start: HrTime | null = null;
+    for (const span of trace) {
+      if (span.startTime) {
+        start = start
+          ? start[0] < span.startTime[0]
+            ? start
+            : span.startTime
+          : span.startTime;
+      }
+    }
+    if (!start) return [0, 0];
+    return start;
+  }
+  getEndTime(trace: ReadableSpan[]): HrTime {
+    if (!trace || trace.length === 0) return [0, 0];
+    let end: HrTime | null = null;
+    for (const span of trace) {
+      if (span.endTime) {
+        end = end
+          ? end[0] > span.endTime[0]
+            ? end
+            : span.endTime
+          : span.endTime;
+      }
+    }
+    if (!end) return [0, 0];
+    return end;
+  }
+
+  getTraceId(trace: ReadableSpan[]): string {
+    return trace[0].spanContext().traceId;
+  }
+}

--- a/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input } from "@angular/core";
 import { CommonModule } from "@angular/common";
 import { Attributes, HrTime } from "@opentelemetry/api";
-import { OnInit } from "@angular/core";
 import { ReadableSpan, TimedEvent } from "@opentelemetry/sdk-trace-base";
 
 @Component({

--- a/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/trace-group-list/trace-group-list.component.ts
@@ -56,7 +56,6 @@ export class TraceGroupListComponent {
       spanName: string;
       traceId: string;
     }[] = [];
-    console.log("Extracting events from trace:", trace);
     for (const span of trace) {
       for (const event of span.events || []) {
         events.push({
@@ -67,7 +66,6 @@ export class TraceGroupListComponent {
         });
       }
     }
-    console.log("Unsorted events:", events);
     // Sort events by time
     events.sort((a, b) => {
       if (!a.event.time && !b.event.time) return 0;
@@ -77,7 +75,6 @@ export class TraceGroupListComponent {
         return a.event.time[0] - b.event.time[0];
       return a.event.time[1] - b.event.time[1];
     });
-    console.log("Extracted events:", events);
     return events;
   }
 
@@ -109,7 +106,6 @@ export class TraceGroupListComponent {
   }
 
   getEventSpanId(trace: ReadableSpan[], e: TimedEvent): string {
-    console.log("Finding span ID for event:", e, trace);
     for (const span of trace) {
       if (span.events?.includes(e)) {
         return span.spanContext().spanId;

--- a/webapp/src/main/webapp/src/app/pages/services/{serviceId}/operation/operation-override.page.html
+++ b/webapp/src/main/webapp/src/app/pages/services/{serviceId}/operation/operation-override.page.html
@@ -204,6 +204,13 @@
         <button type="button" class="btn btn-default" (click)="resetOperationProperties()">Reset</button>&nbsp;
         <button type="submit" class="btn btn-primary" (click)="saveOperationProperties()" ng-disabled="form.$invalid">Save</button>
       </div>
+
+      <br/><br/><br/>
+      <h3 class="section-label">Live Traces</h3>
+      <app-live-traces 
+        [initialServiceName]="view.service.name" 
+        [initialOperationName]="operationName">
+      </app-live-traces>
     </div>
     <div class="col-md-4 help-bar">
       <h3 class="section-label">Help needed?</h3>

--- a/webapp/src/main/webapp/src/app/pages/services/{serviceId}/operation/operation-override.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/services/{serviceId}/operation/operation-override.page.ts
@@ -40,6 +40,7 @@ import {
 } from '../../../../models/service.model';
 import { ServicesService } from '../../../../services/services.service';
 import { ConfigService } from '../../../../services/config.service';
+import { LiveTracesComponent } from '../../../../components/live-traces/live-traces.component';
 
 @Component({
   selector: 'app-operation-override-page',
@@ -49,7 +50,8 @@ import { ConfigService } from '../../../../services/config.service';
     CommonModule,
     FormsModule,
     RouterLink,
-    ToastNotificationListComponent
+    ToastNotificationListComponent,
+    LiveTracesComponent
   ],
 })
 export class OperationOverridePageComponent implements OnInit {

--- a/webapp/src/main/webapp/src/app/services/tracing.service.ts
+++ b/webapp/src/main/webapp/src/app/services/tracing.service.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { HttpClient, HttpParams } from "@angular/common/http";
+import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+
+import { ConfigService } from "./config.service";
+import { parseReadableSpans } from "../utils/otel-parser";
+
+@Injectable({ providedIn: "root" })
+export class TracingService {
+  private readonly rootUrl = "/api";
+
+  constructor(
+    private config: ConfigService,
+    private http: HttpClient,
+  ) {}
+
+  /**
+   * Get all trace IDs currently stored.
+   * @returns Observable of Set of trace IDs
+   */
+  getAllTraceIds(): Observable<Set<string>> {
+    return this.http.get<Set<string>>(`${this.rootUrl}/traces`);
+  }
+
+  /**
+   * Get all spans for a specific trace ID.
+   * @param traceId The trace ID to look up
+   * @returns Observable of List of spans for the trace
+   */
+  getSpansForTrace(traceId: string): Observable<any[]> {
+    return this.http.get<any[]>(`${this.rootUrl}/traces/${traceId}/spans`);
+  }
+
+  /**
+   * Get traces for a specific service operation.
+   * @param serviceName The service name
+   * @param operationName The operation name
+   * @param clientAddress The client address pattern (optional, defaults to '.*')
+   * @returns Observable of List of List of ReadableSpan
+   */
+  getTracesForOperation(
+    serviceName: string,
+    operationName: string,
+    clientAddress?: string,
+  ): Observable<ReadableSpan[][]> {
+    const params = new HttpParams()
+      .set("serviceName", serviceName)
+      .set("operationName", operationName)
+      .set("clientAddress", clientAddress || ".*");
+
+    return new Observable<ReadableSpan[][]>((subscriber) => {
+      this.http
+        .get<any[][]>(`${this.rootUrl}/traces/operations`, { params })
+        .subscribe({
+          next: (rawTraces) => {
+            // Parse each trace
+            const parsedTraces = rawTraces.map((traceGroup) =>
+              parseReadableSpans(traceGroup),
+            );
+            subscriber.next(parsedTraces);
+            subscriber.complete();
+          },
+          error: (err) => {
+            subscriber.error(err);
+          },
+        });
+    });
+  }
+
+  /**
+   * Clear all stored traces and spans.
+   * @returns Observable of success message
+   */
+  clearAllTraces(): Observable<string> {
+    return this.http.delete<string>(`${this.rootUrl}/traces`);
+  }
+
+  /**
+   * Open an SSE stream of spans for a given service/operation.
+   * Emits whenever a 'trace' event arrives with a JSON array of spans.
+   * The returned Observable will close the connection on unsubscribe.
+   */
+  streamSpans(
+    serviceName: string,
+    operationName: string,
+    clientAddress?: string,
+  ): Observable<ReadableSpan[]> {
+    return new Observable<ReadableSpan[]>((subscriber) => {
+      // Build query string safely
+      let params = new HttpParams()
+        .set("serviceName", serviceName)
+        .set("operationName", operationName)
+        .set("clientAddress", clientAddress || "*");
+
+      const url = `${this.rootUrl}/traces/operations/stream?${params.toString()}`;
+
+      // withCredentials allows cookies if backend uses session auth
+      const es = new EventSource(url, { withCredentials: true });
+
+      const onTrace = (evt: MessageEvent) => {
+        try {
+          const raw = JSON.parse(evt.data);
+          const spans = Array.isArray(raw) ? parseReadableSpans(raw) : [];
+          subscriber.next(spans);
+        } catch (err) {
+          subscriber.error(err);
+          // Keep the stream open; caller can resubscribe if needed
+        }
+      };
+
+      const onError = (err: any) => {
+        // EventSource reconnection is automatic; only close on fatal network errors.
+        // We forward the error for UI to optionally display status.
+        subscriber.error(err);
+        try {
+          es.close();
+        } catch {}
+      };
+
+      es.addEventListener("trace", onTrace as EventListener);
+      // Optional: handle default 'message' events if server doesn't name them
+      es.onmessage = onTrace;
+      es.onerror = onError as any;
+
+      // Cleanup on unsubscribe
+      return () => {
+        try {
+          es.removeEventListener("trace", onTrace as EventListener);
+          es.close();
+        } catch {}
+      };
+    });
+  }
+}

--- a/webapp/src/main/webapp/src/app/utils/trace-utils.ts
+++ b/webapp/src/main/webapp/src/app/utils/trace-utils.ts
@@ -1,0 +1,70 @@
+import { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+
+/**
+ * Extract trace event information from spans
+ * Looks for service.name, operation.name, and client.address attributes
+ */
+export interface TraceEvent {
+  traceId: string;
+  serviceName: string;
+  operationName: string;
+  clientAddress: string;
+}
+
+export function extractTraceEvent(spans: ReadableSpan[]): TraceEvent | null {
+  if (!spans || spans.length === 0) {
+    return null;
+  }
+
+  let serviceName: string | null = null;
+  let operationName: string | null = null;
+  let clientAddress: string | null = null;
+  let traceId: string | null = null;
+
+  // Iterate through spans to find the attributes
+  for (const span of spans) {
+    if (!span) {
+      continue;
+    }
+
+    // Get trace ID from span context
+    if (!traceId && span.spanContext) {
+      traceId = span.spanContext()?.traceId || null;
+    }
+
+    // Extract attributes
+    const attributes = span.attributes || {};
+    
+    // Look for service.name attribute
+    if (!serviceName && attributes['service.name']) {
+      serviceName = String(attributes['service.name']);
+    }
+
+    // Look for operation.name attribute
+    if (!operationName && attributes['operation.name']) {
+      operationName = String(attributes['operation.name']);
+    }
+
+    // Look for client.address attribute
+    if (!clientAddress && attributes['client.address']) {
+      clientAddress = String(attributes['client.address']);
+    }
+
+    // If we found all required attributes, we can stop
+    if (serviceName && operationName && clientAddress && traceId) {
+      break;
+    }
+  }
+
+  // Return null if we couldn't find the essential information
+  if (!serviceName || !operationName) {
+    return null;
+  }
+
+  return {
+    traceId: traceId || '',
+    serviceName,
+    operationName,
+    clientAddress: clientAddress || 'unknown'
+  };
+}

--- a/webapp/src/main/webapp/src/styles.css
+++ b/webapp/src/main/webapp/src/styles.css
@@ -51,6 +51,7 @@
     --text-muted-2: #757575; /* text-muted-2: tertiary labels */
     --background: #fff; /* background: main background */
     --accent-text: #fff; /* accent-text: links, highlights and button text color */
+    --danger-tint: #fff5f5; /* danger-tint: subtle error background */
   --overlay-scrim: rgba(0, 0, 0, 0.8); /* overlay-scrim: drag/drop backdrop */
 }
 


### PR DESCRIPTION
### Description
This PR adds the live traces component to the operation override page. The component is also available on the /traces page with additional customization.

I've just added the component to the page but i think we need to rethink the layout of the page to integrate it

### Related issue(s)

#1728 


https://github.com/user-attachments/assets/3ade8b65-7568-44e3-a2d6-80df1feababa

