### PR TITLE
feat(mocks): make ServiceStateStore default TTL configurable

### DIFF
--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -87,6 +87,10 @@ microcks:
     #- name: CORS_REST_ALLOW_CREDENTIALS
     #  value: 'true'
 
+    #- name: MCP_SSE_TIMEOUT
+    #  value: "900000"
+    #- name: MOCKS_SERVICE_STATE_STORE_DEFAULT_TTL
+    #  value: "30"
   #logLevel: TRACE | DEBUG | INFO | WARN
   logLevel: INFO
 

--- a/webapp/src/main/java/io/github/microcks/service/ServiceStateStore.java
+++ b/webapp/src/main/java/io/github/microcks/service/ServiceStateStore.java
@@ -33,6 +33,7 @@ public class ServiceStateStore implements StateStore {
 
    private final ServiceStateRepository repository;
    private final String serviceId;
+   private final int defaultSecondsTtl;
 
    /**
     * Build a ServiceStateStore for required elements.
@@ -40,12 +41,24 @@ public class ServiceStateStore implements StateStore {
     * @param serviceId  The ID of Service this state store will be scoped to
     */
    public ServiceStateStore(ServiceStateRepository repository, String serviceId) {
+      this(repository, serviceId, DEFAULT_SECONDS_TTL);
+   }
+
+   /**
+    * Build a ServiceStateStore for required elements with a customized default TTL.
+    * 
+    * @param repository        The MongoDB repository to use for persistence
+    * @param serviceId         The ID of Service this state store will be scoped to
+    * @param defaultSecondsTtl The default Time To Live in seconds for the state elements
+    */
+   public ServiceStateStore(ServiceStateRepository repository, String serviceId, int defaultSecondsTtl) {
       this.repository = repository;
       this.serviceId = serviceId;
+      this.defaultSecondsTtl = defaultSecondsTtl;
    }
 
    public void put(String key, String value) {
-      put(key, value, DEFAULT_SECONDS_TTL);
+      put(key, value, defaultSecondsTtl);
    }
 
    public void put(String key, String value, int secondsTTL) {

--- a/webapp/src/main/java/io/github/microcks/web/GraphQLInvocationProcessor.java
+++ b/webapp/src/main/java/io/github/microcks/web/GraphQLInvocationProcessor.java
@@ -81,6 +81,9 @@ public class GraphQLInvocationProcessor {
    @Value("${mocks.enable-invocation-stats}")
    private Boolean enableInvocationStats;
 
+   @Value("${mocks.service-state-store.default-ttl:10}")
+   private int defaultTtl;
+
    /**
     * Build a GraphQLInvocationProcessor with required dependencies.
     * @param serviceStateRepository The repository to access service state
@@ -248,7 +251,8 @@ public class GraphQLInvocationProcessor {
                try {
                   // Evaluating request with script coming from operation dispatcher rules.
                   ScriptContext scriptContext = ScriptEngineBinder.buildEvaluationContext(scriptEngine, body,
-                        requestContext, new ServiceStateStore(serviceStateRepository, service.getId()), request);
+                        requestContext, new ServiceStateStore(serviceStateRepository, service.getId(), defaultTtl),
+                        request);
                   dispatchCriteria = (String) scriptEngine.eval(dispatcherRules, scriptContext);
                } catch (Exception e) {
                   log.error("Error during Script evaluation", e);
@@ -256,7 +260,7 @@ public class GraphQLInvocationProcessor {
                break;
             case DispatchStyles.JS:
                Engine scriptContext = JsScriptEngineBinder.buildEvaluationContext(body, requestContext,
-                     new ServiceStateStore(serviceStateRepository, service.getId()), request);
+                     new ServiceStateStore(serviceStateRepository, service.getId(), defaultTtl), request);
                String result = JsScriptEngineBinder.invokeProcessFn(dispatcherRules, scriptContext);
                if (result != null) {
                   dispatchCriteria = result;

--- a/webapp/src/main/java/io/github/microcks/web/GrpcInvocationProcessor.java
+++ b/webapp/src/main/java/io/github/microcks/web/GrpcInvocationProcessor.java
@@ -94,6 +94,9 @@ public class GrpcInvocationProcessor {
    @Value("${mocks.enable-invocation-stats}")
    private Boolean enableInvocationStats;
 
+   @Value("${mocks.service-state-store.default-ttl:10}")
+   private int defaultTtl;
+
    /**
     * Build a GrpcInvocationProcessor with required dependencies.
     * @param serviceStateRepository       The repository to access service state
@@ -257,8 +260,8 @@ public class GrpcInvocationProcessor {
                      StringToStringsMap headers = GrpcMetadataUtil.convertToMap(metadata);
                      // Evaluating request with script coming from operation dispatcher rules.
                      ScriptContext scriptContext = ScriptEngineBinder.buildEvaluationContext(scriptEngine, jsonBody,
-                           requestContext, new ServiceStateStore(serviceStateRepository, service.getId()), headers,
-                           null);
+                           requestContext, new ServiceStateStore(serviceStateRepository, service.getId(), defaultTtl),
+                           headers, null);
                      dispatchCriteria = (String) scriptEngine.eval(dispatcherRules, scriptContext);
                   } catch (Exception e) {
                      // Get current span and record failure
@@ -279,7 +282,7 @@ public class GrpcInvocationProcessor {
                      StringToStringsMap headers = GrpcMetadataUtil.convertToMap(metadata);
                      // Evaluating request with script coming from operation dispatcher rules.
                      Engine scriptContext = JsScriptEngineBinder.buildEvaluationContext(jsonBody, requestContext,
-                           new ServiceStateStore(serviceStateRepository, service.getId()), headers, null);
+                           new ServiceStateStore(serviceStateRepository, service.getId(), defaultTtl), headers, null);
                      dispatchCriteria = JsScriptEngineBinder.invokeProcessFn(dispatcherRules, scriptContext);
                   } catch (Exception e) {
                      log.error(SCRIPT_EVALUATION_ERROR, e);

--- a/webapp/src/main/java/io/github/microcks/web/RestInvocationProcessor.java
+++ b/webapp/src/main/java/io/github/microcks/web/RestInvocationProcessor.java
@@ -111,6 +111,9 @@ public class RestInvocationProcessor {
    @Value("${mocks.enable-binary-response-decode:false}")
    private boolean enableBinaryResponseDecode;
 
+   @Value("${mocks.service-state-store.default-ttl:10}")
+   private int defaultTtl;
+
    /**
     * Build a RestMockInvocationProcessor with required dependencies.
     * @param serviceStateRepository       The repository to access service state
@@ -355,8 +358,8 @@ public class RestInvocationProcessor {
                      // Evaluating request with script coming from operation dispatcher rules.
                      String script = ScriptEngineBinder.ensureSoapUICompatibility(dispatcherRules);
                      ScriptContext scriptContext = ScriptEngineBinder.buildEvaluationContext(scriptEngine, body,
-                           requestContext, new ServiceStateStore(serviceStateRepository, service.getId()), request,
-                           uriParameters);
+                           requestContext, new ServiceStateStore(serviceStateRepository, service.getId(), defaultTtl),
+                           request, uriParameters);
                      dispatchCriteria = (String) scriptEngine.eval(script, scriptContext);
                   } catch (Exception e) {
                      // Get current span and record failure
@@ -378,7 +381,8 @@ public class RestInvocationProcessor {
                   // Evaluating request with script coming from operation dispatcher rules.
                   String script = JsScriptEngineBinder.wrapIntoFunction(dispatcherRules);
                   Engine scriptContext = JsScriptEngineBinder.buildEvaluationContext(body, requestContext,
-                        new ServiceStateStore(serviceStateRepository, service.getId()), request, jsUriParameters);
+                        new ServiceStateStore(serviceStateRepository, service.getId(), defaultTtl), request,
+                        jsUriParameters);
                   String result = JsScriptEngineBinder.invokeProcessFn(script, scriptContext);
                   if (result != null) {
                      dispatchCriteria = result;

--- a/webapp/src/main/java/io/github/microcks/web/SoapController.java
+++ b/webapp/src/main/java/io/github/microcks/web/SoapController.java
@@ -112,6 +112,9 @@ public class SoapController {
    @Value("${validation.resourceUrl}")
    private String resourceUrl;
 
+   @Value("${mocks.service-state-store.default-ttl:10}")
+   private int defaultTtl;
+
 
    /**
     * Build a SoapController with required dependencies.
@@ -485,7 +488,7 @@ public class SoapController {
          // Evaluating request with script coming from operation dispatcher rules.
          String script = ScriptEngineBinder.ensureSoapUICompatibility(dispatcherRules);
          ScriptContext scriptContext = ScriptEngineBinder.buildEvaluationContext(scriptEngine, body, requestContext,
-               new ServiceStateStore(serviceStateRepository, service.getId()), request);
+               new ServiceStateStore(serviceStateRepository, service.getId(), defaultTtl), request);
 
          return new DispatchContext((String) scriptEngine.eval(script, scriptContext), requestContext);
       } catch (Exception e) {
@@ -509,7 +512,7 @@ public class SoapController {
       Map<String, Object> requestContext = new HashMap<>();
       try {
          Engine scriptContext = JsScriptEngineBinder.buildEvaluationContext(body, requestContext,
-               new ServiceStateStore(serviceStateRepository, service.getId()), request);
+               new ServiceStateStore(serviceStateRepository, service.getId(), defaultTtl), request);
 
          return new DispatchContext(JsScriptEngineBinder.invokeProcessFn(dispatcherRules, scriptContext),
                requestContext);

--- a/webapp/src/test/java/io/github/microcks/service/ServiceStateStoreTest.java
+++ b/webapp/src/test/java/io/github/microcks/service/ServiceStateStoreTest.java
@@ -95,4 +95,26 @@ class ServiceStateStoreTest {
       state = repository.findByServiceIdAndKey(SERVICE_ID, "foo");
       assertNull(state);
    }
+
+   @Test
+   void testCustomDefaultTtl() {
+      // Arrange
+      int customTtl = 60;
+      ServiceStateStore customStore = new ServiceStateStore(repository, SERVICE_ID, customTtl);
+
+      // Act
+      customStore.put("my-key", "my-value");
+
+      // Assert
+      ServiceState state = repository.findByServiceIdAndKey(SERVICE_ID, "my-key");
+      assertNotNull(state);
+      assertEquals("my-value", state.getValue());
+
+      // Verify expiration is set correctly
+      long expectedExpiration = System.currentTimeMillis() + (customTtl * 1000L);
+      long diff = Math.abs(expectedExpiration - state.getExpireAt().getTime());
+
+      // Allow 1 second variance for processing execution time
+      assertTrue(diff < 1000, "TTL Expiration should be within bounds");
+   }
 }


### PR DESCRIPTION
Fixes #1964

Make ServiceStateStore default TTL configurable.

- Add property `mocks.service-state-store.default-ttl`
- Default remains 10 seconds
- Inject configurable TTL into invocation processors
- Add unit test validating custom TTL

No breaking changes.