### PR TITLE
fix(sonar): type and serialization cleanup

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/ReplyInfo.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/ReplyInfo.java
@@ -15,6 +15,7 @@
  */
 package io.github.microcks.domain;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,13 +24,16 @@ import java.util.Map;
  * reply address and the channel address where replies are sent.
  * @author adamhicks
  */
-public class ReplyInfo implements BindingsHolder {
+public class ReplyInfo implements Serializable, BindingsHolder {
+
+   private static final long serialVersionUID = 2402252041950251207L;
 
    private String addressLocation;
    private String channelAddress;
    private Map<String, Binding> bindings;
 
    public ReplyInfo() {
+      // Default constructor for framework deserialization.
    }
 
    public String getAddressLocation() {

--- a/webapp/src/main/java/io/github/microcks/service/MessageService.java
+++ b/webapp/src/main/java/io/github/microcks/service/MessageService.java
@@ -15,7 +15,13 @@
  */
 package io.github.microcks.service;
 
-import io.github.microcks.domain.*;
+import io.github.microcks.domain.EventMessage;
+import io.github.microcks.domain.Exchange;
+import io.github.microcks.domain.Request;
+import io.github.microcks.domain.RequestReplyEvent;
+import io.github.microcks.domain.RequestResponsePair;
+import io.github.microcks.domain.Response;
+import io.github.microcks.domain.UnidirectionalEvent;
 import io.github.microcks.repository.EventMessageRepository;
 import io.github.microcks.repository.RequestRepository;
 import io.github.microcks.repository.ResponseRepository;
@@ -63,7 +69,7 @@ public class MessageService {
     * @param operationId The identifier of operation to get messages for.
     * @return A list of event messages
     */
-   public List<? extends Exchange> getEventByOperation(String operationId) {
+   public List<Exchange> getEventByOperation(String operationId) {
       // Retrieve event messages using operation identifier.
       List<EventMessage> eventMessages = eventMessageRepository.findByOperationId(operationId);
       if (log.isDebugEnabled()) {
@@ -99,7 +105,7 @@ public class MessageService {
     * @param testCaseId The identifier of test case to get messages for.
     * @return A list of unidirectional event messages
     */
-   public List<? extends Exchange> getEventByTestCase(String testCaseId) {
+   public List<Exchange> getEventByTestCase(String testCaseId) {
       // Retrieve events using testCase identifier.
       List<EventMessage> eventMessages = eventMessageRepository.findByTestCaseId(testCaseId);
       if (log.isDebugEnabled()) {
@@ -130,7 +136,7 @@ public class MessageService {
       return results;
    }
 
-   private List<? extends Exchange> createEvents(List<EventMessage> eventMessages) {
+   private List<Exchange> createEvents(List<EventMessage> eventMessages) {
       List<Exchange> results = new ArrayList<>(eventMessages.size());
 
       Set<String> replyIds = eventMessages.stream().map(EventMessage::getReplyId).filter(Objects::nonNull)

--- a/webapp/src/main/java/io/github/microcks/web/TestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/TestController.java
@@ -157,7 +157,7 @@ public class TestController {
    }
 
    @GetMapping(value = "tests/{id}/events/{testCaseId}")
-   public List<? extends Exchange> getEventMessagesForTestCase(@PathVariable("id") String testResultId,
+   public List<Exchange> getEventMessagesForTestCase(@PathVariable("id") String testResultId,
          @PathVariable("testCaseId") String testCaseId) {
       // We may have testCaseId being URLEncoded, with forbidden '/' replaced by '_' so unwrap id.
       // Switched form _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal


### PR DESCRIPTION
Address Sonar issues around wildcard API types and serialization:
- use List<Exchange> return types in MessageService event APIs
- align TestController event endpoint return type
- make ReplyInfo Serializable and document default constructor intent

(cherry picked from commit 82c324326b0f50e187e71712f13538539e435a9e) from https://github.com/microcks/microcks/pull/1971


### Related issue(s)
https://github.com/microcks/microcks/issues/1883