### PR TITLE
fix: reflection config so that opentelemetry SpanData and Events are serialized correctly

### DIFF
--- a/distro/uber/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/distro/uber/src/main/resources/META-INF/native-image/reflect-config.json
@@ -32,6 +32,102 @@
     "allPermittedSubclasses": true
   },
   {
+    "name": "io.opentelemetry.sdk.trace.data.SpanData",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.opentelemetry.sdk.trace.data.EventData",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.opentelemetry.api.common.Attributes",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "io.opentelemetry.api.common.ArrayBackedAttributes",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "queryAllDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "asMap",
+        "parameterTypes": []
+      },
+      {
+        "name": "isEmpty",
+        "parameterTypes": []
+      },
+      {
+        "name": "size",
+        "parameterTypes": []
+      },
+      {
+        "name": "forEach",
+        "parameterTypes": ["java.util.function.BiConsumer"]
+      }
+    ]
+  },
+  {
+    "name": "io.opentelemetry.api.internal.ImmutableKeyValuePairs",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllDeclaredConstructors": true,
+    "queryAllDeclaredFields": true,
+    "queryAllPublicMethods": true,
+    "unsafeAllocated": true,
+    "methods": [
+      {
+        "name": "data",
+        "parameterTypes": []
+      },
+      {
+        "name": "size",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.opentelemetry.api.common.AttributeKey",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true,
+    "methods": [
+      {
+        "name": "getKey",
+        "parameterTypes": []
+      },
+      {
+        "name": "getType",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "java.util.AbstractMap$SimpleImmutableEntry",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true,
+    "queryAllDeclaredMethods": true,
+    "queryAllPublicMethods": true
+  },
+  {
     "condition": {
       "typeReachable": "io.grpc.netty.shaded.io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields"
     },


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
- This PR adds OpenTelemetry SDK classes to the native reflection configuration so serialization works correctly

### Related issue(s)

#1780 