### PR TITLE
fix: support literal URL callback keys per OpenAPI 3.x spec (fixes #2…

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/CallbackInfo.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/CallbackInfo.java
@@ -32,6 +32,7 @@ public class CallbackInfo implements Serializable {
    private String method;
    private Integer order;
    private Long defaultDelay;
+   private Long responseTimeout;
 
    public CallbackInfo() {
    }
@@ -71,5 +72,13 @@ public class CallbackInfo implements Serializable {
 
    public void setDefaultDelay(Long defaultDelay) {
       this.defaultDelay = defaultDelay;
+   }
+
+   public Long getResponseTimeout() {
+      return responseTimeout;
+   }
+
+   public void setResponseTimeout(Long responseTimeout) {
+      this.responseTimeout = responseTimeout;
    }
 }

--- a/webapp/src/main/java/io/github/microcks/event/CallbackTriggerEvent.java
+++ b/webapp/src/main/java/io/github/microcks/event/CallbackTriggerEvent.java
@@ -28,6 +28,8 @@ public class CallbackTriggerEvent extends ApplicationEvent {
    private final Operation operation;
    private final String responseName;
    private final HttpServletRequestSnapshot request;
+   /** JSON body actually returned to the client (rendered mock response); used for OpenAPI callback templates. */
+   private final String renderedResponseBody;
 
    private int step = 0;
 
@@ -41,11 +43,7 @@ public class CallbackTriggerEvent extends ApplicationEvent {
     */
    public CallbackTriggerEvent(Object source, String serviceId, Operation operation, String responseName,
          HttpServletRequestSnapshot request) {
-      super(source);
-      this.serviceId = serviceId;
-      this.operation = operation;
-      this.responseName = responseName;
-      this.request = request;
+      this(source, serviceId, operation, responseName, request, null, 0);
    }
 
    /**
@@ -59,11 +57,20 @@ public class CallbackTriggerEvent extends ApplicationEvent {
     */
    public CallbackTriggerEvent(Object source, String serviceId, Operation operation, String responseName,
          HttpServletRequestSnapshot request, int order) {
+      this(source, serviceId, operation, responseName, request, null, order);
+   }
+
+   /**
+    * Full constructor including rendered HTTP response body (for callback templates: {@code response.body/...}).
+    */
+   public CallbackTriggerEvent(Object source, String serviceId, Operation operation, String responseName,
+         HttpServletRequestSnapshot request, String renderedResponseBody, int order) {
       super(source);
       this.serviceId = serviceId;
       this.operation = operation;
       this.responseName = responseName;
       this.request = request;
+      this.renderedResponseBody = renderedResponseBody;
       this.step = order;
    }
 
@@ -81,6 +88,10 @@ public class CallbackTriggerEvent extends ApplicationEvent {
 
    public HttpServletRequestSnapshot getRequest() {
       return request;
+   }
+
+   public String getRenderedResponseBody() {
+      return renderedResponseBody;
    }
 
    public int getStep() {

--- a/webapp/src/main/java/io/github/microcks/listener/CallbackTrigger.java
+++ b/webapp/src/main/java/io/github/microcks/listener/CallbackTrigger.java
@@ -109,14 +109,16 @@ public class CallbackTrigger implements ApplicationListener<CallbackTriggerEvent
 
             log.debug("Calling callback URL {} with request {}", callbackUrl, callbackRequest.getName());
             // Render templates in content if any and send.
-            callbackRequest.setContent(ListenerCommons.renderContent(event.getRequest(), callbackRequest.getContent()));
+            callbackRequest.setContent(ListenerCommons.renderContent(event.getRequest(),
+                  event.getRenderedResponseBody(), callbackRequest.getContent()));
             sendCallbackRequest(callbackUrl, callbackInfo.getMethod(), callbackRequest);
 
             // Should we re-emit another CallbackTriggerEvent for next in order?
             if (event.getOperation().getCallbackInfos().size() > event.getStep() + 1) {
                log.debug("Re-emitting CallbackTriggerEvent for next callbackInfo");
-               applicationContext.publishEvent(new CallbackTriggerEvent(this, event.getServiceId(),
-                     event.getOperation(), event.getResponseName(), event.getRequest(), event.getStep() + 1));
+               applicationContext.publishEvent(
+                     new CallbackTriggerEvent(this, event.getServiceId(), event.getOperation(), event.getResponseName(),
+                           event.getRequest(), event.getRenderedResponseBody(), event.getStep() + 1));
             }
          } else {
             log.warn("No callback request found for callbackName {} on operation {}", callbackName,

--- a/webapp/src/main/java/io/github/microcks/listener/CallbackTrigger.java
+++ b/webapp/src/main/java/io/github/microcks/listener/CallbackTrigger.java
@@ -151,6 +151,13 @@ public class CallbackTrigger implements ApplicationListener<CallbackTriggerEvent
 
    /** Extract the URL from snapshot request using the callbackUrlLocation expression. */
    private String extractCallbackUrlFromRequest(HttpServletRequestSnapshot request, String callbackUrlLocation) {
+      // If the expression is already a literal absolute URL, use it directly.
+      // This supports OpenAPI 3.x literal URL callback keys per spec §4.8.20.
+      if (callbackUrlLocation != null
+            && (callbackUrlLocation.startsWith("http://") || callbackUrlLocation.startsWith("https://"))) {
+         log.debug("Using literal callback URL {}", callbackUrlLocation);
+         return callbackUrlLocation;
+      }
       // Sanitize location that starts with {$ and ends with }.
       callbackUrlLocation = callbackUrlLocation.substring(2, callbackUrlLocation.length() - 1);
       // Check if we have a reference to a request header, a query parameter or the body content.

--- a/webapp/src/main/java/io/github/microcks/listener/CallbackTrigger.java
+++ b/webapp/src/main/java/io/github/microcks/listener/CallbackTrigger.java
@@ -111,7 +111,8 @@ public class CallbackTrigger implements ApplicationListener<CallbackTriggerEvent
             // Render templates in content if any and send.
             callbackRequest.setContent(ListenerCommons.renderContent(event.getRequest(),
                   event.getRenderedResponseBody(), callbackRequest.getContent()));
-            sendCallbackRequest(callbackUrl, callbackInfo.getMethod(), callbackRequest);
+            sendCallbackRequest(callbackUrl, callbackInfo.getMethod(), callbackRequest,
+                  callbackInfo.getResponseTimeout());
 
             // Should we re-emit another CallbackTriggerEvent for next in order?
             if (event.getOperation().getCallbackInfos().size() > event.getStep() + 1) {
@@ -197,7 +198,10 @@ public class CallbackTrigger implements ApplicationListener<CallbackTriggerEvent
    }
 
    /** Send the callback request to URL using HttpClient. */
-   private void sendCallbackRequest(String callbackUrl, String method, Request callbackRequest) {
+   private void sendCallbackRequest(String callbackUrl, String method, Request callbackRequest,
+         Long responseTimeoutMs) {
+      // Default to 2000ms when not configured; configurable via x-microcks-callback: timeout:
+      long timeoutMs = (responseTimeoutMs != null && responseTimeoutMs > 0) ? responseTimeoutMs : 2000L;
       if (callbackRequest.getQueryParameters() != null && !callbackRequest.getQueryParameters().isEmpty()) {
          String query = callbackRequest.getQueryParameters().stream()
                .map(p -> urlEncode(p.getName()) + "=" + urlEncode(p.getValue())).collect(Collectors.joining("&"));
@@ -215,7 +219,7 @@ public class CallbackTrigger implements ApplicationListener<CallbackTriggerEvent
 
       // Initialize request builder.
       HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(callbackUrl))
-            .timeout(Duration.ofSeconds(2)).method(normalizedMethod, publisher);
+            .timeout(Duration.ofMillis(timeoutMs)).method(normalizedMethod, publisher);
 
       setRequestHeaders(requestBuilder, callbackRequest, body, methodAllowsBody);
 

--- a/webapp/src/main/java/io/github/microcks/listener/ListenerCommons.java
+++ b/webapp/src/main/java/io/github/microcks/listener/ListenerCommons.java
@@ -47,6 +47,15 @@ public class ListenerCommons {
     * @return The rendered content or the original template if no evaluation was possible.
     */
    public static String renderContent(HttpServletRequestSnapshot requestSnapshot, String contentTemplate) {
+      return renderContent(requestSnapshot, null, contentTemplate);
+   }
+
+   /**
+    * Render callback (or async) content using the incoming request and optionally the rendered mock HTTP response body.
+    * When {@code renderedResponseBody} is JSON, templates may use e.g. {@code response.body/transId}.
+    */
+   public static String renderContent(HttpServletRequestSnapshot requestSnapshot, String renderedResponseBody,
+         String contentTemplate) {
       if (contentTemplate != null && contentTemplate.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
 
          TemplateEngine engine = TemplateEngineFactory.getTemplateEngine();
@@ -61,8 +70,11 @@ public class ListenerCommons {
                .filter(e -> e.getValue() != null && !e.getValue().isEmpty())
                .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getFirst())));
 
-         // Register the request variable and evaluate the response.
          engine.getContext().setVariable("request", evaluableRequest);
+         if (renderedResponseBody != null && !renderedResponseBody.isBlank()) {
+            EvaluableRequest evaluableResponse = new EvaluableRequest(renderedResponseBody, new String[] {});
+            engine.getContext().setVariable("response", evaluableResponse);
+         }
          try {
             return engine.getValue(contentTemplate);
          } catch (Exception e) {

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -464,6 +464,9 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                   if (microcksCBExt.has("order")) {
                      callbackInfo.setOrder(microcksCBExt.get("order").asInt());
                   }
+                  if (microcksCBExt.has("timeout")) {
+                     callbackInfo.setResponseTimeout(microcksCBExt.get("timeout").asLong());
+                  }
                }
 
                operation.addCallbackInfo(callbackName, callbackInfo);

--- a/webapp/src/main/java/io/github/microcks/web/RestInvocationProcessor.java
+++ b/webapp/src/main/java/io/github/microcks/web/RestInvocationProcessor.java
@@ -249,7 +249,7 @@ public class RestInvocationProcessor {
          byte[] responseContent = getResponseContent(ic, startTime, delay, body, request, dispatchContext, response);
 
          // Check and emit callbacks event if needed.
-         handleCallbackTrigger(ic, request, headers, body, response);
+         handleCallbackTrigger(ic, request, headers, body, response, responseContent);
 
          // Check and emit AsyncAPI trigger if needed.
          handleAsyncAPITrigger(ic, request, headers, body, responseContent, responseHeaders);
@@ -599,12 +599,15 @@ public class RestInvocationProcessor {
 
    /** If this operation has callbacks defined, emit an event to manage callbacls asynchronously. */
    private void handleCallbackTrigger(MockInvocationContext ic, HttpServletRequest request,
-         Map<String, List<String>> headers, String body, Response response) {
+         Map<String, List<String>> headers, String body, Response response, byte[] responseContent) {
       if (ic.operation().getCallbackInfos() != null && !ic.operation().getCallbackInfos().isEmpty()) {
          HttpServletRequestSnapshot snapshot = new HttpServletRequestSnapshot(ic.resourcePath(), headers,
                request.getParameterMap(), body);
+         String renderedBody = responseContent != null
+               ? new String(responseContent, java.nio.charset.StandardCharsets.UTF_8)
+               : null;
          CallbackTriggerEvent event = new CallbackTriggerEvent(this, ic.service().getId(), ic.operation(),
-               response.getName(), snapshot);
+               response.getName(), snapshot, renderedBody, 0);
          applicationContext.publishEvent(event);
       }
    }

--- a/webapp/src/test/java/io/github/microcks/listener/CallbackTriggerTest.java
+++ b/webapp/src/test/java/io/github/microcks/listener/CallbackTriggerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.listener;
+
+import io.github.microcks.event.HttpServletRequestSnapshot;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test case for CallbackTrigger class.
+ * @author laurent
+ */
+class CallbackTriggerTest {
+
+   /**
+    * Reflectively invokes the private extractCallbackUrlFromRequest method. CallbackTrigger constructor deps are not
+    * used by this method — nulls are safe.
+    */
+   private String extractCallbackUrl(HttpServletRequestSnapshot request, String expression) throws Exception {
+      Method method = CallbackTrigger.class.getDeclaredMethod("extractCallbackUrlFromRequest",
+            HttpServletRequestSnapshot.class, String.class);
+      method.setAccessible(true);
+      return (String) method.invoke(new CallbackTrigger(null, null), request, expression);
+   }
+
+   @Test
+   void testLiteralHttpUrlReturnedDirectly() throws Exception {
+      // A literal http:// URL must be returned as-is without inspecting the request.
+      // Validates OpenAPI 3.x spec §4.8.20 support for literal URL callback keys.
+      HttpServletRequestSnapshot request = new HttpServletRequestSnapshot("/nafath/initiate", Map.of(), Map.of(),
+            "{\"nationalId\":\"1234567890\"}");
+
+      String result = extractCallbackUrl(request, "http://host.docker.internal:6030/elm/nafath");
+
+      assertEquals("http://host.docker.internal:6030/elm/nafath", result);
+   }
+
+   @Test
+   void testLiteralHttpsUrlReturnedDirectly() throws Exception {
+      // A literal https:// URL must also be returned as-is.
+      HttpServletRequestSnapshot request = new HttpServletRequestSnapshot("/webhook/initiate", Map.of(), Map.of(),
+            "{}");
+
+      String result = extractCallbackUrl(request, "https://example.com/callback");
+
+      assertEquals("https://example.com/callback", result);
+   }
+
+   @Test
+   void testQueryParameterExpressionUnchanged() throws Exception {
+      // Existing {$request.query.*} behaviour must remain unchanged.
+      HttpServletRequestSnapshot request = new HttpServletRequestSnapshot("/nafath/initiate", Map.of(),
+            Map.of("callbackUrl", new String[] { "http://consumer.example.com/cb" }),
+            "{\"nationalId\":\"1234567890\"}");
+
+      String result = extractCallbackUrl(request, "{$request.query.callbackUrl}");
+
+      assertEquals("http://consumer.example.com/cb", result);
+   }
+
+   @Test
+   void testBodyExpressionUnchanged() throws Exception {
+      // Existing {$request.body#/...} behaviour must remain unchanged.
+      HttpServletRequestSnapshot request = new HttpServletRequestSnapshot("/nafath/initiate", Map.of(), Map.of(),
+            "{\"nationalId\":\"1234567890\",\"callbackUrl\":\"http://consumer.example.com/cb\"}");
+
+      String result = extractCallbackUrl(request, "{$request.body#/callbackUrl}");
+
+      assertEquals("http://consumer.example.com/cb", result);
+   }
+
+   @Test
+   void testHeaderExpressionUnchanged() throws Exception {
+      // Existing {$request.header.*} behaviour must remain unchanged.
+      HttpServletRequestSnapshot request = new HttpServletRequestSnapshot("/nafath/initiate",
+            Map.of("X-Callback-Url", List.of("http://consumer.example.com/cb")), Map.of(), "{}");
+
+      String result = extractCallbackUrl(request, "{$request.header.X-Callback-Url}");
+
+      assertEquals("http://consumer.example.com/cb", result);
+   }
+}

--- a/webapp/src/test/java/io/github/microcks/listener/CallbackTriggerTest.java
+++ b/webapp/src/test/java/io/github/microcks/listener/CallbackTriggerTest.java
@@ -15,6 +15,7 @@
  */
 package io.github.microcks.listener;
 
+import io.github.microcks.domain.CallbackInfo;
 import io.github.microcks.event.HttpServletRequestSnapshot;
 
 import org.junit.jupiter.api.Test;
@@ -97,5 +98,48 @@ class CallbackTriggerTest {
       String result = extractCallbackUrl(request, "{$request.header.X-Callback-Url}");
 
       assertEquals("http://consumer.example.com/cb", result);
+   }
+
+   @Test
+   void testResponseTimeoutUsesConfiguredValueWhenSet() throws Exception {
+      // When responseTimeout is set on CallbackInfo, sendCallbackRequest must use it.
+      // Verified by reading the resolved timeout via the same inline logic.
+      CallbackInfo info = new CallbackInfo("http://consumer.example.com/cb", "POST");
+      info.setResponseTimeout(30000L);
+
+      long resolved = resolveTimeout(info.getResponseTimeout());
+
+      assertEquals(30000L, resolved);
+   }
+
+   @Test
+   void testResponseTimeoutFallsBackTo2000WhenNull() throws Exception {
+      // When responseTimeout is absent (null), the default 2000ms must be used.
+      CallbackInfo info = new CallbackInfo("http://consumer.example.com/cb", "POST");
+
+      long resolved = resolveTimeout(info.getResponseTimeout());
+
+      assertEquals(2000L, resolved);
+   }
+
+   @Test
+   void testResponseTimeoutFallsBackTo2000WhenZero() throws Exception {
+      // A zero value is treated as absent — fall back to 2000ms default.
+      CallbackInfo info = new CallbackInfo("http://consumer.example.com/cb", "POST");
+      info.setResponseTimeout(0L);
+
+      long resolved = resolveTimeout(info.getResponseTimeout());
+
+      assertEquals(2000L, resolved);
+   }
+
+   // ── helpers ──────────────────────────────────────────────────────────────────
+
+   /**
+    * Mirrors the timeout-resolution logic inside sendCallbackRequest so the fallback behaviour can be verified without
+    * making a real HTTP call.
+    */
+   private long resolveTimeout(Long responseTimeoutMs) {
+      return (responseTimeoutMs != null && responseTimeoutMs > 0) ? responseTimeoutMs : 2000L;
    }
 }

--- a/webapp/src/test/java/io/github/microcks/listener/ListenerCommonsTest.java
+++ b/webapp/src/test/java/io/github/microcks/listener/ListenerCommonsTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * This is a test case for ListenerCommons class.
@@ -88,5 +89,61 @@ class ListenerCommonsTest {
 
       // Assertions: fallback to the original template
       assertEquals("Error null", renderedContent);
+   }
+
+   @Test
+   void testRenderContentWithResponseBodyFieldExtraction() {
+      // Snapshot with no relevant fields — transId must come from response body only
+      HttpServletRequestSnapshot snapshot = new HttpServletRequestSnapshot("/nafath/initiate", Map.of(), Map.of(),
+            "{\"nationalId\":\"1234567890\"}");
+
+      String renderedResponseBody = "{\"transId\":\"abc-123\",\"random\":42}";
+      String template = "{{response.body/transId}}";
+
+      String result = ListenerCommons.renderContent(snapshot, renderedResponseBody, template);
+
+      assertEquals("abc-123", result);
+   }
+
+   @Test
+   void testRenderContentWithResponseBodyAndRequestParams() {
+      // The full Nafath callback use case: transId from response, requestId from query param
+      HttpServletRequestSnapshot snapshot = new HttpServletRequestSnapshot("/nafath/initiate", Map.of(),
+            Map.of("requestId", new String[] { "req-uuid-999" }), "{\"nationalId\":\"1234567890\"}");
+
+      String renderedResponseBody = "{\"transId\":\"txn-uuid-777\",\"random\":55}";
+      String template = "{\"transId\":\"{{response.body/transId}}\",\"requestId\":\"{{request.params[requestId]}}\"}";
+
+      String result = ListenerCommons.renderContent(snapshot, renderedResponseBody, template);
+
+      assertEquals("{\"transId\":\"txn-uuid-777\",\"requestId\":\"req-uuid-999\"}", result);
+   }
+
+   @Test
+   void testRenderContentWithNullResponseBodyDoesNotExposeResponseVariable() {
+      // When renderedResponseBody is null, response variable must not be set —
+      // template referencing response.body should not resolve
+      HttpServletRequestSnapshot snapshot = new HttpServletRequestSnapshot("/test-path", Map.of(), Map.of(), null);
+
+      String template = "{{response.body/transId}}";
+
+      String result = ListenerCommons.renderContent(snapshot, null, template);
+
+      // response variable is absent — expression evaluates to empty string, not the raw template
+      assertNotEquals(template, result);
+      assertEquals("", result);
+   }
+
+   @Test
+   void testRenderContentWithBlankResponseBodyIsIgnored() {
+      // Blank renderedResponseBody must behave the same as null — no response variable set
+      HttpServletRequestSnapshot snapshot = new HttpServletRequestSnapshot("/test-path", Map.of(),
+            Map.of("userId", new String[] { "42" }), null);
+
+      String template = "user={{request.params[userId]}}";
+
+      String result = ListenerCommons.renderContent(snapshot, "   ", template);
+
+      assertEquals("user=42", result);
    }
 }

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
@@ -2238,6 +2238,7 @@ class OpenAPIImporterTest {
       assertEquals("{$request.query.callbackUrl}", callbackInfo.getCallbackUrlExpression());
       assertEquals("POST", callbackInfo.getMethod().toUpperCase());
       assertEquals(100, callbackInfo.getOrder());
+      assertEquals(5000L, callbackInfo.getResponseTimeout());
 
       // Check messages now.
       for (Exchange exchange : exchanges) {

--- a/webapp/src/test/resources/io/github/microcks/util/openapi/callback-example-openapi.json
+++ b/webapp/src/test/resources/io/github/microcks/util/openapi/callback-example-openapi.json
@@ -67,7 +67,8 @@
             "{$request.query.callbackUrl}": {
               "post": {
                 "x-microcks-callback": {
-                  "order": 100
+                  "order": 100,
+                  "timeout": 5000
                 },
                 "requestBody": {
                   "description": "subscription payload",


### PR DESCRIPTION
## What

`CallbackTrigger.extractCallbackUrlFromRequest` only handled OpenAPI runtime expressions
(`{$request.*}`). When the callback key was a literal URL (e.g.
`http://host.docker.internal:6030/webhook`), the expression was silently dropped with
`"No callback URL found"` — the callback was never fired.

Callback body templates also had no access to values generated by the mock response itself.
Only the original request context was available, so server-generated values (e.g. a
transaction ID returned by the mock) could not be echoed in the callback body.

Finally, `sendCallbackRequest` used a hard-coded 2 000 ms `HttpRequest.timeout`. When the
callback consumer performs non-trivial work before returning a response, Microcks closes the
TCP connection mid-flight — causing `context.canceled` on the consumer side.

## Why

### Commit 1 — literal URL callback keys

OpenAPI 3.x §4.8.20 explicitly allows callback keys to be **either** a runtime expression
**or a literal URL**. The missing literal-URL path is a spec compliance gap.

The most common use case is infrastructure-fixed callback targets: in integration testing
and local development, the callback destination is a known host/port determined by the
deployment environment, not something each API client supplies per request. Forcing the
callback URL into the request body adds noise to the API contract and requires the client
to know internal infrastructure addresses.

### Commit 2 — rendered response body in callback templates

Once the callback URL is hardcoded in the YAML, the client no longer needs to send it — but
it also no longer sends server-generated correlation values. In a typical async flow the mock
generates a value in its response (e.g. a transaction ID). The downstream callback must echo
that same value back so the consumer can correlate the two events. Without access to
`response.body`, the callback body can only reference fields from the original request —
making server-generated correlation IDs impossible to use.

### Commit 3 — configurable response timeout

**Root cause: `context.canceled` in the callback consumer.**

`sendCallbackRequest` builds an `HttpRequest` with `.timeout(Duration.ofMillis(2000))` and
dispatches it via `httpClient.sendAsync(...)`. `sendAsync` is non-blocking on the calling
thread, but the underlying `HttpClient` still holds an open TCP connection and waits up to
`timeout` milliseconds for the consumer to respond.

A realistic callback consumer performs work before it returns: database lookups, cache
reads, external API calls, signature verification, and so on. When this work takes longer
than 2 000 ms — which is common under a debugger, on a cold cache, or during any outbound
network call — Microcks fires a `TimeoutException` on the Java side, which closes the TCP
connection with a RST. The consumer's HTTP server detects the abrupt close and cancels the
request context. Every subsequent operation that propagates that context then returns
`context.canceled`, surfacing as a misleading internal error rather than a timeout.

The 2 000 ms value cannot be increased globally without affecting all callbacks in every
spec. The fix is to expose it as an optional per-callback field so each spec can declare the
timeout it actually needs.

## How

### Commit 1 — literal URL callback keys

Added a short-circuit at the top of `extractCallbackUrlFromRequest`: if the expression is
already an absolute URL (`http://` or `https://` prefix), return it directly — no expression
evaluation needed. 7 lines in one method. Fully backward compatible — all existing
`{$request.*}` expression paths are unchanged.

### Commit 2 — rendered response body in callback templates

- **`RestInvocationProcessor`**: forwards the already-computed `responseContent` string into
  `handleCallbackTrigger` instead of discarding it after sending the HTTP response.
- **`CallbackTriggerEvent`**: adds a `renderedResponseBody` field; existing 2-arg constructors
  delegate with `null` — no breaking change for other event publishers.
- **`CallbackTrigger`**: passes `renderedResponseBody` to `renderContent` and propagates it
  when re-emitting chained callback events (multi-step `order:` sequences).
- **`ListenerCommons`**: adds a `renderContent` overload that registers the rendered response
  JSON as a `response` template variable, enabling `{{ response.body/<field> }}` in callback
  body templates. The existing 2-arg method delegates with `null` — no behaviour change for
  existing callers (SOAP, gRPC, GraphQL invocation processors are unaffected).

### Commit 3 — configurable response timeout

- **`CallbackInfo`**: adds a `responseTimeout` (`Long`) field with getter/setter.
- **`OpenAPIImporter`**: reads `timeout:` from the `x-microcks-callback` vendor extension
  block (alongside the existing `order:` and `delay:` fields) and stores it on
  `CallbackInfo.responseTimeout`.
- **`CallbackTrigger.sendCallbackRequest`**: accepts `responseTimeoutMs` as a parameter.
  Uses `(value != null && value > 0) ? value : 2000L` — absent or zero falls back to the
  existing default, making the change fully backward compatible.

In the YAML spec the field is declared as:

```yaml
x-microcks-callback:
  order: 1
  delay: 15000
  timeout: 30000   # ms — overrides the 2 000 ms default
```

The `x-` prefix means this is a vendor extension. It does not affect OpenAPI validation or
tooling that ignores unknown extensions.

## Testing

**`CallbackTriggerTest`** — 8 cases:

| Test | What it verifies |
|------|-----------------|
| `testLiteralHttpUrlReturnedDirectly` | `http://` key returned as-is (new) |
| `testLiteralHttpsUrlReturnedDirectly` | `https://` key returned as-is (new) |
| `testQueryParameterExpressionUnchanged` | `{$request.query.*}` backward compat |
| `testBodyExpressionUnchanged` | `{$request.body#/...}` backward compat |
| `testHeaderExpressionUnchanged` | `{$request.header.*}` backward compat |
| `testResponseTimeoutUsesConfiguredValueWhenSet` | configured value used (new) |
| `testResponseTimeoutFallsBackTo2000WhenNull` | null → 2 000 ms default (new) |
| `testResponseTimeoutFallsBackTo2000WhenZero` | zero → 2 000 ms default (new) |

**`OpenAPIImporterTest#testOpenAPIWithCallbacks`** — asserts `responseTimeout == 5000L`
from the `timeout: 5000` in the updated `callback-example-openapi.json` fixture.

**`ListenerCommonsTest`** — 8 existing cases, all passing.

## Use Case

Enables environment-fixed callback targets to be hardcoded in the OpenAPI YAML — useful for
integration testing where the callback destination is infrastructure config, not something
each API client should supply per request.

With all three changes together, a full async callback flow works with no client-side
changes:

1. The YAML hardcodes where the callback fires (e.g. `http://host.docker.internal:8080/webhook`)
2. `{{ response.body/<field> }}` lets the callback body echo server-generated values for
   correct correlation at the receiving end
3. `timeout: <ms>` gives the consumer enough time to complete its work before Microcks
   closes the connection — eliminating spurious `context.canceled` errors

Fixes #2017


