### PR TITLE
Explicitly define the QuickJs4J annotation processor

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -211,12 +211,6 @@
       <artifactId>quickjs4j-annotations</artifactId>
       <version>${quickjs4j.version}</version>
     </dependency>
-    <dependency>
-        <groupId>io.roastedroot</groupId>
-        <artifactId>quickjs4j-processor</artifactId>
-        <version>${quickjs4j.version}</version>
-        <scope>compile</scope>
-    </dependency>
 
     <dependency>
       <groupId>io.grpc</groupId>
@@ -327,7 +321,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.14.1</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
@@ -335,6 +329,13 @@
           <compilerArgument>-Xlint:deprecation</compilerArgument>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
           <compilerArgument>-parameters</compilerArgument>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.roastedroot</groupId>
+              <artifactId>quickjs4j-processor</artifactId>
+              <version>${quickjs4j.version}</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Fix `webapp` module build on Java 25.

### Description

Starting with Java 23 (and Java 25) annotation processing in `javac` is disabled by default.
Ref: https://inside.java/2024/06/18/quality-heads-up/?utm_source=chatgpt.com

### Related issue(s)

Fix #1910 