### PR TITLE
 Fix SonarQube code smells - add private constructor and reduce regex complexity

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/UTF8ContentTypeChecker.java
+++ b/webapp/src/main/java/io/github/microcks/util/UTF8ContentTypeChecker.java
@@ -20,8 +20,12 @@ import java.util.regex.Matcher;
 
 public class UTF8ContentTypeChecker {
    private static final Pattern UTF8_ENCODABLE_PATTERN = Pattern.compile(
-         "^(text/[a-z0-9.+-]+|application/([a-z0-9.+-]*\\+(json|xml)|json|xml|javascript|x-www-form-urlencoded))(\\s*;.*)?$",
+         "^(text/[a-z0-9.+-]+|application/([a-z0-9.+-]+\\+)?(json|xml)|application/(javascript|x-www-form-urlencoded))(\\s*;.*)?$",
          Pattern.CASE_INSENSITIVE);
+
+   private UTF8ContentTypeChecker() {
+      // Private constructor to prevent instantiation
+   }
 
    public static boolean isUtf8Encodable(String contentType) {
       if (contentType == null)


### PR DESCRIPTION

Fixes two SonarQube issues in `UTF8ContentTypeChecker`:

1. Add private constructor to hide implicit public one
2. Simplify regular expression to reduce complexity from 21 to 20

## Changes
- Added private constructor to prevent instantiation of utility class
- Refactored regex pattern to reduce cognitive complexity while maintaining functionality
- All existing tests pass

<img width="2280" height="564" alt="image" src="https://github.com/user-attachments/assets/6fa1f29e-1f55-4aba-844b-0f863785fe98" />


<img width="1544" height="798" alt="image" src="https://github.com/user-attachments/assets/b9a8cbf4-662f-4c25-b206-0fab17a30334" />

 
### Related issue(s)
#1714