### PR TITLE
QuickFix: jackson config to not fail on empty beans that happens in the Groovy exceptions

### DIFF
--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -3,6 +3,7 @@ spring.threads.virtual.enabled=true
 spring.servlet.multipart.max-file-size=${MAX_UPLOAD_FILE_SIZE:2MB}
 spring.jackson.serialization.write-dates-as-timestamps=true
 spring.jackson.default-property-inclusion=non_null
+spring.jackson.serialization.fail-on-empty-beans=false
 
 server.compression.enabled=true
 server.forward-headers-strategy=NATIVE


### PR DESCRIPTION
…

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
- This PR is a quick fix of the Serilization bug in the groovy exception

### Related issue(s)

#1801 