### PR TITLE
feat(graphql): Add extensions and errors keys in response.

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
+++ b/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
@@ -15,65 +15,37 @@
  */
 package io.github.microcks.web;
 
-import io.github.microcks.domain.Header;
-import io.github.microcks.domain.Operation;
-import io.github.microcks.domain.ParameterConstraint;
-import io.github.microcks.domain.Resource;
-import io.github.microcks.domain.ResourceType;
-import io.github.microcks.domain.Response;
-import io.github.microcks.domain.Service;
-import io.github.microcks.repository.ResourceRepository;
-import io.github.microcks.repository.ServiceRepository;
-import io.github.microcks.util.ParameterConstraintUtil;
-import io.github.microcks.util.SafeLogger;
-import io.github.microcks.util.graphql.GraphQLHttpRequest;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.language.Argument;
-import graphql.language.Definition;
-import graphql.language.Document;
-import graphql.language.Field;
-import graphql.language.FragmentDefinition;
-import graphql.language.FragmentSpread;
-import graphql.language.OperationDefinition;
-import graphql.language.Selection;
-import graphql.language.SelectionSet;
-import graphql.language.StringValue;
-import graphql.language.VariableReference;
+import graphql.language.*;
+import graphql.parser.Parser;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
-import graphql.parser.Parser;
+import io.github.microcks.domain.*;
+import io.github.microcks.repository.ResourceRepository;
+import io.github.microcks.repository.ServiceRepository;
+import io.github.microcks.util.ParameterConstraintUtil;
+import io.github.microcks.util.SafeLogger;
+import io.github.microcks.util.delay.DelaySpec;
+import io.github.microcks.util.graphql.GraphQLHttpRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-
-import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import io.github.microcks.util.delay.DelaySpec;
+import java.util.*;
 
 /**
  * A controller for mocking GraphQL responses.
@@ -252,6 +224,29 @@ public class GraphQLController {
       for (GraphQLQueryResponse response : graphqlResponses) {
          dataNode.set(StringUtils.defaultIfBlank(response.getAlias(), response.getOperationName()),
                response.getJsonResponse().path("data").path(response.getOperationName()).deepCopy());
+      }
+      // Aggregate errors
+      ArrayNode errorsNode = mapper.createArrayNode();
+      for (GraphQLQueryResponse response : graphqlResponses) {
+         JsonNode errors = response.getJsonResponse().path("errors");
+         if (errors.isArray()) {
+            errors.forEach(errorsNode::add);
+         }
+      }
+      if (!errorsNode.isEmpty()) {
+         aggregated.set("errors", errorsNode);
+      }
+
+      // Aggregate extensions
+      ObjectNode extensionsNode = mapper.createObjectNode();
+      for (GraphQLQueryResponse response : graphqlResponses) {
+         JsonNode extensions = response.getJsonResponse().path("extensions");
+         if (extensions.isObject()) {
+            extensions.properties().forEach(e -> extensionsNode.set(e.getKey(), e.getValue().deepCopy()));
+         }
+      }
+      if (!extensionsNode.isEmpty()) {
+         aggregated.set("extensions", extensionsNode);
       }
       responseNode = aggregated;
       try {

--- a/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
+++ b/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
@@ -15,37 +15,66 @@
  */
 package io.github.microcks.web;
 
+import io.github.microcks.domain.Header;
+import io.github.microcks.domain.Operation;
+import io.github.microcks.domain.ParameterConstraint;
+import io.github.microcks.domain.Resource;
+import io.github.microcks.domain.ResourceType;
+import io.github.microcks.domain.Response;
+import io.github.microcks.domain.Service;
+import io.github.microcks.repository.ResourceRepository;
+import io.github.microcks.repository.ServiceRepository;
+import io.github.microcks.util.ParameterConstraintUtil;
+import io.github.microcks.util.SafeLogger;
+import io.github.microcks.util.graphql.GraphQLHttpRequest;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.language.*;
-import graphql.parser.Parser;
+import graphql.language.Argument;
+import graphql.language.Definition;
+import graphql.language.Document;
+import graphql.language.Field;
+import graphql.language.FragmentDefinition;
+import graphql.language.FragmentSpread;
+import graphql.language.OperationDefinition;
+import graphql.language.Selection;
+import graphql.language.SelectionSet;
+import graphql.language.StringValue;
+import graphql.language.VariableReference;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.idl.RuntimeWiring;
 import graphql.schema.idl.SchemaGenerator;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.TypeDefinitionRegistry;
-import io.github.microcks.domain.*;
-import io.github.microcks.repository.ResourceRepository;
-import io.github.microcks.repository.ServiceRepository;
-import io.github.microcks.util.ParameterConstraintUtil;
-import io.github.microcks.util.SafeLogger;
-import io.github.microcks.util.delay.DelaySpec;
-import io.github.microcks.util.graphql.GraphQLHttpRequest;
-import jakarta.servlet.http.HttpServletRequest;
+import graphql.parser.Parser;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.github.microcks.util.delay.DelaySpec;
 
 /**
  * A controller for mocking GraphQL responses.

--- a/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
@@ -17,6 +17,7 @@ package io.github.microcks.web;
 
 import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Service;
+
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;

--- a/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
@@ -17,10 +17,12 @@ package io.github.microcks.web;
 
 import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Service;
-
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.skyscreamer.jsonassert.RegularExpressionValueMatcher;
+import org.skyscreamer.jsonassert.comparator.CustomComparator;
 import org.springframework.http.ResponseEntity;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -154,6 +156,36 @@ class GraphQLControllerIT extends AbstractBaseIT {
                      + "      \"id\": \"ZmlsbXM6MQ==\",\n" + "      \"title\": \"A New Hope\",\n"
                      + "      \"episodeID\": 4,\n" + "      \"starCount\": 432\n" + "    }\n" + "  }\n" + "}",
                response.getBody(), JSONCompareMode.LENIENT);
+      } catch (Exception e) {
+         fail("No Exception should be thrown here");
+      }
+   }
+
+   @Test
+   void testFilmsGraphQLAPIMockingErrorsAndExtensions() {
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/graphql/films.graphql", true);
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/graphql/films-1.0-examples.yml", false);
+
+      String query = "{\"query\": \"mutation AddStar($filmId: String) {\\n" + "  addStar(filmId: $filmId) {\\n"
+            + "    id\\n" + "    title\\n" + "    episodeID\\n" + "    director\\n" + "    starCount\\n"
+            + "    rating\\n" + "  }\\n" + "}\", \"variables\": {\"filmId\": \"notavailable\"}" + "}";
+
+      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatusCode().value());
+      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertNotNull(response.getBody(), "Response body should not be null");
+      assertTrue(response.getBody().contains("\"errors\""));
+      assertTrue(response.getBody().contains("\"extensions\""));
+      try {
+         JSONAssert.assertEquals("{\n" + "  \"errors\": [\n" + "    {\n"
+               + "      \"message\": \"The system is not available, due to maintenance, please try again later.\",\n"
+               + "      \"extensions\": {\n" + "        \"code\": \"MAINTENANCE_MODE\"\n" + "      }\n" + "    }\n"
+               + "  ],\n" + "  \"data\": {\n" + "    \"addStar\": null\n" + "  },\n" + "  \"extensions\": {\n"
+               + "    \"correlationId\": {\n" + "      \"traceId\": \"123e4567-e89b-12d3-a456-426614174000\"\n"
+               + "    }\n" + "  }\n" + "}", response.getBody(),
+               new CustomComparator(JSONCompareMode.LENIENT,
+                     new Customization("extensions.correlationId.traceId", new RegularExpressionValueMatcher<>(
+                           "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"))));
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }

--- a/webapp/src/test/resources/io/github/microcks/util/graphql/films-1.0-examples.yml
+++ b/webapp/src/test/resources/io/github/microcks/util/graphql/films-1.0-examples.yml
@@ -146,6 +146,34 @@ operations:
               director: Irvin Kershner
               starCount: 434
               rating: 4.3
+    notAvailable:
+      request:
+        body:
+          query: |-
+            mutation AddStar($filmId: String) {
+              addStar(filmId: $filmId) {
+                id
+                title
+                episodeID
+                director
+                starCount
+                rating
+              }
+            }
+          variables:
+            filmId: notavailable
+      response:
+        mediaType: application/json
+        body:
+          errors:
+            - message: "The system is not available, due to maintenance, please try again later."
+              extensions:
+                code: "MAINTENANCE_MODE"
+          data:
+            addStar: null
+          extensions:
+            correlationId:
+              traceId: "{{guid()}}"
   addReview:
     addReview to ZmlsbXM6Mg==:
       request:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Adds support for errors and extensions top level key in graphql json response
- Adds integration test.


### Related issue(s)

Resolves #2034 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->

### Test results

query / mutation with errors and extensions in response

```shell
curl -X POST 'http://localhost:8080/graphql/Movie+Graph+API/1.0' -H 'Content-Type: application/json' -d '{"query":"mutation AddStar($filmId: String) {\n  addStar(filmId: $filmId) {\n    id\n    title\n    episodeID\n    director\n    starCount\n    rating\n  }\n}","variables":{"filmId":"notavailable"}}' | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   444  100   246  100   198  17545  14121 --:--:-- --:--:-- --:--:-- 34153
{
  "data": {
    "addStar": null
  },
  "errors": [
    {
      "message": "The system is not available, due to maintenance, please try again later.",
      "extensions": {
        "code": "MAINTENANCE_MODE"
      }
    }
  ],
  "extensions": {
    "correlationId": {
      "traceId": "0c025278-f518-47a0-b8b8-9088e277d968"
    }
  }
}

```

example query without errors/extensions
```shell
curl -X POST 'http://localhost:8080/graphql/Movie+Graph+API/1.0' -H 'Content-Type: application/json' -d '{"query":"query {\n  allFilms {\n    films {\n      id\n      title\n      episodeID\n      director\n      starCount\n      rating\n    }\n  }\n}"}' | jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   907  100   759  100   148  39857   7771 --:--:-- --:--:-- --:--:-- 50388
{
  "data": {
    "allFilms": {
      "films": [
        {
          "id": "ZmlsbXM6MQ==",
          "title": "A New Hope",
          "episodeID": 4,
          "director": "George Lucas",
          "starCount": 432,
          "rating": 4.3
        },
        {
          "id": "ZmlsbXM6Mg==",
          "title": "The Empire Strikes Back",
          "episodeID": 5,
          "director": "Irvin Kershner",
          "starCount": 433,
          "rating": 4.3
        },
        {
          "id": "ZmlsbXM6Mw==",
          "title": "Return of the Jedi",
          "episodeID": 6,
          "director": "Richard Marquand",
          "starCount": 434,
          "rating": 4.3
        },
        {
          "id": "ZmlsbXM6NA==",
          "title": "The Phantom Menace",
          "episodeID": 1,
          "director": "George Lucas",
          "starCount": 252,
          "rating": 3.2
        },
        {
          "id": "ZmlsbXM6NQ==",
          "title": "Attack of the Clones",
          "episodeID": 2,
          "director": "George Lucas",
          "starCount": 320,
          "rating": 3.9
        },
        {
          "id": "ZmlsbXM6Ng==",
          "title": "Revenge of the Sith",
          "episodeID": 3,
          "director": "George Lucas",
          "starCount": 410,
          "rating": 4.1
        }
      ]
    }
  }
}
```

![Screenshot_20260411_115554](https://github.com/user-attachments/assets/d9dd6c62-670b-4d5a-819a-13177d89a58a)

