### PR TITLE
Fix: spacing between operation nodes by scaling the height by the number of operations

### DIFF
--- a/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/live-traces-graph.component.ts
+++ b/webapp/src/main/webapp/src/app/components/live-traces/live-traces-graph/live-traces-graph.component.ts
@@ -287,7 +287,7 @@ export class LiveTracesGraphComponent
 
     // Calculate tree dimensions (horizontal layout)
     const treeWidth = this.baseRadius + this.opRingRadius;
-    const treeHeight = 800; // Vertical spread
+    const treeHeight = Math.max(800, tracesMap.size * 90); // Vertical spread
     const tree = d3h
       .tree<any>()
       .size([treeHeight, treeWidth])


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
This PR implements height scaling with the number of operation nodes in the graph
<img width="812" height="903" alt="image" src="https://github.com/user-attachments/assets/ad669132-ac92-4db8-b249-6be9bbdcbe7e" />


### Related issue(s)

Resolves #1805 