### PR TITLE
fix(sonar): correctness and security

### DIFF
--- a/webapp/src/main/java/io/github/microcks/listener/CallbackTrigger.java
+++ b/webapp/src/main/java/io/github/microcks/listener/CallbackTrigger.java
@@ -43,6 +43,7 @@ import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -71,8 +72,17 @@ public class CallbackTrigger implements ApplicationListener<CallbackTriggerEvent
 
       // Find the callbackInfo and callback name.
       CallbackInfo callbackInfo = selectCallbackInfo(event);
+      if (callbackInfo == null) {
+         log.warn("No callbackInfo found on operation {}", event.getOperation().getName());
+         return;
+      }
       String callbackName = event.getOperation().getCallbackInfos().entrySet().stream()
-            .filter(entry -> entry.getValue().equals(callbackInfo)).findFirst().get().getKey();
+            .filter(entry -> entry.getValue().equals(callbackInfo)).map(Map.Entry::getKey).findFirst().orElse(null);
+      if (callbackName == null) {
+         log.warn("No callback name found for callbackInfo {} on operation {}", callbackInfo,
+               event.getOperation().getName());
+         return;
+      }
 
       // Check if we're able to find a callback url.
       String callbackUrlLocation = callbackInfo.getCallbackUrlExpression();
@@ -92,7 +102,9 @@ public class CallbackTrigger implements ApplicationListener<CallbackTriggerEvent
             try {
                Thread.sleep(Duration.ofSeconds(3));
             } catch (InterruptedException e) {
+               Thread.currentThread().interrupt();
                log.warn("Interrupted while simulating waiting for callback request to be send", e);
+               return;
             }
 
             log.debug("Calling callback URL {} with request {}", callbackUrl, callbackRequest.getName());
@@ -118,9 +130,13 @@ public class CallbackTrigger implements ApplicationListener<CallbackTriggerEvent
 
    /** Select the correct callback info from event operation. */
    private CallbackInfo selectCallbackInfo(CallbackTriggerEvent event) {
+      if (event.getOperation().getCallbackInfos() == null || event.getOperation().getCallbackInfos().isEmpty()) {
+         return null;
+      }
+
       // Sort by order the CallbackInfo from included event operation.
       List<CallbackInfo> infos = event.getOperation().getCallbackInfos().values().stream()
-            .sorted((info1, info2) -> Comparator.comparingInt(CallbackInfo::getOrder).compare(info1, info2)).toList();
+            .sorted(Comparator.comparing(CallbackInfo::getOrder, Comparator.nullsLast(Integer::compareTo))).toList();
 
       log.debug("Ordered callbackInfos:");
       for (CallbackInfo info : infos) {

--- a/webapp/src/main/java/io/github/microcks/listener/ListenerCommons.java
+++ b/webapp/src/main/java/io/github/microcks/listener/ListenerCommons.java
@@ -65,8 +65,8 @@ public class ListenerCommons {
          engine.getContext().setVariable("request", evaluableRequest);
          try {
             return engine.getValue(contentTemplate);
-         } catch (Throwable t) {
-            log.error("Failing at evaluating template {}", contentTemplate, t);
+         } catch (Exception e) {
+            log.error("Failing at evaluating template {}", contentTemplate, e);
          }
       }
       return contentTemplate;

--- a/webapp/src/main/java/io/github/microcks/task/TriggerWebhookTask.java
+++ b/webapp/src/main/java/io/github/microcks/task/TriggerWebhookTask.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -110,18 +111,27 @@ public class TriggerWebhookTask {
          List<WebhookRegistration> toRemove, List<WebhookRegistration> toUpdate) {
       try {
          sendWebhookRequests(registration, requests);
-      } catch (Exception e) {
+      } catch (InterruptedException e) {
+         Thread.currentThread().interrupt();
+         log.error("Error while sending webhook request to {}", registration.getTargetUrl(), e);
+         handleWebhookFailure(registration, toRemove, toUpdate);
+      } catch (IOException e) {
          log.error("Error while sending webhook request to {}", registration.getTargetUrl());
-         // Increment error count and check against threshold.
-         registration.setErrorCount(registration.getErrorCount() + 1);
-         if (registration.getErrorCount() >= registration.getErrorCountThreshold()) {
-            log.error("Webhook registration {} has reached error threshold {} and will be removed",
-                  registration.getId(), registration.getErrorCountThreshold());
-            toRemove.add(registration);
-         } else {
-            // Keep track for update.
-            toUpdate.add(registration);
-         }
+         handleWebhookFailure(registration, toRemove, toUpdate);
+      }
+   }
+
+   private void handleWebhookFailure(WebhookRegistration registration, List<WebhookRegistration> toRemove,
+         List<WebhookRegistration> toUpdate) {
+      // Increment error count and check against threshold.
+      registration.setErrorCount(registration.getErrorCount() + 1);
+      if (registration.getErrorCount() >= registration.getErrorCountThreshold()) {
+         log.error("Webhook registration {} has reached error threshold {} and will be removed", registration.getId(),
+               registration.getErrorCountThreshold());
+         toRemove.add(registration);
+      } else {
+         // Keep track for update.
+         toUpdate.add(registration);
       }
    }
 
@@ -136,7 +146,8 @@ public class TriggerWebhookTask {
       }
    }
 
-   private void sendWebhookRequests(WebhookRegistration registration, List<Request> requests) throws Exception {
+   private void sendWebhookRequests(WebhookRegistration registration, List<Request> requests)
+         throws IOException, InterruptedException {
       // Build the http client and send the request in a fire and forget mode.
       HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2))
             .version(HttpClient.Version.HTTP_1_1).build();

--- a/webapp/src/main/java/io/github/microcks/web/WebhookController.java
+++ b/webapp/src/main/java/io/github/microcks/web/WebhookController.java
@@ -88,7 +88,7 @@ public class WebhookController {
       // Check Service and Operation exist.
       String[] parts = registrationRequest.getOperationId().split("-");
       if (parts.length != 2) {
-         log.error("Invalid operationId '{}'", registrationRequest.getOperationId());
+         log.error("Invalid operationId received for webhook registration");
          return new ResponseEntity<>("OperationId is invalid", HttpStatus.NOT_FOUND);
       }
       String serviceId = parts[0];


### PR DESCRIPTION
Address Sonar issues in listener/task/controller paths:
- avoid Optional#get without presence check
- preserve interrupt status on InterruptedException
- catch Exception instead of Throwable
- replace generic throws Exception with specific checked exceptions
- remove user-controlled value from webhook operationId error log path

(cherry picked from commit bdead9dfa7a0cd86050497f9e8460dbc6e240597) from https://github.com/microcks/microcks/pull/1971

### Related issue(s)
https://github.com/microcks/microcks/issues/1883
