### PR TITLE
chore(sonar): batch 1 mechanical cleanup

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncMinionApp.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncMinionApp.java
@@ -15,20 +15,15 @@
  */
 package io.github.microcks.minion.async;
 
-import io.github.microcks.domain.EventMessage;
-import io.github.microcks.domain.Exchange;
 import io.github.microcks.domain.Operation;
-import io.github.microcks.domain.RequestReplyEvent;
 import io.github.microcks.domain.Service;
 import io.github.microcks.domain.ServiceType;
 import io.github.microcks.domain.ServiceView;
-import io.github.microcks.domain.UnidirectionalEvent;
 
 import io.github.microcks.minion.async.client.ConnectorException;
 import io.github.microcks.minion.async.client.KeycloakConfig;
 import io.github.microcks.minion.async.client.KeycloakConnector;
 import io.github.microcks.minion.async.client.MicrocksAPIConnector;
-import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -42,7 +37,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 /**
  * A Minion App for dealing with Async message mocks.

--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncMockDefinitionUpdater.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncMockDefinitionUpdater.java
@@ -30,7 +30,6 @@ import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.jboss.logging.Logger;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -118,12 +117,10 @@ public class AsyncMockDefinitionUpdater {
    }
 
    public static List<EventMessage> getMessages(List<? extends Exchange> exchanges) {
-      return exchanges.stream().flatMap(e -> {
-         return switch (e) {
-            case UnidirectionalEvent u -> Stream.of(u.getEventMessage());
-            case RequestReplyEvent r -> Stream.of(r.getRequestMessage(), r.getReplyMessage());
-            default -> Stream.empty();
-         };
+      return exchanges.stream().flatMap(e -> switch (e) {
+         case UnidirectionalEvent u -> Stream.of(u.getEventMessage());
+         case RequestReplyEvent r -> Stream.of(r.getRequestMessage(), r.getReplyMessage());
+         default -> Stream.empty();
       }).toList();
    }
 }

--- a/webapp/src/main/java/io/github/microcks/listener/ServiceChangeEventPublisher.java
+++ b/webapp/src/main/java/io/github/microcks/listener/ServiceChangeEventPublisher.java
@@ -20,7 +20,6 @@ import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.RequestResponsePair;
 import io.github.microcks.domain.Service;
 import io.github.microcks.domain.ServiceType;
-import io.github.microcks.domain.UnidirectionalEvent;
 import io.github.microcks.event.ChangeType;
 import io.github.microcks.event.ServiceChangeEvent;
 import io.github.microcks.event.ServiceViewChangeEvent;

--- a/webapp/src/test/java/io/github/microcks/MicrocksApplicationFuzz.java
+++ b/webapp/src/test/java/io/github/microcks/MicrocksApplicationFuzz.java
@@ -110,7 +110,7 @@ public class MicrocksApplicationFuzz {
             (host, portD) -> host.equals("localhost") && portD.equals(mongoDBContainer.getMappedPort(27017)))) {
 
          String name = data.consumeRemainingAsString();
-         apiTest(mockMvc, "/api/version/info", get("/api/version/info").param("name", name));
+         apiTest(mockMvc, get("/api/version/info").param("name", name));
       }
    }
 
@@ -125,11 +125,11 @@ public class MicrocksApplicationFuzz {
             (host, portD) -> host.equals("localhost") && portD.equals(mongoDBContainer.getMappedPort(27017)))) {
 
          int page = data.consumeInt(0, 10);
-         apiTest(mockMvc, "/api/services", get("/api/services").param("page", String.valueOf(page)));
+         apiTest(mockMvc, get("/api/services").param("page", String.valueOf(page)));
 
          String serviceId = data.consumeAsciiString(32);
          String encodedServiceId = URLEncoder.encode(serviceId, StandardCharsets.UTF_8);
-         apiTest(mockMvc, "/api/services/" + encodedServiceId, get("/api/services/" + encodedServiceId));
+         apiTest(mockMvc, get("/api/services/" + encodedServiceId));
       }
    }
 
@@ -154,14 +154,8 @@ public class MicrocksApplicationFuzz {
       log.info("Just uploaded: {}", response.getBody());
    }
 
-   protected static ResultActions apiTest(MockMvc mockMvc, String requestURI,
-         MockHttpServletRequestBuilder requestBuilder) throws Exception {
-      String method = requestBuilder.buildRequest(mockMvc.getDispatcherServlet().getServletContext()).getMethod();
-
-      try {
-         return mockMvc.perform(requestBuilder);
-      } catch (Exception e) {
-         throw e;
-      }
+   protected static ResultActions apiTest(MockMvc mockMvc, MockHttpServletRequestBuilder requestBuilder)
+         throws Exception {
+      return mockMvc.perform(requestBuilder);
    }
 }

--- a/webapp/src/test/java/io/github/microcks/service/MessageServiceTest.java
+++ b/webapp/src/test/java/io/github/microcks/service/MessageServiceTest.java
@@ -261,14 +261,14 @@ class MessageServiceTest {
       assertEquals(3, results.size());
 
       // Count types
-      long unidirectionalCount = results.stream().filter(e -> e instanceof UnidirectionalEvent).count();
-      long requestReplyCount = results.stream().filter(e -> e instanceof RequestReplyEvent).count();
+      long unidirectionalCount = results.stream().filter(UnidirectionalEvent.class::isInstance).count();
+      long requestReplyCount = results.stream().filter(RequestReplyEvent.class::isInstance).count();
 
       assertEquals(2, unidirectionalCount);
       assertEquals(1, requestReplyCount);
 
       // Verify the request-reply event
-      RequestReplyEvent requestReply = results.stream().filter(e -> e instanceof RequestReplyEvent)
+      RequestReplyEvent requestReply = results.stream().filter(RequestReplyEvent.class::isInstance)
             .map(e -> (RequestReplyEvent) e).findFirst().orElse(null);
 
       assertNotNull(requestReply);


### PR DESCRIPTION
Address low-risk Sonar issues:
- remove unused imports
- simplify single-expression lambda
- replace lambda filters with method references
- remove unused parameter/assignment in fuzz helper 


(cherry picked from commit 1e548260f5c9e4a2166d58b63ba5d46fa937daa6) from https://github.com/microcks/microcks/pull/1971

### Related issue(s)
https://github.com/microcks/microcks/issues/1883