### PR TITLE
feat: add TLS support for Microcks HTTP endpoint #1784

### DIFF
--- a/install/kubernetes/microcks/templates/configmap.yaml
+++ b/install/kubernetes/microcks/templates/configmap.yaml
@@ -147,6 +147,15 @@ data:
     grpc.server.privateKeyFilePath=/deployments/config/grpc/tls.key
     {{- end }}
 
+    {{- if .Values.microcks.httpEnableTLS }}
+
+    # HTTP server TLS properties
+    server.port=8443
+    server.ssl.enabled=true
+    server.ssl.certificate=/deployments/config/https/tls.crt
+    server.ssl.certificate-private-key=/deployments/config/https/tls.key
+    {{- end }}
+
     # AI Copilot configuration properties
     ai-copilot.enabled={{ .Values.features.aiCopilot.enabled }}
     ai-copilot.implementation={{ .Values.features.aiCopilot.implementation }}

--- a/install/kubernetes/microcks/templates/deployment.yaml
+++ b/install/kubernetes/microcks/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
         - name: grpc
           containerPort: 9090
           protocol: TCP
+        {{- if .Values.microcks.httpEnableTLS }}
+        - name: https
+          containerPort: 8443
+          protocol: TCP
+        {{- end }}
         env:
           - name: JAVA_OPTIONS
             value: "-XX:+TieredCompilation -XX:TieredStopAtLevel=2"
@@ -121,8 +126,8 @@ spec:
         livenessProbe:
           httpGet:
             path: "/api/health"
-            port: 8080
-            scheme: HTTP
+            port: {{ if .Values.microcks.httpEnableTLS }}8443{{ else }}8080{{ end }}
+            scheme: {{ if .Values.microcks.httpEnableTLS }}HTTPS{{ else }}HTTP{{ end }}
           initialDelaySeconds: 25
           timeoutSeconds: 3
           periodSeconds: 10
@@ -131,8 +136,8 @@ spec:
         readinessProbe:
           httpGet:
             path: "/api/health"
-            port: 8080
-            scheme: HTTP
+            port: {{ if .Values.microcks.httpEnableTLS }}8443{{ else }}8080{{ end }}
+            scheme: {{ if .Values.microcks.httpEnableTLS }}HTTPS{{ else }}HTTP{{ end }}
           initialDelaySeconds: 35
           timeoutSeconds: 3
           periodSeconds: 10
@@ -141,8 +146,8 @@ spec:
         startupProbe:
           httpGet:
             path: "/api/health"
-            port: 8080
-            scheme: HTTP
+            port: {{ if .Values.microcks.httpEnableTLS }}8443{{ else }}8080{{ end }}
+            scheme: {{ if .Values.microcks.httpEnableTLS }}HTTPS{{ else }}HTTP{{ end }}
           initialDelaySeconds: 10
           timeoutSeconds: 3
           periodSeconds: 10
@@ -154,6 +159,10 @@ spec:
           {{- if (.Values.microcks.grpcEnableTLS) }}
           - name: "{{ .Values.appName }}-grpc-certs"
             mountPath: "/deployments/config/grpc"
+          {{- end }}
+          {{- if .Values.microcks.httpEnableTLS }}
+          - name: "{{ .Values.appName }}-http-certs"
+            mountPath: "/deployments/config/https"
           {{- end }}
           {{- if eq .Values.features.async.kafka.install false }}
             {{- if not (eq .Values.features.async.kafka.authentication.type "none") }}
@@ -180,6 +189,11 @@ spec:
         - name: "{{ .Values.appName }}-grpc-certs"
           secret:
             secretName: "{{ .Values.microcks.grpcSecretRef | default (print .Values.appName "-microcks-grpc-secret") }}"
+        {{- end }}
+        {{- if .Values.microcks.httpEnableTLS }}
+        - name: "{{ .Values.appName }}-http-certs"
+          secret:
+            secretName: "{{ .Values.microcks.httpSecretRef | default (print .Values.appName "-microcks-http-secret") }}"
         {{- end }}
         {{- if eq .Values.features.async.kafka.install false }}
           {{- if not (eq .Values.features.async.kafka.authentication.type "none") }}

--- a/install/kubernetes/microcks/templates/ingress.yaml
+++ b/install/kubernetes/microcks/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
           service:
             name: "{{ .Values.appName }}"
             port:
-              number: 8080
+              number: {{ if .Values.microcks.httpEnableTLS }}8443{{ else }}8080{{ end }}
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1

--- a/install/kubernetes/microcks/templates/service.yaml
+++ b/install/kubernetes/microcks/templates/service.yaml
@@ -13,8 +13,8 @@ metadata:
 spec:
   ports:
   - protocol: TCP
-    port: 8080
-    targetPort: 8080
+    port: {{ if .Values.microcks.httpEnableTLS }}8443{{ else }}8080{{ end }}
+    targetPort: {{ if .Values.microcks.httpEnableTLS }}8443{{ else }}8080{{ end }}
     name: spring
   type: {{ .Values.microcks.serviceType | default "ClusterIP" | quote }}
   sessionAffinity: None

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -36,6 +36,10 @@ microcks:
 
   grpcEnableTLS: true
   #grpcSecretRef: my-secret-for-microcks-grpc
+
+  # Uncomment to enable TLS on Microcks HTTP/HTTPS endpoint directly.
+  httpEnableTLS: false
+  #httpSecretRef: my-secret-for-microcks-http
   #grpcIngressClassName: nginx
 
   # gRPC ingress annotations are also used for GRPCRoute resources.


### PR DESCRIPTION
Summary:-
Fixes -1784

 Changes:-
- Added httpEnableTLS and httpSecretRef options in values.yaml
- Added HTTPS port 8443 in deployment.yaml
- Added conditional volumeMount and volume for HTTP TLS certificate
- Updated liveness, readiness and startup probes to support HTTPS
- Added Spring Boot SSL configuration in `configmap.yaml`

 How to use:-
To enable TLS on the HTTP endpoint, set the following values:
```yaml
microcks:
  httpEnableTLS: true
  httpSecretRef: my-tls-secret
```
The secret must be of type 'kubernetes.io/tls' containing 'tls.crt' and 'tls.key'.

testing
- helm lint passed with 0 failures
- helm template verified all TLS properties are generated correctly