### PR TITLE
feat(async): Implement request-reply for kafka

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncMinionApp.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncMinionApp.java
@@ -19,11 +19,11 @@ import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Service;
 import io.github.microcks.domain.ServiceType;
 import io.github.microcks.domain.ServiceView;
-
 import io.github.microcks.minion.async.client.ConnectorException;
 import io.github.microcks.minion.async.client.KeycloakConfig;
 import io.github.microcks.minion.async.client.KeycloakConnector;
 import io.github.microcks.minion.async.client.MicrocksAPIConnector;
+import io.github.microcks.minion.async.handler.RequestReplyHandlerManager;
 import io.quarkus.runtime.StartupEvent;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -40,6 +40,7 @@ import java.util.Optional;
 
 /**
  * A Minion App for dealing with Async message mocks.
+ *
  * @author laurent
  */
 @ApplicationScoped
@@ -64,24 +65,28 @@ public class AsyncMinionApp {
    final AsyncMockRepository mockRepository;
    final SchemaRegistry schemaRegistry;
    final ProducerScheduler producerScheduler;
+   final RequestReplyHandlerManager requestReplyHandlerManager;
 
    /**
     * Build a new instance of the AsyncMinionApp with required dependencies.
-    * @param microcksAPIConnector to access Microcks API
-    * @param keycloakConnector    to access Keycloak server for authentication
-    * @param mockRepository       to store and retrieve mock definitions
-    * @param schemaRegistry       to store and retrieve schema definitions
-    * @param producerScheduler    to initiate producer jobs
+    *
+    * @param microcksAPIConnector       to access Microcks API
+    * @param keycloakConnector          to access Keycloak server for authentication
+    * @param mockRepository             to store and retrieve mock definitions
+    * @param schemaRegistry             to store and retrieve schema definitions
+    * @param producerScheduler          to initiate producer jobs
+    * @param requestReplyHandlerManager to manage request-reply handlers
     */
    public AsyncMinionApp(@RestClient MicrocksAPIConnector microcksAPIConnector, KeycloakConnector keycloakConnector,
-         AsyncMockRepository mockRepository, SchemaRegistry schemaRegistry, ProducerScheduler producerScheduler) {
+         AsyncMockRepository mockRepository, SchemaRegistry schemaRegistry, ProducerScheduler producerScheduler,
+         RequestReplyHandlerManager requestReplyHandlerManager) {
       this.microcksAPIConnector = microcksAPIConnector;
       this.keycloakConnector = keycloakConnector;
       this.mockRepository = mockRepository;
       this.schemaRegistry = schemaRegistry;
       this.producerScheduler = producerScheduler;
+      this.requestReplyHandlerManager = requestReplyHandlerManager;
    }
-
 
    /** Application startup method. */
    void onStart(@Observes StartupEvent ev) {
@@ -98,7 +103,8 @@ public class AsyncMinionApp {
       }
 
       try {
-         // First retrieve an authentication token before fetching async messages to publish.
+         // First retrieve an authentication token before fetching async messages to
+         // publish.
          String oauthToken;
          if (config.isEnabled()) {
             // We've got a full Keycloak config, attempt an authent.
@@ -149,6 +155,9 @@ public class AsyncMinionApp {
 
          logger.info("Starting scheduling of all producer jobs...");
          producerScheduler.scheduleAllProducerJobs();
+
+         logger.info("Starting all request-reply handlers...");
+         requestReplyHandlerManager.startAllHandlers();
 
       } catch (ConnectorException ce) {
          logger.error("Cannot authenticate to Keycloak server and thus enable to call Microcks API"

--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncMockDefinitionUpdater.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncMockDefinitionUpdater.java
@@ -24,6 +24,7 @@ import io.github.microcks.domain.UnidirectionalEvent;
 import io.github.microcks.domain.RequestReplyEvent;
 import io.github.microcks.event.ChangeType;
 import io.github.microcks.event.ServiceViewChangeEvent;
+import io.github.microcks.minion.async.handler.RequestReplyHandlerManager;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
@@ -37,6 +38,7 @@ import java.util.stream.Stream;
 /**
  * This bean is responsible for listening the incoming <code>ServiceViewChangeEvent</code> on
  * <code>microcks-services-updates</code> Kafka topic and updating the AsyncMockRepository accordingly.
+ *
  * @author laurent
  */
 @ApplicationScoped
@@ -53,15 +55,20 @@ public class AsyncMockDefinitionUpdater {
 
    final AsyncMockRepository mockRepository;
    final SchemaRegistry schemaRegistry;
+   final RequestReplyHandlerManager requestReplyHandlerManager;
 
    /**
     * Create a new AsyncMockDefinitionUpdater with required dependencies.
-    * @param mockRepository The repository for mock definitions
-    * @param schemaRegistry The registry for schema definitions
+    *
+    * @param mockRepository             The repository for mock definitions
+    * @param schemaRegistry             The registry for schema definitions
+    * @param requestReplyHandlerManager The manager for request-reply handlers
     */
-   public AsyncMockDefinitionUpdater(AsyncMockRepository mockRepository, SchemaRegistry schemaRegistry) {
+   public AsyncMockDefinitionUpdater(AsyncMockRepository mockRepository, SchemaRegistry schemaRegistry,
+         RequestReplyHandlerManager requestReplyHandlerManager) {
       this.mockRepository = mockRepository;
       this.schemaRegistry = schemaRegistry;
+      this.requestReplyHandlerManager = requestReplyHandlerManager;
    }
 
    @Incoming("microcks-services-updates")
@@ -78,13 +85,15 @@ public class AsyncMockDefinitionUpdater {
          logger.infof("Removing mock definitions for %s", serviceViewChangeEvent.getServiceId());
          mockRepository.removeMockDefinitions(serviceViewChangeEvent.getServiceId());
          schemaRegistry.clearRegistryForService(serviceViewChangeEvent.getServiceId());
+         requestReplyHandlerManager.stopHandlersForService(serviceViewChangeEvent.getServiceId());
       } else {
          // Only deal with service of type EVENT...
          if (serviceViewChangeEvent.getServiceView() != null && (serviceViewChangeEvent.getServiceView().getService()
                .getType().equals(ServiceType.EVENT)
                || serviceViewChangeEvent.getServiceView().getService().getType().equals(ServiceType.GENERIC_EVENT))) {
 
-            // Browse and check operation regarding restricted frequencies and supported bindings.
+            // Browse and check operation regarding restricted frequencies and supported
+            // bindings.
             boolean scheduled = scheduleOperations(serviceViewChangeEvent.getServiceView());
 
             if (!scheduled) {
@@ -92,12 +101,15 @@ public class AsyncMockDefinitionUpdater {
                      serviceViewChangeEvent.getServiceId());
                mockRepository.removeMockDefinitions(serviceViewChangeEvent.getServiceId());
                schemaRegistry.clearRegistryForService(serviceViewChangeEvent.getServiceId());
+               requestReplyHandlerManager.stopHandlersForService(serviceViewChangeEvent.getServiceId());
             }
          }
       }
    }
 
-   /** Browse and check operation regarding restricted frequencies and supported bindings. */
+   /**
+    * Browse and check operation regarding restricted frequencies and supported bindings.
+    */
    private boolean scheduleOperations(ServiceView serviceView) {
       boolean scheduled = false;
       for (Operation operation : serviceView.getService().getOperations()) {
@@ -110,6 +122,13 @@ public class AsyncMockDefinitionUpdater {
                   getMessages(serviceView.getMessagesMap().get(operation.getName())));
             mockRepository.storeMockDefinition(mockDefinition);
             schemaRegistry.updateRegistryForService(mockDefinition.getOwnerService());
+
+            // If this is a request-reply operation, start a handler for it
+            if (mockDefinition.isRequestReply()) {
+               logger.info("Starting request-reply handler for " + operation.getName());
+               requestReplyHandlerManager.startHandlerForDefinition(mockDefinition);
+            }
+
             scheduled = true;
          }
       }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/handler/EventData.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/handler/EventData.java
@@ -1,0 +1,80 @@
+package io.github.microcks.minion.async.handler;
+
+import com.fasterxml.jackson.core.exc.StreamReadException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.microcks.domain.EventMessage;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Compute dispatch criteria for async request-reply events.
+ */
+public class EventData {
+
+   private static final Logger LOGGER = Logger.getLogger(EventData.class);
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   private EventData() {
+   }
+
+   public static boolean matchesExpectedMessage(EventMessage expMessage, String payload) {
+      if (expMessage == null) {
+         return false;
+      }
+      String expectedCriteria = expMessage.getContent();
+      if (expectedCriteria == null || expectedCriteria.isBlank()) {
+         return true;
+      }
+      try {
+         JsonNode expectedNode = MAPPER.readTree(expectedCriteria);
+         JsonNode incomingNode = MAPPER.readTree(payload);
+         return isJsonSubset(expectedNode, incomingNode);
+      } catch (StreamReadException e) {
+         LOGGER.errorf("message data is not valid JSON: %s", e.getMessage());
+         return false;
+
+      } catch (IOException e) {
+         LOGGER.errorf("Error reading expected message data: %s", e.getMessage());
+         return false;
+      }
+   }
+
+   private static boolean isJsonSubset(JsonNode expectedNode, JsonNode incomingNode) {
+      if (expectedNode == null || incomingNode == null) {
+         return expectedNode == incomingNode;
+      }
+
+      if (expectedNode.isObject()) {
+         if (!incomingNode.isObject()) {
+            return false;
+         }
+         Iterator<String> fieldNames = expectedNode.fieldNames();
+         while (fieldNames.hasNext()) {
+            String fieldName = fieldNames.next();
+            JsonNode expectedFieldValue = expectedNode.get(fieldName);
+            JsonNode incomingFieldValue = incomingNode.get(fieldName);
+            if (incomingFieldValue == null || !isJsonSubset(expectedFieldValue, incomingFieldValue)) {
+               return false;
+            }
+         }
+         return true;
+      }
+
+      if (expectedNode.isArray()) {
+         if (!incomingNode.isArray() || expectedNode.size() != incomingNode.size()) {
+            return false;
+         }
+         for (int i = 0; i < expectedNode.size(); i++) {
+            if (!isJsonSubset(expectedNode.get(i), incomingNode.get(i))) {
+               return false;
+            }
+         }
+         return true;
+      }
+
+      return expectedNode.equals(incomingNode);
+   }
+}

--- a/minions/async/src/main/java/io/github/microcks/minion/async/handler/EventData.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/handler/EventData.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.github.microcks.minion.async.handler;
 
 import com.fasterxml.jackson.core.exc.StreamReadException;
@@ -11,11 +26,13 @@ import java.util.Iterator;
 
 /**
  * Compute dispatch criteria for async request-reply events.
+ *
+ * @author adamhicks
  */
 public class EventData {
 
-   private static final Logger LOGGER = Logger.getLogger(EventData.class);
-   private static final ObjectMapper MAPPER = new ObjectMapper();
+   private static final Logger logger = Logger.getLogger(EventData.class);
+   private static final ObjectMapper mapper = new ObjectMapper();
 
    private EventData() {
    }
@@ -29,15 +46,15 @@ public class EventData {
          return true;
       }
       try {
-         JsonNode expectedNode = MAPPER.readTree(expectedCriteria);
-         JsonNode incomingNode = MAPPER.readTree(payload);
+         JsonNode expectedNode = mapper.readTree(expectedCriteria);
+         JsonNode incomingNode = mapper.readTree(payload);
          return isJsonSubset(expectedNode, incomingNode);
       } catch (StreamReadException e) {
-         LOGGER.errorf("message data is not valid JSON: %s", e.getMessage());
+         logger.errorf("message data is not valid JSON: %s", e.getMessage());
          return false;
 
       } catch (IOException e) {
-         LOGGER.errorf("Error reading expected message data: %s", e.getMessage());
+         logger.errorf("Error reading expected message data: %s", e.getMessage());
          return false;
       }
    }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandler.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandler.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.handler;
+
+import io.github.microcks.domain.Binding;
+import io.github.microcks.domain.EventMessage;
+import io.github.microcks.domain.Header;
+import io.github.microcks.minion.async.AsyncMockDefinition;
+import io.github.microcks.minion.async.SchemaRegistry;
+import io.github.microcks.minion.async.producer.KafkaProducerManager;
+import io.github.microcks.util.el.EvaluableRequest;
+import io.github.microcks.util.el.TemplateEngine;
+import io.github.microcks.util.el.TemplateEngineFactory;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.eclipse.microprofile.config.Config;
+import org.jboss.logging.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Kafka implementation of request-reply handler. Listens for incoming request messages on a Kafka topic and sends
+ * correlated replies.
+ *
+ * @author adamhicks
+ */
+public class KafkaRequestReplyHandler implements RequestReplyHandler {
+
+   /** Get a JBoss logging logger. */
+   private final Logger logger = Logger.getLogger(getClass());
+
+   private final AsyncMockDefinition mockDefinition;
+   private final Binding binding;
+   private final KafkaProducerManager producerManager;
+   private final SchemaRegistry schemaRegistry;
+   private final Config config;
+
+   private KafkaConsumer<String, byte[]> consumer;
+   private Thread consumerThread;
+   private final AtomicBoolean running = new AtomicBoolean(false);
+
+   /**
+    * Create a new Kafka request-reply handler.
+    *
+    * @param mockDefinition  The mock definition containing operation and messages
+    * @param binding         The Kafka binding information
+    * @param producerManager The producer manager for sending replies
+    * @param schemaRegistry  The schema registry for message schemas
+    * @param config          The application configuration
+    */
+   public KafkaRequestReplyHandler(AsyncMockDefinition mockDefinition, Binding binding,
+         KafkaProducerManager producerManager, SchemaRegistry schemaRegistry, Config config) {
+      this.mockDefinition = mockDefinition;
+      this.binding = binding;
+      this.producerManager = producerManager;
+      this.schemaRegistry = schemaRegistry;
+      this.config = config;
+   }
+
+   @Override
+   public void start() throws Exception {
+      if (running.get()) {
+         logger.warn("Handler already running");
+         return;
+      }
+
+      logger.infof("Starting Kafka request-reply handler for %s - %s",
+            mockDefinition.getOwnerService().getName() + ":" + mockDefinition.getOwnerService().getVersion(),
+            mockDefinition.getOperation().getName());
+
+      // Create Kafka consumer
+      consumer = createConsumer();
+
+      // Start consumer thread
+      running.set(true);
+      consumerThread = new Thread(this::consumeLoop, "kafka-request-reply-" + getRequestTopic());
+      consumerThread.start();
+
+      logger.infof("Kafka request-reply handler started for %s", getRequestTopic());
+   }
+
+   @Override
+   public void stop() {
+      if (!running.get()) {
+         return;
+      }
+
+      logger.infof("Stopping Kafka request-reply handler for %s", getRequestTopic());
+
+      running.set(false);
+
+      if (consumer != null) {
+         consumer.wakeup();
+      }
+
+      if (consumerThread != null) {
+         try {
+            consumerThread.join(5000); // Wait up to 5 seconds for graceful shutdown
+         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.warn("Interrupted while waiting for consumer thread to stop");
+         }
+      }
+
+      if (consumer != null) {
+         consumer.close();
+      }
+
+      logger.infof("Kafka request-reply handler stopped for %s", getRequestTopic());
+   }
+
+   @Override
+   public boolean isRunning() {
+      return running.get();
+   }
+
+   @Override
+   public AsyncMockDefinition getMockDefinition() {
+      return mockDefinition;
+   }
+
+   /** Main consumer loop - runs in separate thread. */
+   private void consumeLoop() {
+      logger.debugf("Starting consume loop for %s", getRequestTopic());
+
+      try {
+         while (running.get()) {
+            ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofMillis(1000));
+
+            for (ConsumerRecord<String, byte[]> record : records) {
+               handleRequest(record);
+            }
+         }
+      } catch (org.apache.kafka.common.errors.WakeupException e) {
+         // Expected on shutdown
+         logger.debug("Consumer wakeup called, shutting down");
+      } catch (Exception e) {
+         logger.errorf(e, "Unexpected error in consume loop for %s", getRequestTopic());
+      } finally {
+         logger.debugf("Exiting consume loop for %s", getRequestTopic());
+      }
+   }
+
+   /** Handle a single request message and send the corresponding reply. */
+   private void handleRequest(ConsumerRecord<String, byte[]> record) {
+      logger.debugf("Received request message on %s", getRequestTopic());
+
+      // Build an EvaluableRequest from the incoming Kafka request record.
+      String requestBody = new String(record.value(), StandardCharsets.UTF_8);
+      EvaluableRequest evaluableRequest = new EvaluableRequest(requestBody, null);
+
+      // Extract request headers and make them available.
+      Map<String, String> requestHeaders = new HashMap<>();
+      for (org.apache.kafka.common.header.Header header : record.headers()) {
+         requestHeaders.put(header.key(), new String(header.value(), StandardCharsets.UTF_8));
+      }
+      evaluableRequest.setHeaders(requestHeaders);
+
+      // Find matching request-reply pair
+      EventMessage replyMessage = findReplyForRequest(evaluableRequest);
+      if (replyMessage == null) {
+         logger.warnf("No matching reply message found for request, skipping");
+         return;
+      }
+
+      // Render reply message content
+      String replyContent = renderReplyContent(replyMessage, evaluableRequest);
+
+      // Publish reply
+      String replyTopic = getReplyTopic(replyMessage);
+      String key = String.valueOf(System.currentTimeMillis());
+
+      logger.debugf("Sending reply to %s", replyTopic);
+
+      // Convert to byte array and publish with headers
+      byte[] replyBytes = replyContent.getBytes(StandardCharsets.UTF_8);
+      Set<org.apache.kafka.common.header.Header> kafkaHeaders = buildReplyHeaders(replyMessage);
+      producerManager.publishMessage(replyTopic, key, replyBytes, kafkaHeaders);
+   }
+
+   /**
+    * Find the reply message that corresponds to the incoming request. Matches requests to replies using the replyId
+    * field. Request messages have their replyId set to point to their corresponding reply message's ID.
+    */
+   private EventMessage findReplyForRequest(EvaluableRequest evaluableRequest) {
+      // Find the request message that matches the incoming content
+      // Request messages have a replyId that points to their reply
+      EventMessage matchingRequest = mockDefinition.getEventMessages().stream().filter(msg -> msg.getReplyId() != null)
+            .filter(msg -> EventData.matchesExpectedMessage(msg, evaluableRequest.getBody())).findFirst().orElse(null);
+
+      if (matchingRequest == null) {
+         logger.debugf("No request message definition matches incoming request");
+         return null;
+      }
+
+      // Find the reply message using the request's replyId
+      String replyId = matchingRequest.getReplyId();
+      return mockDefinition.getEventMessages().stream().filter(msg -> replyId.equals(msg.getId())).findFirst()
+            .orElse(null);
+   }
+
+   /** Render reply content with any templating. */
+   private String renderReplyContent(EventMessage replyMessage, EvaluableRequest evaluableRequest) {
+      String content = replyMessage.getContent();
+
+      // Apply template rendering if content contains expressions
+      if (content.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
+         logger.debug("Reply message contains dynamic EL expression, rendering it...");
+         TemplateEngine engine = TemplateEngineFactory.getTemplateEngine();
+         engine.getContext().setVariable("request", evaluableRequest);
+
+         try {
+            content = engine.getValue(content);
+         } catch (Throwable t) {
+            logger.errorf(t, "Failed to evaluate template '%s'", content);
+         }
+      }
+
+      return content;
+   }
+
+   /** Build headers for reply message. */
+   private Set<org.apache.kafka.common.header.Header> buildReplyHeaders(EventMessage replyMessage) {
+      Set<org.apache.kafka.common.header.Header> headers = new HashSet<>();
+
+      // TODO: Add correlation ID header when we parse correlation object from
+      // AsyncAPI spec
+
+      // Add any headers defined in the reply message
+      if (replyMessage.getHeaders() != null) {
+         for (Header domainHeader : replyMessage.getHeaders()) {
+            // Convert domain Header to Kafka Header
+            if (domainHeader.getValues() != null && !domainHeader.getValues().isEmpty()) {
+               String value = domainHeader.getValues().iterator().next();
+               org.apache.kafka.common.header.Header kafkaHeader = new org.apache.kafka.common.header.internals.RecordHeader(
+                     domainHeader.getName(), value.getBytes(StandardCharsets.UTF_8));
+               headers.add(kafkaHeader);
+            }
+         }
+      }
+
+      return headers;
+   }
+
+   /** Get the request topic name. */
+   private String getRequestTopic() {
+      return producerManager.getTopicName(mockDefinition, mockDefinition.getEventMessages().get(0));
+   }
+
+   /** Get the reply topic name. */
+   private String getReplyTopic(EventMessage replyMessage) {
+      if (mockDefinition.getOperation().getReply() == null) {
+         throw new IllegalStateException(
+               "Request-reply operation must have reply information, but none found for operation: "
+                     + mockDefinition.getOperation().getName());
+      }
+
+      // Check if we have an addressLocation (runtime expression)
+      if (mockDefinition.getOperation().getReply().getAddressLocation() != null) {
+         // TODO: Implement runtime expression resolution for addressLocation
+         // This would parse expressions like "$message.header#/replyTo" or
+         // "$message.payload#/topicName"
+         // and extract the value from the request message headers or payload
+         throw new UnsupportedOperationException(
+               "Runtime expression resolution for addressLocation is not yet supported: "
+                     + mockDefinition.getOperation().getReply().getAddressLocation());
+      }
+
+      // Use the channelAddress as the raw topic name
+      if (mockDefinition.getOperation().getReply().getChannelAddress() != null) {
+         return mockDefinition.getOperation().getReply().getChannelAddress();
+      }
+
+      throw new IllegalStateException("Reply information must specify either channelAddress or addressLocation");
+   }
+
+   /** Create and configure the Kafka consumer. */
+   private KafkaConsumer<String, byte[]> createConsumer() {
+      Properties props = new Properties();
+
+      // Get bootstrap servers from config
+      String bootstrapServers = config.getValue("kafka.bootstrap.servers", String.class);
+      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+      // Generate unique group ID for this handler
+      String groupId = "microcks-request-reply-" + mockDefinition.getOwnerService().getId() + "-"
+            + mockDefinition.getOperation().getName();
+      props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+      props.put(ConsumerConfig.CLIENT_ID_CONFIG, "microcks-async-minion-request-reply");
+
+      // Use byte array deserializer for flexibility
+      props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+      props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+
+      // Start from latest messages
+      props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+      props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true);
+
+      // Add security config if available
+      addSecurityConfig(props);
+
+      KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(props);
+
+      // Subscribe to request topic
+      String requestTopic = getRequestTopic();
+      kafkaConsumer.subscribe(Collections.singletonList(requestTopic));
+
+      logger.infof("Created Kafka consumer for request topic: %s", requestTopic);
+
+      return kafkaConsumer;
+   }
+
+   /** Add security configuration if available. */
+   private void addSecurityConfig(Properties props) {
+      Optional<String> securityProtocol = config.getOptionalValue("kafka.security.protocol", String.class);
+      if (securityProtocol.isPresent()) {
+         props.put("security.protocol", securityProtocol.get());
+
+         if (config.getOptionalValue("kafka.ssl.truststore.location", String.class).isPresent()) {
+            props.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+                  config.getValue("kafka.ssl.truststore.location", String.class));
+         }
+         if (config.getOptionalValue("kafka.ssl.truststore.password", String.class).isPresent()) {
+            props.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+                  config.getValue("kafka.ssl.truststore.password", String.class));
+         }
+         if (config.getOptionalValue("kafka.ssl.truststore.type", String.class).isPresent()) {
+            props.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG,
+                  config.getValue("kafka.ssl.truststore.type", String.class));
+         }
+      }
+   }
+}

--- a/minions/async/src/main/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandler.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandler.java
@@ -37,7 +37,13 @@ import org.jboss.logging.Logger;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**

--- a/minions/async/src/main/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandlerFactory.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandlerFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.handler;
+
+import io.github.microcks.domain.Binding;
+import io.github.microcks.minion.async.AsyncMockDefinition;
+import io.github.microcks.minion.async.SchemaRegistry;
+import io.github.microcks.minion.async.producer.KafkaProducerManager;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.logging.Logger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Factory for creating Kafka request-reply handlers.
+ *
+ * @author adamhicks
+ */
+@ApplicationScoped
+public class KafkaRequestReplyHandlerFactory {
+
+   /** Get a JBoss logging logger. */
+   private final Logger logger = Logger.getLogger(getClass());
+
+   @Inject
+   Config config;
+
+   final KafkaProducerManager producerManager;
+   final SchemaRegistry schemaRegistry;
+
+   /**
+    * Create a new factory with required dependencies.
+    *
+    * @param producerManager The Kafka producer manager for sending replies
+    * @param schemaRegistry  The schema registry for message schemas
+    */
+   public KafkaRequestReplyHandlerFactory(KafkaProducerManager producerManager, SchemaRegistry schemaRegistry) {
+      this.producerManager = producerManager;
+      this.schemaRegistry = schemaRegistry;
+   }
+
+   /**
+    * Create a Kafka request-reply handler for the given mock definition.
+    *
+    * @param definition The mock definition to create a handler for
+    * @param binding    The Kafka binding information
+    * @return A new KafkaRequestReplyHandler
+    */
+   public KafkaRequestReplyHandler createHandler(AsyncMockDefinition definition, Binding binding) {
+      logger.debugf("Creating Kafka request-reply handler for %s - %s",
+            definition.getOwnerService().getName() + ":" + definition.getOwnerService().getVersion(),
+            definition.getOperation().getName());
+
+      return new KafkaRequestReplyHandler(definition, binding, producerManager, schemaRegistry, config);
+   }
+}

--- a/minions/async/src/main/java/io/github/microcks/minion/async/handler/RequestReplyHandler.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/handler/RequestReplyHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.handler;
+
+import io.github.microcks.minion.async.AsyncMockDefinition;
+
+/**
+ * Interface for request-reply handlers that listen for incoming request messages and send correlated replies. Each
+ * handler manages a single request-reply operation for a specific protocol binding.
+ *
+ * @author adamhicks
+ */
+public interface RequestReplyHandler {
+
+   /**
+    * Start the handler to begin listening for request messages.
+    *
+    * @throws Exception if the handler cannot be started
+    */
+   void start() throws Exception;
+
+   /**
+    * Stop the handler and clean up all resources.
+    */
+   void stop();
+
+   /**
+    * Check if the handler is currently running.
+    *
+    * @return true if the handler is running, false otherwise
+    */
+   boolean isRunning();
+
+   /**
+    * Get the mock definition this handler is managing.
+    *
+    * @return the AsyncMockDefinition
+    */
+   AsyncMockDefinition getMockDefinition();
+}

--- a/minions/async/src/main/java/io/github/microcks/minion/async/handler/RequestReplyHandlerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/handler/RequestReplyHandlerManager.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.handler;
+
+import io.github.microcks.domain.Binding;
+import io.github.microcks.domain.BindingType;
+import io.github.microcks.minion.async.AsyncMockDefinition;
+import io.github.microcks.minion.async.AsyncMockRepository;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manager responsible for lifecycle management of request-reply handlers. Creates, starts, and stops handlers for
+ * request-reply operations based on their protocol bindings.
+ *
+ * @author adamhicks
+ */
+@ApplicationScoped
+public class RequestReplyHandlerManager {
+
+   /** Get a JBoss logging logger. */
+   private final Logger logger = Logger.getLogger(getClass());
+
+   private final Map<String, RequestReplyHandler> handlers = new ConcurrentHashMap<>();
+
+   final AsyncMockRepository mockRepository;
+   final KafkaRequestReplyHandlerFactory kafkaHandlerFactory;
+
+   @ConfigProperty(name = "minion.supported-bindings")
+   String[] supportedBindings;
+
+   /**
+    * Create a new RequestReplyHandlerManager with required dependencies.
+    *
+    * @param mockRepository      The repository for mock definitions
+    * @param kafkaHandlerFactory Factory for creating Kafka handlers
+    */
+   public RequestReplyHandlerManager(AsyncMockRepository mockRepository,
+         KafkaRequestReplyHandlerFactory kafkaHandlerFactory) {
+      this.mockRepository = mockRepository;
+      this.kafkaHandlerFactory = kafkaHandlerFactory;
+   }
+
+   /**
+    * Start handlers for all request-reply mock definitions.
+    */
+   public void startAllHandlers() {
+      logger.info("Starting all request-reply handlers...");
+      Set<AsyncMockDefinition> requestReplyDefinitions = mockRepository.getRequestReplyMockDefinitions();
+
+      for (AsyncMockDefinition definition : requestReplyDefinitions) {
+         startHandlerForDefinition(definition);
+      }
+
+      logger.infof("Started %d request-reply handler(s)", handlers.size());
+   }
+
+   /**
+    * Start a handler for a specific mock definition.
+    *
+    * @param definition The mock definition to start a handler for
+    */
+   public void startHandlerForDefinition(AsyncMockDefinition definition) {
+      String handlerKey = buildHandlerKey(definition);
+
+      // Check if handler already exists
+      if (handlers.containsKey(handlerKey)) {
+         logger.debugf("Handler for %s already exists, skipping", handlerKey);
+         return;
+      }
+
+      // Determine which binding to use (first supported binding)
+      for (String binding : definition.getOperation().getBindings().keySet()) {
+         if (Arrays.asList(supportedBindings).contains(binding)) {
+            RequestReplyHandler handler = createHandlerForBinding(definition, binding);
+            if (handler != null) {
+               try {
+                  handler.start();
+                  handlers.put(handlerKey, handler);
+                  logger.infof("Started request-reply handler for %s using %s binding",
+                        definition.getOwnerService().getName() + ":" + definition.getOwnerService().getVersion() + " - "
+                              + definition.getOperation().getName(),
+                        binding);
+                  break; // Only start one handler per definition
+               } catch (Exception e) {
+                  logger.errorf(e, "Failed to start request-reply handler for %s", handlerKey);
+               }
+            }
+         }
+      }
+   }
+
+   /**
+    * Stop and remove a handler for a specific service.
+    *
+    * @param serviceId The service ID to stop handlers for
+    */
+   public void stopHandlersForService(String serviceId) {
+      logger.infof("Stopping request-reply handlers for service %s", serviceId);
+
+      handlers.entrySet().removeIf(entry -> {
+         if (entry.getKey().startsWith(serviceId + ":")) {
+            entry.getValue().stop();
+            logger.infof("Stopped handler for %s", entry.getKey());
+            return true;
+         }
+         return false;
+      });
+   }
+
+   /**
+    * Stop all handlers.
+    */
+   public void stopAllHandlers() {
+      logger.info("Stopping all request-reply handlers...");
+
+      for (Map.Entry<String, RequestReplyHandler> entry : handlers.entrySet()) {
+         try {
+            entry.getValue().stop();
+            logger.debugf("Stopped handler for %s", entry.getKey());
+         } catch (Exception e) {
+            logger.errorf(e, "Error stopping handler for %s", entry.getKey());
+         }
+      }
+
+      handlers.clear();
+      logger.info("All request-reply handlers stopped");
+   }
+
+   /**
+    * Get the number of active handlers.
+    *
+    * @return the count of active handlers
+    */
+   public int getHandlerCount() {
+      return handlers.size();
+   }
+
+   /** Create a handler for a specific binding type. */
+   private RequestReplyHandler createHandlerForBinding(AsyncMockDefinition definition, String binding) {
+      try {
+         BindingType bindingType = BindingType.valueOf(binding);
+         Binding bindingDef = definition.getOperation().getBindings().get(binding);
+
+         return switch (bindingType) {
+            case KAFKA -> kafkaHandlerFactory.createHandler(definition, bindingDef);
+            // TODO: Add other binding types as they are implemented
+            // case MQTT -> mqttHandlerFactory.createHandler(definition, bindingDef);
+            // case AMQP -> amqpHandlerFactory.createHandler(definition, bindingDef);
+            default -> {
+               logger.warnf("Request-reply handler not implemented for binding type: %s", binding);
+               yield null;
+            }
+         };
+      } catch (Exception e) {
+         logger.errorf(e, "Error creating handler for binding %s", binding);
+         return null;
+      }
+   }
+
+   /** Build a unique key for a handler. */
+   private String buildHandlerKey(AsyncMockDefinition definition) {
+      return definition.getOwnerService().getId() + ":" + definition.getOperation().getName();
+   }
+}

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
@@ -46,6 +46,7 @@ import java.util.*;
 
 /**
  * Kafka implementation of producer for async event messages.
+ *
  * @author laurent
  */
 @ApplicationScoped
@@ -80,6 +81,7 @@ public class KafkaProducerManager {
 
    /**
     * Tells if producer is connected to a Schema registry and thus able to send Avro GenericRecord.
+    *
     * @return True if connected to a Schema registry, false otherwise.
     */
    public boolean isRegistryEnabled() {
@@ -128,7 +130,8 @@ public class KafkaProducerManager {
             props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
 
             props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl.get());
-            // If authentication turned on (see https://docs.confluent.io/platform/current/security/basic-auth.html#basic-auth-sr)
+            // If authentication turned on (see
+            // https://docs.confluent.io/platform/current/security/basic-auth.html#basic-auth-sr)
             if (schemaRegistryUsername.isPresent()) {
                props.put(AbstractKafkaSchemaSerDeConfig.USER_INFO_CONFIG, schemaRegistryUsername.get());
                props.put(AbstractKafkaSchemaSerDeConfig.BASIC_AUTH_CREDENTIALS_SOURCE, schemaRegistryCredentialsSource);
@@ -160,6 +163,7 @@ public class KafkaProducerManager {
 
    /**
     * Publish a message on specified topic.
+    *
     * @param topic   The destination topic for message
     * @param key     The message key
     * @param value   The message payload
@@ -175,6 +179,7 @@ public class KafkaProducerManager {
 
    /**
     * Publish a raw byte array message on specified topic.
+    *
     * @param topic   The destination topic for message
     * @param key     The message key
     * @param value   The message payload
@@ -190,6 +195,7 @@ public class KafkaProducerManager {
 
    /**
     * Publish an Avro GenericRecord built with Schema onto specified topic and using underlying schema registry.
+    *
     * @param topic   The destination topic for message
     * @param key     The message key
     * @param value   The message payload
@@ -205,6 +211,7 @@ public class KafkaProducerManager {
 
    /**
     * Transform and render Microcks headers into Kafka specific headers.
+    *
     * @param engine  The template engine to reuse (because we do not want to initialize and manage a context at the
     *                KafkaProducerManager level.)
     * @param headers The Microcks event message headers definition.
@@ -234,29 +241,29 @@ public class KafkaProducerManager {
    }
 
    /**
-    * Get the Kafka topic name corresponding to a AsyncMockDefinition, sanitizing all parameters.
+    * Get the Kafka topic name corresponding to a AsyncMockDefinition. The operation must have exactly one resource
+    * path, which will be used as the topic name.
+    *
     * @param definition   The AsyncMockDefinition
     * @param eventMessage The message to get topic
     * @return The topic name for definition and event
+    * @throws IllegalArgumentException if the operation does not have exactly one resource path
     */
    public String getTopicName(AsyncMockDefinition definition, EventMessage eventMessage) {
-      // Produce service name part of topic name.
-      String serviceName = definition.getOwnerService().getName().replace(" ", "");
-      serviceName = serviceName.replace("-", "");
+      Set<String> resourcePaths = definition.getOperation().getResourcePaths();
 
-      // Produce version name part of topic name.
-      String versionName = definition.getOwnerService().getVersion().replace(" ", "");
+      if (resourcePaths == null || resourcePaths.size() != 1) {
+         throw new IllegalArgumentException(
+               String.format("Operation '%s' must have exactly one resource path to determine topic name, but has: %s",
+                     definition.getOperation().getName(), resourcePaths));
+      }
 
-      // Produce operation name part of topic name.
-      String operationName = ProducerManager.getDestinationOperationPart(definition.getOperation(), eventMessage);
-      operationName = operationName.replace('/', '-');
-
-      // Aggregate the 3 parts using '_' as delimiter.
-      return serviceName + "-" + versionName + "-" + operationName;
+      return resourcePaths.iterator().next();
    }
 
    /**
     * Completing the ProducerRecord with the set of provided headers.
+    *
     * @param kafkaRecord The record to complete
     * @param headers     The set of headers
     */

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
@@ -250,15 +250,19 @@ public class KafkaProducerManager {
     * @throws IllegalArgumentException if the operation does not have exactly one resource path
     */
    public String getTopicName(AsyncMockDefinition definition, EventMessage eventMessage) {
-      Set<String> resourcePaths = definition.getOperation().getResourcePaths();
+      // Produce service name part of topic name.
+      String serviceName = definition.getOwnerService().getName().replace(" ", "");
+      serviceName = serviceName.replace("-", "");
 
-      if (resourcePaths == null || resourcePaths.size() != 1) {
-         throw new IllegalArgumentException(
-               String.format("Operation '%s' must have exactly one resource path to determine topic name, but has: %s",
-                     definition.getOperation().getName(), resourcePaths));
-      }
+      // Produce version name part of topic name.
+      String versionName = definition.getOwnerService().getVersion().replace(" ", "");
 
-      return resourcePaths.iterator().next();
+      // Produce operation name part of topic name.
+      String operationName = ProducerManager.getDestinationOperationPart(definition.getOperation(), eventMessage);
+      operationName = operationName.replace('/', '-');
+
+      // Aggregate the 3 parts using '_' as delimiter.
+      return serviceName + "-" + versionName + "-" + operationName;
    }
 
    /**

--- a/minions/async/src/test/java/io/github/microcks/minion/async/AsyncAPITestManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/AsyncAPITestManagerIT.java
@@ -31,7 +31,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.KafkaContainer;
@@ -55,6 +54,7 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 /**
  * This is an integration test case using <a href="https://testcontainers.com/">Testcontainers</a> to test
  * {@link AsyncAPITestManager} class.
+ *
  * @author laurent
  */
 @Testcontainers

--- a/minions/async/src/test/java/io/github/microcks/minion/async/AsyncAPITestManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/AsyncAPITestManagerIT.java
@@ -130,7 +130,7 @@ class AsyncAPITestManagerIT {
       testSpecification.setRunnerType(TestRunnerType.ASYNC_API_SCHEMA);
       testSpecification.setAsyncAPISpec(asyncAPIContent);
       testSpecification.setOperationName(config.operationName);
-      testSpecification.setTimeoutMS(2200L);
+      testSpecification.setTimeoutMS(5000L);
       testSpecification.setTestResultId("test-result-id");
 
       AsyncAPITestManager manager = new AsyncAPITestManager(microcksAPIConnector, schemaRegistry);
@@ -139,12 +139,14 @@ class AsyncAPITestManagerIT {
       // Act.
       manager.launchTest(testSpecification);
 
-      // Wait a bit so that consumption task has actually started.
-      await().during(1250, TimeUnit.MILLISECONDS).until(() -> true);
+      // Wait for the consumer to complete partition assignment before sending
+      // messages.
+      await().during(2500, TimeUnit.MILLISECONDS).until(() -> true);
       sendTextMessagesOnTopic(5, config.message);
 
-      // Wait a bit so that consumption task has actually finished.
-      await().during(3, TimeUnit.SECONDS).until(() -> true);
+      // Wait until the test result is actually reported rather than sleeping a fixed
+      // duration.
+      await().atMost(10, TimeUnit.SECONDS).until(() -> reportedTestCases.containsKey("test-result-id"));
 
       // Assert.
       Assertions.assertEquals(1, reportedTestCases.size());

--- a/minions/async/src/test/java/io/github/microcks/minion/async/handler/DispatchTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/handler/DispatchTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.handler;
+
+import io.github.microcks.domain.EventMessage;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DispatchTest {
+
+   @Test
+   void matchesEventMessage_WithJsonSubsetAndExtraIncomingFields() {
+      EventMessage eventMessage = new EventMessage();
+      eventMessage.setContent("""
+            {
+              "streetlightId": "ea89",
+              "state": "off",
+              "metadata": {
+                "source": "sensor"
+              }
+            }
+            """);
+
+      String eventPayload = """
+            {
+              "streetlightId": "ea89",
+              "state": "off",
+              "metadata": {
+                "source": "sensor",
+                "zone": "north"
+              },
+              "timestamp": "2026-03-03T10:15:30Z"
+            }
+            """;
+
+      assertTrue(EventData.matchesExpectedMessage(eventMessage, eventPayload));
+   }
+
+   @Test
+   void matchesEventMessage_FailsWhenExpectedJsonFieldIsMissing() {
+      EventMessage eventMessage = new EventMessage();
+      eventMessage.setContent("""
+            {
+              "streetlightId": "ea89",
+              "state": "off"
+            }
+            """);
+
+      String eventPayload = """
+            {
+              "streetlightId": "ea89"
+            }
+            """;
+
+      assertFalse(EventData.matchesExpectedMessage(eventMessage, eventPayload));
+   }
+}

--- a/minions/async/src/test/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandlerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandlerIT.java
@@ -80,8 +80,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @Testcontainers
 class KafkaRequestReplyHandlerIT {
 
-   private static final String REQUEST_TOPIC = "user-signup-request";
-   private static final String REPLY_TOPIC = "user-signup-reply";
+   private static final String REQUEST_TOPIC = "UserAccountService-1.0.0-user-signup";
+   private static final String REPLY_TOPIC = "UserAccountService-1.0.0-user-signup-reply";
    private static final Network NETWORK = Network.newNetwork();
 
    @Container

--- a/minions/async/src/test/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandlerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/handler/KafkaRequestReplyHandlerIT.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.handler;
+
+import io.github.microcks.domain.Binding;
+import io.github.microcks.domain.BindingType;
+import io.github.microcks.domain.EventMessage;
+import io.github.microcks.domain.Operation;
+import io.github.microcks.domain.ReplyInfo;
+import io.github.microcks.domain.Service;
+import io.github.microcks.domain.ServiceType;
+import io.github.microcks.minion.async.AsyncMockDefinition;
+import io.github.microcks.minion.async.AsyncMockRepository;
+import io.github.microcks.minion.async.SchemaRegistry;
+import io.github.microcks.minion.async.client.MicrocksAPIConnector;
+import io.github.microcks.minion.async.producer.FakeMicrocksAPIConnector;
+import io.github.microcks.minion.async.producer.KafkaProducerManager;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicCollection;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This is an integration test case using <a href="https://testcontainers.com/">Testcontainers</a> to test
+ * {@link KafkaRequestReplyHandler} and {@link RequestReplyHandlerManager} classes.
+ *
+ * @author adamhicks
+ */
+@Testcontainers
+class KafkaRequestReplyHandlerIT {
+
+   private static final String REQUEST_TOPIC = "user-signup-request";
+   private static final String REPLY_TOPIC = "user-signup-reply";
+   private static final Network NETWORK = Network.newNetwork();
+
+   @Container
+   private static final KafkaContainer kafkaContainer = new KafkaContainer(
+         DockerImageName.parse("confluentinc/cp-kafka:7.5.0")).withNetwork(NETWORK).withNetworkAliases("kafka")
+               .withListener(() -> "kafka:19092");
+
+   private KafkaRequestReplyHandler handler;
+   private KafkaProducerManager kafkaProducerManager;
+
+   @BeforeEach
+   void beforeEach() throws Exception {
+      Properties props = new Properties();
+      props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+
+      try (AdminClient adminClient = AdminClient.create(props)) {
+         // Delete topics if they exist
+         adminClient.deleteTopics(TopicCollection.ofTopicNames(List.of(REQUEST_TOPIC, REPLY_TOPIC)));
+      }
+
+      // Wait a bit for topic deletion
+      Thread.sleep(500);
+   }
+
+   @AfterEach
+   void afterEach() {
+      if (handler != null && handler.isRunning()) {
+         handler.stop();
+      }
+   }
+
+   @Test
+   void testRequestReplyHandlerWithJsonMessages() throws Exception {
+      // Arrange.
+      String asyncAPIContent = Files.readString(
+            Paths.get("target/test-classes/io/github/microcks/minion/async", "user-signedup-asyncapi-3.0-reply.yaml"));
+
+      // Prepare request and reply messages.
+      EventMessage requestMessage = new EventMessage();
+      requestMessage.setName("UserSignupRequest");
+      requestMessage.setMediaType("application/json");
+      requestMessage.setContent("""
+            {"email": "john.doe@example.com", "username": "johndoe", "fullName": "John Doe"}""");
+
+      EventMessage replyMessage = new EventMessage();
+      replyMessage.setId("reply-msg-1"); // Set ID for linking
+      replyMessage.setName("UserSignupReply");
+      replyMessage.setMediaType("application/json");
+      replyMessage.setContent("""
+            {"userId": "usr-12345", "status": "success", "message": "User account created successfully"}""");
+
+      // Link request to reply via replyId
+      requestMessage.setReplyId(replyMessage.getId());
+
+      // Prepare associated service and operation.
+      Service service = new Service();
+      service.setId("user-account-service-id");
+      service.setName("User Account Service");
+      service.setVersion("1.0.0");
+      service.setType(ServiceType.EVENT);
+
+      Operation signupOperation = new Operation();
+      signupOperation.setName("RECEIVE user/signup");
+      signupOperation.addResourcePath(REQUEST_TOPIC);
+
+      // Setup reply information
+      ReplyInfo replyInfo = new ReplyInfo();
+      replyInfo.setChannelAddress(REPLY_TOPIC);
+      signupOperation.setReply(replyInfo);
+
+      service.setOperations(List.of(signupOperation));
+
+      // Assemble them into a repository - both request and reply messages!
+      AsyncMockRepository mockRepository = new AsyncMockRepository();
+      AsyncMockDefinition mockDefinition = new AsyncMockDefinition(service, signupOperation,
+            List.of(requestMessage, replyMessage));
+      mockRepository.storeMockDefinition(mockDefinition);
+
+      MicrocksAPIConnector microcksAPIConnector = new FakeMicrocksAPIConnector("user-account-service-id",
+            asyncAPIContent);
+      SchemaRegistry schemaRegistry = new SchemaRegistry(microcksAPIConnector);
+
+      // Setup Kafka producer manager for replies
+      kafkaProducerManager = createKafkaProducerManager();
+
+      // Create Kafka binding
+      Binding kafkaBinding = new Binding();
+      kafkaBinding.setType(BindingType.KAFKA);
+
+      // Create and start the handler
+      KafkaRequestReplyHandlerFactory factory = createFactory(kafkaProducerManager, schemaRegistry);
+      handler = factory.createHandler(mockDefinition, kafkaBinding);
+
+      handler.start();
+
+      // Wait for consumer to be ready
+      Thread.sleep(2000);
+
+      // Act - Send a request message to the request topic
+      sendRequestMessage(REQUEST_TOPIC, """
+            {"email": "john.doe@example.com", "username": "johndoe", "fullName": "John Doe"}""");
+
+      // Wait for handler to process and send reply
+      Thread.sleep(1000);
+
+      // Consume reply messages from reply topic
+      List<String> replyMessages = consumeMessagesFromTopic(REPLY_TOPIC, 2000);
+
+      // Assert.
+      assertFalse(replyMessages.isEmpty(), "Should have received at least one reply message");
+
+      String receivedReply = replyMessages.get(0);
+      assertTrue(receivedReply.contains("usr-12345"), "Reply should contain userId");
+      assertTrue(receivedReply.contains("success"), "Reply should contain success status");
+   }
+
+   @Test
+   void testRequestReplyHandlerIgnoresUnmatchingMessage() throws Exception {
+      // Arrange.
+      String asyncAPIContent = Files.readString(
+            Paths.get("target/test-classes/io/github/microcks/minion/async", "user-signedup-asyncapi-3.0-reply.yaml"));
+
+      // Prepare request and reply messages.
+      EventMessage requestMessage = new EventMessage();
+      requestMessage.setName("UserSignupRequest");
+      requestMessage.setMediaType("application/json");
+      requestMessage.setContent("""
+            {"email": "john.doe@example.com", "username": "johndoe", "fullName": "John Doe"}""");
+
+      EventMessage replyMessage = new EventMessage();
+      replyMessage.setId("reply-msg-1"); // Set ID for linking
+      replyMessage.setName("UserSignupReply");
+      replyMessage.setMediaType("application/json");
+      replyMessage.setContent("""
+            {"userId": "usr-12345", "status": "success", "message": "User account created successfully"}""");
+
+      // Link request to reply via replyId
+      requestMessage.setReplyId(replyMessage.getId());
+
+      // Prepare associated service and operation.
+      Service service = new Service();
+      service.setId("user-account-service-id");
+      service.setName("User Account Service");
+      service.setVersion("1.0.0");
+      service.setType(ServiceType.EVENT);
+
+      Operation signupOperation = new Operation();
+      signupOperation.setName("RECEIVE user/signup");
+      signupOperation.addResourcePath(REQUEST_TOPIC);
+
+      // Setup reply information
+      ReplyInfo replyInfo = new ReplyInfo();
+      replyInfo.setChannelAddress(REPLY_TOPIC);
+      signupOperation.setReply(replyInfo);
+
+      service.setOperations(List.of(signupOperation));
+
+      // Assemble them into a repository - both request and reply messages!
+      AsyncMockRepository mockRepository = new AsyncMockRepository();
+      AsyncMockDefinition mockDefinition = new AsyncMockDefinition(service, signupOperation,
+            List.of(requestMessage, replyMessage));
+      mockRepository.storeMockDefinition(mockDefinition);
+
+      MicrocksAPIConnector microcksAPIConnector = new FakeMicrocksAPIConnector("user-account-service-id",
+            asyncAPIContent);
+      SchemaRegistry schemaRegistry = new SchemaRegistry(microcksAPIConnector);
+
+      // Setup Kafka producer manager for replies
+      kafkaProducerManager = createKafkaProducerManager();
+
+      // Create Kafka binding
+      Binding kafkaBinding = new Binding();
+      kafkaBinding.setType(BindingType.KAFKA);
+
+      // Create and start the handler
+      KafkaRequestReplyHandlerFactory factory = createFactory(kafkaProducerManager, schemaRegistry);
+      handler = factory.createHandler(mockDefinition, kafkaBinding);
+
+      handler.start();
+
+      // Wait for consumer to be ready
+      Thread.sleep(2000);
+
+      // Act - Send a request message to the request topic with test@example.com
+      // instead of john.doe@example.com
+      sendRequestMessage(REQUEST_TOPIC, """
+            {"email": "test@example.com", "username": "johndoe", "fullName": "John Doe"}""");
+
+      // Wait for handler to process and send reply
+      Thread.sleep(1000);
+
+      // Consume reply messages from reply topic
+      List<String> replyMessages = consumeMessagesFromTopic(REPLY_TOPIC, 2000);
+
+      // Assert.
+      assertTrue(replyMessages.isEmpty(), "Should not have received any reply message");
+   }
+
+   @Test
+   void testHandlerStartStop() throws Exception {
+      // Arrange.
+      String asyncAPIContent = Files.readString(
+            Paths.get("target/test-classes/io/github/microcks/minion/async", "user-signedup-asyncapi-3.0-reply.yaml"));
+
+      EventMessage requestMessage = new EventMessage();
+      requestMessage.setName("TestRequest");
+      requestMessage.setMediaType("application/json");
+      requestMessage.setContent("{}");
+
+      EventMessage replyMessage = new EventMessage();
+      replyMessage.setId("test-reply-1");
+      replyMessage.setName("TestReply");
+      replyMessage.setMediaType("application/json");
+      replyMessage.setContent("""
+            {"status": "ok"}""");
+
+      // Link request to reply
+      requestMessage.setReplyId(replyMessage.getId());
+
+      Service service = new Service();
+      service.setId("test-service-id");
+      service.setName("Test Service");
+      service.setVersion("1.0.0");
+      service.setType(ServiceType.EVENT);
+
+      Operation operation = new Operation();
+      operation.setName("RECEIVE test/op");
+      operation.addResourcePath("test/op");
+
+      ReplyInfo replyInfo = new ReplyInfo();
+      replyInfo.setChannelAddress("test/reply");
+      operation.setReply(replyInfo);
+
+      service.setOperations(List.of(operation));
+
+      AsyncMockDefinition mockDefinition = new AsyncMockDefinition(service, operation,
+            List.of(requestMessage, replyMessage));
+
+      MicrocksAPIConnector microcksAPIConnector = new FakeMicrocksAPIConnector("test-service-id", asyncAPIContent);
+      SchemaRegistry schemaRegistry = new SchemaRegistry(microcksAPIConnector);
+
+      kafkaProducerManager = createKafkaProducerManager();
+
+      Binding kafkaBinding = new Binding();
+      kafkaBinding.setType(BindingType.KAFKA);
+
+      KafkaRequestReplyHandlerFactory factory = createFactory(kafkaProducerManager, schemaRegistry);
+      handler = factory.createHandler(mockDefinition, kafkaBinding);
+
+      // Act & Assert
+      assertFalse(handler.isRunning(), "Handler should not be running initially");
+
+      handler.start();
+      Thread.sleep(500);
+      assertTrue(handler.isRunning(), "Handler should be running after start");
+
+      handler.stop();
+      Thread.sleep(500);
+      assertFalse(handler.isRunning(), "Handler should not be running after stop");
+   }
+
+   private void sendRequestMessage(String topic, String message) {
+      Properties props = new Properties();
+      props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+      props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+      props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+
+      try (KafkaProducer<String, byte[]> producer = new KafkaProducer<>(props)) {
+         ProducerRecord<String, byte[]> record = new ProducerRecord<>(topic, message.getBytes(StandardCharsets.UTF_8));
+         producer.send(record).get();
+         producer.flush();
+      } catch (Exception e) {
+         fail("Failed to send request message", e);
+      }
+   }
+
+   private List<String> consumeMessagesFromTopic(String topic, long timeout) {
+      List<String> messages = new ArrayList<>();
+
+      Properties props = new Properties();
+      props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+      props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-consumer-" + System.currentTimeMillis());
+      props.put(ConsumerConfig.CLIENT_ID_CONFIG, "test-consumer-" + System.currentTimeMillis());
+      props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+      props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+
+      // Only retrieve incoming messages and do not persist offset.
+      props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+      props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+      try (KafkaConsumer<String, byte[]> consumer = new KafkaConsumer<>(props)) {
+         // Subscribe Kafka consumer and receive messages.
+         consumer.subscribe(Collections.singletonList(topic), new ConsumerRebalanceListener() {
+            @Override
+            public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+            }
+
+            @Override
+            public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+               partitions.forEach(p -> consumer.seek(p, 0));
+            }
+         });
+
+         long startTime = System.currentTimeMillis();
+         long timeoutTime = startTime + timeout;
+
+         while (System.currentTimeMillis() < timeoutTime) {
+            ConsumerRecords<String, byte[]> records = consumer
+                  .poll(Duration.ofMillis(timeoutTime - System.currentTimeMillis()));
+            if (!records.isEmpty()) {
+               records.forEach(rec -> messages.add(new String(rec.value(), StandardCharsets.UTF_8)));
+            }
+         }
+      } catch (Exception e) {
+         fail("Exception while connecting to Kafka broker", e);
+      }
+      return messages;
+   }
+
+   private KafkaProducerManager createKafkaProducerManager() {
+      KafkaProducerManager manager = new KafkaProducerManager();
+      // Use reflection to set private fields for testing
+      try {
+         java.lang.reflect.Field configField = KafkaProducerManager.class.getDeclaredField("config");
+         configField.setAccessible(true);
+         configField.set(manager, new FakeConfig(kafkaContainer.getBootstrapServers()));
+
+         java.lang.reflect.Field bootstrapField = KafkaProducerManager.class.getDeclaredField("bootstrapServers");
+         bootstrapField.setAccessible(true);
+         bootstrapField.set(manager, kafkaContainer.getBootstrapServers());
+
+         java.lang.reflect.Field registryField = KafkaProducerManager.class.getDeclaredField("schemaRegistryUrl");
+         registryField.setAccessible(true);
+         registryField.set(manager, Optional.empty());
+
+         manager.create();
+      } catch (Exception e) {
+         fail("Failed to initialize KafkaProducerManager", e);
+      }
+      return manager;
+   }
+
+   private KafkaRequestReplyHandlerFactory createFactory(KafkaProducerManager producerManager,
+         SchemaRegistry schemaRegistry) {
+      KafkaRequestReplyHandlerFactory factory = new KafkaRequestReplyHandlerFactory(producerManager, schemaRegistry);
+      // Use reflection to set the config field
+      try {
+         java.lang.reflect.Field configField = KafkaRequestReplyHandlerFactory.class.getDeclaredField("config");
+         configField.setAccessible(true);
+         configField.set(factory, new FakeConfig(kafkaContainer.getBootstrapServers()));
+      } catch (Exception e) {
+         fail("Failed to initialize factory", e);
+      }
+      return factory;
+   }
+
+   private static class FakeConfig implements Config {
+      private final Map<String, String> properties = new HashMap<>();
+
+      public FakeConfig(String bootstrapServers) {
+         properties.put("kafka.bootstrap.servers", bootstrapServers);
+      }
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public <T> T getValue(String propertyName, Class<T> propertyType) {
+         if (properties.containsKey(propertyName)) {
+            return (T) properties.get(propertyName);
+         }
+         return null;
+      }
+
+      @Override
+      public ConfigValue getConfigValue(String propertyName) {
+         return null;
+      }
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+         if (properties.containsKey(propertyName)) {
+            return Optional.of((T) properties.get(propertyName));
+         }
+         return Optional.empty();
+      }
+
+      @Override
+      public Iterable<String> getPropertyNames() {
+         return properties.keySet();
+      }
+
+      @Override
+      public Iterable<ConfigSource> getConfigSources() {
+         return null;
+      }
+
+      @Override
+      public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
+         return Optional.empty();
+      }
+
+      @Override
+      public <T> T unwrap(Class<T> type) {
+         return null;
+      }
+   }
+}

--- a/minions/async/src/test/java/io/github/microcks/minion/async/handler/RequestReplyHandlerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/handler/RequestReplyHandlerManagerTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.handler;
+
+import io.github.microcks.domain.Binding;
+import io.github.microcks.domain.EventMessage;
+import io.github.microcks.domain.Operation;
+import io.github.microcks.domain.ReplyInfo;
+import io.github.microcks.domain.Service;
+import io.github.microcks.minion.async.AsyncMockDefinition;
+import io.github.microcks.minion.async.AsyncMockRepository;
+import io.github.microcks.minion.async.producer.KafkaProducerManager;
+import io.github.microcks.minion.async.SchemaRegistry;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test case for RequestReplyHandlerManager class. Note: This is a simple test without actual Kafka integration. Full
+ * integration tests require a running Kafka instance.
+ * 
+ * @author adamhicks
+ */
+class RequestReplyHandlerManagerTest {
+
+   private AsyncMockRepository mockRepository;
+   private KafkaRequestReplyHandlerFactory kafkaHandlerFactory;
+   private RequestReplyHandlerManager handlerManager;
+
+   @BeforeEach
+   void setUp() {
+      // Create simple in-memory implementations for testing
+      mockRepository = new AsyncMockRepository();
+      kafkaHandlerFactory = new TestKafkaHandlerFactory();
+      handlerManager = new RequestReplyHandlerManager(mockRepository, kafkaHandlerFactory);
+
+      // Inject supported bindings via reflection (since it's normally from
+      // ConfigProperty)
+      try {
+         var field = RequestReplyHandlerManager.class.getDeclaredField("supportedBindings");
+         field.setAccessible(true);
+         field.set(handlerManager, new String[] { "KAFKA" });
+      } catch (Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   @Test
+   void testStartAllHandlers_NoDefinitions() {
+      // Execute
+      handlerManager.startAllHandlers();
+
+      // Verify
+      assertEquals(0, handlerManager.getHandlerCount());
+   }
+
+   @Test
+   void testStartAllHandlers_WithKafkaDefinition() {
+      // Setup
+      AsyncMockDefinition definition = createRequestReplyMockDefinition("kafka");
+      mockRepository.storeMockDefinition(definition);
+
+      // Execute
+      handlerManager.startAllHandlers();
+
+      // Verify
+      assertEquals(1, handlerManager.getHandlerCount());
+   }
+
+   @Test
+   void testStopHandlersForService() {
+      // Setup
+      AsyncMockDefinition definition1 = createRequestReplyMockDefinition("kafka");
+      definition1.getOwnerService().setId("service-1");
+      mockRepository.storeMockDefinition(definition1);
+
+      AsyncMockDefinition definition2 = createRequestReplyMockDefinition("kafka");
+      definition2.getOwnerService().setId("service-2");
+      definition2.getOperation().setName("SUBSCRIBE test/request2");
+      mockRepository.storeMockDefinition(definition2);
+
+      handlerManager.startAllHandlers();
+      assertEquals(2, handlerManager.getHandlerCount());
+
+      // Execute - stop handlers for service-1
+      handlerManager.stopHandlersForService("service-1");
+
+      // Verify - only service-2 handler should remain
+      assertEquals(1, handlerManager.getHandlerCount());
+   }
+
+   @Test
+   void testStopAllHandlers() {
+      // Setup
+      AsyncMockDefinition definition = createRequestReplyMockDefinition("kafka");
+      mockRepository.storeMockDefinition(definition);
+
+      handlerManager.startAllHandlers();
+      assertEquals(1, handlerManager.getHandlerCount());
+
+      // Execute
+      handlerManager.stopAllHandlers();
+
+      // Verify
+      assertEquals(0, handlerManager.getHandlerCount());
+   }
+
+   @Test
+   void testStartHandlerForDefinition_DuplicatePrevented() {
+      // Setup
+      AsyncMockDefinition definition = createRequestReplyMockDefinition("kafka");
+
+      // Execute - start twice
+      handlerManager.startHandlerForDefinition(definition);
+      handlerManager.startHandlerForDefinition(definition);
+
+      // Verify - only one handler should be created
+      assertEquals(1, handlerManager.getHandlerCount());
+   }
+
+   // Helper methods and test implementations
+
+   private AsyncMockDefinition createRequestReplyMockDefinition(String binding) {
+      Service service = new Service();
+      service.setId("test-service-id");
+      service.setName("TestService");
+      service.setVersion("1.0.0");
+
+      Operation operation = new Operation();
+      operation.setName("SUBSCRIBE test/request");
+
+      // Add binding
+      Binding bindingDef = new Binding();
+      Map<String, Binding> bindings = new HashMap<>();
+      bindings.put(binding.toUpperCase(), bindingDef);
+      operation.setBindings(bindings);
+
+      // Add reply info to make it a request-reply operation
+      ReplyInfo replyInfo = new ReplyInfo();
+      replyInfo.setChannelAddress("test/reply");
+      operation.setReply(replyInfo);
+
+      // Create event messages
+      EventMessage requestMessage = new EventMessage();
+      requestMessage.setName("request1");
+      requestMessage.setContent("{\"action\": \"test\"}");
+
+      List<EventMessage> eventMessages = List.of(requestMessage);
+
+      return new AsyncMockDefinition(service, operation, eventMessages);
+   }
+
+   /**
+    * Simple test implementation of KafkaRequestReplyHandlerFactory that creates test handlers.
+    */
+   private static class TestKafkaHandlerFactory extends KafkaRequestReplyHandlerFactory {
+      public TestKafkaHandlerFactory() {
+         super(null, null);
+      }
+
+      @Override
+      public KafkaRequestReplyHandler createHandler(AsyncMockDefinition definition, Binding binding) {
+         // Return a test implementation that doesn't connect to Kafka
+         return new TestKafkaRequestReplyHandler(definition, binding, null, null, null);
+      }
+   }
+
+   /**
+    * Simple test implementation that extends KafkaRequestReplyHandler but doesn't connect to Kafka.
+    */
+   private static class TestKafkaRequestReplyHandler extends KafkaRequestReplyHandler {
+      private boolean running = false;
+
+      public TestKafkaRequestReplyHandler(AsyncMockDefinition mockDefinition, Binding binding,
+            KafkaProducerManager producerManager, SchemaRegistry schemaRegistry,
+            org.eclipse.microprofile.config.Config config) {
+         super(mockDefinition, binding, producerManager, schemaRegistry, config);
+      }
+
+      @Override
+      public void start() {
+         // Don't actually start Kafka consumer in tests
+         running = true;
+      }
+
+      @Override
+      public void stop() {
+         running = false;
+      }
+
+      @Override
+      public boolean isRunning() {
+         return running;
+      }
+   }
+}

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/FakeMicrocksAPIConnector.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/FakeMicrocksAPIConnector.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 /**
  * A fake implementation of MicrocksAPIConnector for testing purposes.
+ *
  * @author laurent
  */
 public class FakeMicrocksAPIConnector implements MicrocksAPIConnector {
@@ -36,7 +37,7 @@ public class FakeMicrocksAPIConnector implements MicrocksAPIConnector {
    private final String serviceId;
    private final String asyncAPIContent;
 
-   FakeMicrocksAPIConnector(String serviceId, String asyncAPIContent) {
+   public FakeMicrocksAPIConnector(String serviceId, String asyncAPIContent) {
       this.serviceId = serviceId;
       this.asyncAPIContent = asyncAPIContent;
    }

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerIT.java
@@ -127,7 +127,6 @@ class KafkaProducerManagerIT {
 
       Operation signedupOperation = new Operation();
       signedupOperation.setName("SUBSCRIBE user/signedup");
-      signedupOperation.addResourcePath(TOPIC_NAME);
       service.setOperations(List.of(signedupOperation));
 
       // Assemble them into a repository.
@@ -211,7 +210,6 @@ class KafkaProducerManagerIT {
 
       Operation signedupOperation = new Operation();
       signedupOperation.setName("SUBSCRIBE user/signedup");
-      signedupOperation.addResourcePath(TOPIC_NAME);
       service.setOperations(List.of(signedupOperation));
 
       // Assemble them into a repository.

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerIT.java
@@ -77,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * This is an integration test case using <a href="https://testcontainers.com/">Testcontainers</a> to test
  * {@link KafkaProducerManager} and {@link ProducerManager} classes.
+ *
  * @author laurent
  */
 @Testcontainers
@@ -126,6 +127,7 @@ class KafkaProducerManagerIT {
 
       Operation signedupOperation = new Operation();
       signedupOperation.setName("SUBSCRIBE user/signedup");
+      signedupOperation.addResourcePath(TOPIC_NAME);
       service.setOperations(List.of(signedupOperation));
 
       // Assemble them into a repository.
@@ -166,8 +168,10 @@ class KafkaProducerManagerIT {
          String json = AvroUtil.avroToJson(message, union);
          assertTrue(json.contains("Alice") || json.contains("bob@example.com"));
          assertTrue(json.contains("displayName") || json.contains("name"));
-         // We'll probably have a {"displayName": "bob@example.com"} result here because of the union type
-         // and the limitation of Avro that doesn't serialize property names. Both schema can actually be used
+         // We'll probably have a {"displayName": "bob@example.com"} result here because
+         // of the union type
+         // and the limitation of Avro that doesn't serialize property names. Both schema
+         // can actually be used
          // for deserialization and so the first wins!
       }
    }
@@ -180,7 +184,7 @@ class KafkaProducerManagerIT {
                   .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
                   .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8889")
                   .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS",
-                        //"PLAINTEXT://" + kafkaContainer.getNetworkAliases().get(0) + ":9092")
+                        // "PLAINTEXT://" + kafkaContainer.getNetworkAliases().get(0) + ":9092")
                         "PLAINTEXT://kafka:19092")
                   .waitingFor(Wait.forHttp("/subjects").forStatusCode(200));
       schemaRegistryContainer.start();
@@ -207,6 +211,7 @@ class KafkaProducerManagerIT {
 
       Operation signedupOperation = new Operation();
       signedupOperation.setName("SUBSCRIBE user/signedup");
+      signedupOperation.addResourcePath(TOPIC_NAME);
       service.setOperations(List.of(signedupOperation));
 
       // Assemble them into a repository.

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerTest.java
@@ -26,9 +26,11 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This is a test case for KafkaProducerManager.
+ *
  * @author laurent
  */
 class KafkaProducerManagerTest {
@@ -54,11 +56,11 @@ class KafkaProducerManagerTest {
       AsyncMockDefinition definition = new AsyncMockDefinition(service, operation, eventsMessages);
 
       String topicName = producerManager.getTopicName(definition, eventMessage);
-      assertEquals("StreetlightsAPI-0.1.0-receiveLightMeasurement", topicName);
+      assertEquals("smartylighting.streetlights.1.0.event.lighting.measured", topicName);
    }
 
    @Test
-   void testGetDynamicTopicName() {
+   void testGetTopicNameThrowsWhenMultipleResourcePaths() {
       KafkaProducerManager producerManager = new KafkaProducerManager();
 
       Service service = new Service();
@@ -68,22 +70,38 @@ class KafkaProducerManagerTest {
       Operation operation = new Operation();
       operation.setName("RECEIVE receiveLightMeasurement");
       operation.setMethod("RECEIVE");
-      operation.setDispatcher("URI_PARTS");
-      operation.setDispatcherRules("/streetlightId");
       operation.setResourcePaths(Set.of("smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured",
             "smartylighting.streetlights.1.0.event.da059782-3ad0-4e45-88ce-ef3392bc7797.lighting.measured"));
       service.addOperation(operation);
 
       EventMessage eventMessage = new EventMessage();
       eventMessage.setName("Sample");
-      eventMessage.setDispatchCriteria("streetlightId=da059782-3ad0-4e45-88ce-ef3392bc7797");
       List<EventMessage> eventsMessages = List.of(eventMessage);
 
       AsyncMockDefinition definition = new AsyncMockDefinition(service, operation, eventsMessages);
 
-      String topicName = producerManager.getTopicName(definition, eventMessage);
-      assertEquals(
-            "StreetlightsAPI-0.1.0-smartylighting.streetlights.1.0.event.da059782-3ad0-4e45-88ce-ef3392bc7797.lighting.measured",
-            topicName);
+      assertThrows(IllegalArgumentException.class, () -> producerManager.getTopicName(definition, eventMessage));
+   }
+
+   @Test
+   void testGetTopicNameThrowsWhenNoResourcePaths() {
+      KafkaProducerManager producerManager = new KafkaProducerManager();
+
+      Service service = new Service();
+      service.setName("Streetlights API");
+      service.setVersion("0.1.0");
+
+      Operation operation = new Operation();
+      operation.setName("RECEIVE receiveLightMeasurement");
+      operation.setMethod("RECEIVE");
+      service.addOperation(operation);
+
+      EventMessage eventMessage = new EventMessage();
+      eventMessage.setName("Sample");
+      List<EventMessage> eventsMessages = List.of(eventMessage);
+
+      AsyncMockDefinition definition = new AsyncMockDefinition(service, operation, eventsMessages);
+
+      assertThrows(IllegalArgumentException.class, () -> producerManager.getTopicName(definition, eventMessage));
    }
 }

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerTest.java
@@ -56,11 +56,11 @@ class KafkaProducerManagerTest {
       AsyncMockDefinition definition = new AsyncMockDefinition(service, operation, eventsMessages);
 
       String topicName = producerManager.getTopicName(definition, eventMessage);
-      assertEquals("smartylighting.streetlights.1.0.event.lighting.measured", topicName);
+      assertEquals("StreetlightsAPI-0.1.0-receiveLightMeasurement", topicName);
    }
 
    @Test
-   void testGetTopicNameThrowsWhenMultipleResourcePaths() {
+   void testGetDynamicTopicName() {
       KafkaProducerManager producerManager = new KafkaProducerManager();
 
       Service service = new Service();
@@ -70,38 +70,23 @@ class KafkaProducerManagerTest {
       Operation operation = new Operation();
       operation.setName("RECEIVE receiveLightMeasurement");
       operation.setMethod("RECEIVE");
+      operation.setDispatcher("URI_PARTS");
+      operation.setDispatcherRules("/streetlightId");
       operation.setResourcePaths(Set.of("smartylighting.streetlights.1.0.event.{streetlightId}.lighting.measured",
             "smartylighting.streetlights.1.0.event.da059782-3ad0-4e45-88ce-ef3392bc7797.lighting.measured"));
       service.addOperation(operation);
 
       EventMessage eventMessage = new EventMessage();
       eventMessage.setName("Sample");
+      eventMessage.setDispatchCriteria("streetlightId=da059782-3ad0-4e45-88ce-ef3392bc7797");
       List<EventMessage> eventsMessages = List.of(eventMessage);
 
       AsyncMockDefinition definition = new AsyncMockDefinition(service, operation, eventsMessages);
 
-      assertThrows(IllegalArgumentException.class, () -> producerManager.getTopicName(definition, eventMessage));
-   }
+      String topicName = producerManager.getTopicName(definition, eventMessage);
 
-   @Test
-   void testGetTopicNameThrowsWhenNoResourcePaths() {
-      KafkaProducerManager producerManager = new KafkaProducerManager();
-
-      Service service = new Service();
-      service.setName("Streetlights API");
-      service.setVersion("0.1.0");
-
-      Operation operation = new Operation();
-      operation.setName("RECEIVE receiveLightMeasurement");
-      operation.setMethod("RECEIVE");
-      service.addOperation(operation);
-
-      EventMessage eventMessage = new EventMessage();
-      eventMessage.setName("Sample");
-      List<EventMessage> eventsMessages = List.of(eventMessage);
-
-      AsyncMockDefinition definition = new AsyncMockDefinition(service, operation, eventsMessages);
-
-      assertThrows(IllegalArgumentException.class, () -> producerManager.getTopicName(definition, eventMessage));
+      assertEquals(
+            "StreetlightsAPI-0.1.0-smartylighting.streetlights.1.0.event.da059782-3ad0-4e45-88ce-ef3392bc7797.lighting.measured",
+            topicName);
    }
 }

--- a/minions/async/src/test/resources/io/github/microcks/minion/async/user-signedup-asyncapi-3.0-reply.yaml
+++ b/minions/async/src/test/resources/io/github/microcks/minion/async/user-signedup-asyncapi-3.0-reply.yaml
@@ -1,0 +1,139 @@
+asyncapi: 3.0.0
+info:
+  title: User Account Service
+  version: 1.0.0
+  description: Service managing user account operations with request-reply pattern
+
+channels:
+  userSignup:
+    address: 'user/signup'
+    messages:
+      userSignupRequest:
+        $ref: '#/components/messages/userSignupRequest'
+    bindings:
+      googlepubsub:
+        topic: projects/my-project/topics/user-signup
+
+  userSignupReply:
+    address: 'user/signup/reply'
+    messages:
+      userSignupReply:
+        $ref: '#/components/messages/userSignupReply'
+    bindings:
+      googlepubsub:
+        topic: projects/my-project/topics/user-signup-reply
+
+  emailVerification:
+    address: /email/verification
+    messages:
+      userVerificationRequest:
+        $ref: '#/components/messages/userVerificationRequest'
+    bindings:
+      googlepubsub:
+        topic: projects/my-project/topics/user-verification
+
+  emailVerificationReply:
+    messages:
+      userVerificationReply:
+        $ref: '#/components/messages/userVerificationReply'
+
+operations:
+  onUserSignup:
+    action: receive
+    channel:
+      $ref: '#/channels/userSignup'
+    messages:
+      - $ref: '#/components/messages/userSignupRequest'
+    reply:
+      channel:
+        $ref: '#/channels/userSignupReply'
+      messages:
+        - $ref: '#/components/messages/userSignupReply'
+  onEmailVerification:
+    action: receive
+    channel:
+      $ref: '#/channels/emailVerification'
+    messages:
+      - $ref: '#/components/messages/userVerificationRequest'
+    reply:
+      address:
+        location: "$message.header#/replyTo"
+      channel:
+        $ref: '#/channels/emailVerificationReply'
+      messages:
+        - $ref: '#/components/messages/userVerificationReply'
+
+components:
+  messages:
+    userSignupRequest:
+      name: UserSignupRequest
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          email:
+            type: string
+            format: email
+          username:
+            type: string
+          fullName:
+            type: string
+      examples:
+        - name: john_signup
+          payload:
+            email: john.doe@example.com
+            username: johndoe
+            fullName: John Doe
+
+    userSignupReply:
+      name: UserSignupReply
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          userId:
+            type: string
+          status:
+            type: string
+            enum: [success, error]
+          message:
+            type: string
+      examples:
+        - name: john_signup
+          payload:
+            userId: usr-12345
+            status: success
+            message: User account created successfully
+
+    userVerificationRequest:
+      name: UserVerificationRequest
+      contentType: application/json
+      header:
+        type: object
+        properties:
+          replyTo:
+            type: string
+      payload:
+        type: object
+        properties:
+          email:
+            type: string
+            format: email
+      examples:
+        - name: john_verification
+          payload:
+            email: john.doe@example.com
+
+    userVerificationReply:
+      name: UserVerificationReply
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          status:
+            type: string
+            enum: [verified, unverified]
+        examples:
+          - name: john_verification
+            payload:
+              status: verified


### PR DESCRIPTION
### Description

- Implement a request reply handler that can monitor (kafka) topics for messages to reply to
- Implement the request reply manager that can create monitors for operations (from the definitions streamed from the microcks API)
- Implement testcontainers test for a request-reply interaction
- Implement a message matcher based on body content, wasn't able to use Dispatch Criteria (open to discussion)

### Related issue(s)

See https://github.com/microcks/microcks/issues/1916