### PR TITLE
feat: add a info box when the ip is filtered to the graph

### DIFF
--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/live-traces-graph.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/live-traces-graph.component.ts
@@ -50,6 +50,7 @@ interface HierarchyNodeData {
   label: string;
   type?: typeof ExternalUserNodeComponent;
   serviceName?: string;
+  clientIpFilter?: string;
   children?: HierarchyNodeData[];
 }
 
@@ -278,6 +279,7 @@ export class LiveTracesGraphComponent
       label: "External User",
       type: ExternalUserNodeComponent,
       children: children,
+      clientIpFilter: this.manager.clientIpFilter,
     };
 
     // Create d3 hierarchy
@@ -310,6 +312,12 @@ export class LiveTracesGraphComponent
       const label: string = nd.data.label;
 
       const payload: Record<string, unknown> = { label, kind };
+
+      // Add client IP filter for external user node
+      if (kind === "app" && nd.data.clientIpFilter) {
+        payload["clientIpFilter"] = nd.data.clientIpFilter;
+      }
+
       if (kind === "operation" && nd.data.serviceName) {
         payload["serviceName"] = nd.data.serviceName;
         payload["operationName"] = nd.data.label;

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/nodes/external-user-node.component.css
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/nodes/external-user-node.component.css
@@ -1,6 +1,6 @@
 .external-user-node {
   width: 140px;
-  height: 80px;
+  min-height: 80px;
   border: 2px solid var(--user-accent);
   border-radius: 8px;
   display: flex;
@@ -11,6 +11,7 @@
   box-shadow: 0 2px 8px color-mix(in srgb, var(--user-accent) 20%, transparent);
   transition: all 0.2s ease;
   cursor: pointer;
+  padding: 8px 4px;
 }
 
 .external-user-node:hover {
@@ -27,4 +28,24 @@
   font-weight: 600;
   color: var(--user-accent-dark);
   text-align: center;
+}
+
+.ip-filter-indicator {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  padding: 2px 6px;
+  background: color-mix(in srgb, var(--user-accent) 15%, transparent);
+  border-radius: 4px;
+  font-size: 10px;
+  color: var(--user-accent-dark);
+}
+
+.filter-text {
+  font-weight: 500;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/nodes/external-user-node.component.html
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/nodes/external-user-node.component.html
@@ -1,5 +1,11 @@
 <div class="external-user-node">
   <div class="node-icon">👤</div>
   <div class="node-label">External User</div>
+  @if (clientIpFilter()) {
+    <div class="ip-filter-indicator">
+      <span class="filter-icon fa fa-filter"></span>
+      <span class="filter-text">IP: {{ clientIpFilter() }}</span>
+    </div>
+  }
   <handle type="source" position="right" />
 </div>

--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/nodes/external-user-node.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/nodes/external-user-node.component.ts
@@ -19,6 +19,7 @@ import { Vflow, CustomDynamicNodeComponent } from "ngx-vflow";
 export interface ExternalUserNode {
   label: string;
   kind: string;
+  clientIpFilter?: string;
 }
 
 /**
@@ -32,4 +33,9 @@ export interface ExternalUserNode {
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ExternalUserNodeComponent extends CustomDynamicNodeComponent<ExternalUserNode> {}
+export class ExternalUserNodeComponent extends CustomDynamicNodeComponent<ExternalUserNode> {
+
+  clientIpFilter(): string | undefined {
+    return this.data()?.clientIpFilter !== ".*" ? this.data()?.clientIpFilter : undefined;
+  }
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
This PR add a info box in the External User node to show if the ip is filtered

<img width="2549" height="1305" alt="image" src="https://github.com/user-attachments/assets/bc1fc20a-46d1-47a3-8aa9-179a0d577220" />

### Related issue(s)
#1728 