### PR TITLE
chore: #2058 Use unnamed patterns in commons exception handlers

### DIFF
--- a/commons/util-el/src/main/java/io/github/microcks/util/el/function/NowELFunction.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/function/NowELFunction.java
@@ -80,7 +80,7 @@ public class NowELFunction implements ELFunction {
       }
       try {
          int d = Integer.parseInt(strNum);
-      } catch (NumberFormatException nfe) {
+      } catch (NumberFormatException _) {
          return false;
       }
       return true;

--- a/commons/util-el/src/main/java/io/github/microcks/util/el/function/RandomIntELFunction.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/function/RandomIntELFunction.java
@@ -34,7 +34,7 @@ public class RandomIntELFunction extends AbstractRandomELFunction {
                int maxValue = Integer.MAX_VALUE;
                try {
                   maxValue = Integer.parseInt(args[0]);
-               } catch (NumberFormatException nfe) {
+               } catch (NumberFormatException _) {
                   // Ignore, we'll stick to integer max value.
                }
                return String.valueOf(getRandom().nextInt(maxValue));
@@ -44,7 +44,7 @@ public class RandomIntELFunction extends AbstractRandomELFunction {
                try {
                   minValue = Integer.parseInt(args[0]);
                   maxValue = Integer.parseInt(args[1]);
-               } catch (NumberFormatException nfe) {
+               } catch (NumberFormatException _) {
                   // Ignore, we'll stick to the defaults.
                }
                return String.valueOf(getRandom().nextInt(maxValue - minValue) + minValue);

--- a/commons/util-el/src/main/java/io/github/microcks/util/el/function/RandomStringELFunction.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/function/RandomStringELFunction.java
@@ -37,7 +37,7 @@ public class RandomStringELFunction extends AbstractRandomELFunction {
          int maxLength = DEFAULT_LENGTH;
          try {
             maxLength = Integer.parseInt(args[0]);
-         } catch (NumberFormatException nfe) {
+         } catch (NumberFormatException _) {
             // Ignore, we'll stick to the default.
          }
          return generateString(getRandom(), maxLength);

--- a/commons/util-el/src/test/java/io/github/microcks/util/el/TemplateEngineTest.java
+++ b/commons/util-el/src/test/java/io/github/microcks/util/el/TemplateEngineTest.java
@@ -57,7 +57,7 @@ class TemplateEngineTest {
       String content = null;
       try {
          content = engine.getValue(template);
-      } catch (Throwable t) {
+      } catch (Throwable _) {
          fail("Contextless template should not fail.");
       }
       assertTrue(content.startsWith("{\"signedAt\": \"1"));
@@ -75,7 +75,7 @@ class TemplateEngineTest {
       try {
          content = engine.getValue(template);
          postmanContent = engine.getValue(postmanTemplate);
-      } catch (Throwable t) {
+      } catch (Throwable _) {
          fail("Contextless template should not fail.");
       }
       assertTrue(content.startsWith("{\"signedAt\": \"1"));


### PR DESCRIPTION
### Summary
Replace unused exception variables (nfe, t) with the Java 22+ unnamed pattern (_) across the commons/util-el module, addressing 6 of the maintainability findings raised by SonarCloud and aggregated under #2058.

### Sites changed
NowELFunction#isInteger
RandomIntELFunction#evaluate (two catches)
RandomStringELFunction#evaluate
TemplateEngineTest#testContextlessTemplate
TemplateEngineTest#testPostmanNotationCompatibility
Each catch body either has only a comment or calls fail(...) with a hard-coded message — the exception variable was never read.

### Notes
This rule (java:S???? for unnamed patterns) became applicable after the Java 25 upgrade in #2052 / #2057.
I did not include EvaluationContextTest's newInstance Sonar finding in this PR — it's a different rule with non-trivial replacement (Class.getDeclaredConstructor().newInstance() introduces additional checked exceptions). Happy to do it as a follow-up.
