### PR TITLE
chore: #2058 Clean up ExpressionParser.validateSuffixFound

### DIFF
--- a/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/ExpressionParser.java
@@ -68,7 +68,7 @@ public class ExpressionParser {
             int afterPrefixIndex = prefixIndex + expressionPrefix.length();
             int suffixIndex = skipToCorrectEndSuffix(expressionSuffix, template, afterPrefixIndex);
 
-            validateSuffixFound(template, expressionPrefix, expressionSuffix, prefixIndex, suffixIndex);
+            validateSuffixFound(template, expressionSuffix, prefixIndex, suffixIndex);
             validateSuffixNotEmpty(template, expressionPrefix, expressionSuffix, prefixIndex, afterPrefixIndex,
                   suffixIndex);
 
@@ -97,13 +97,14 @@ public class ExpressionParser {
    }
 
    /** Validate that the suffix was found. */
-   private static void validateSuffixFound(String template, String expressionPrefix, String expressionSuffix,
-         int prefixIndex, int suffixIndex) throws ParseException {
+   private static void validateSuffixFound(String template, String expressionSuffix, int prefixIndex, int suffixIndex)
+         throws ParseException {
       if (suffixIndex == -1) {
+         String unparsed = template.substring(prefixIndex);
          log.info("No ending suffix '{}' for expression starting at character {}: {}", expressionSuffix, prefixIndex,
-               template.substring(prefixIndex));
+               unparsed);
          throw new ParseException(template, prefixIndex, "No ending suffix '" + expressionSuffix
-               + "' for expression starting at character " + prefixIndex + ": " + template.substring(prefixIndex));
+               + "' for expression starting at character " + prefixIndex + ": " + unparsed);
       }
    }
 


### PR DESCRIPTION
Address two Sonar maintainability findings on ExpressionParser:

- Remove unused 'expressionPrefix' parameter from the private validateSuffixFound helper and update its single call site.
- Extract template.substring(prefixIndex) into a local 'unparsed' variable so it is computed once and reused for both the log message and the ParseException message, avoiding the eager invocation that was being passed as a logger argument.

Behaviour is unchanged.

### Description

- `commons/util-el` — `ExpressionParser.validateSuffixFound`: removed the unused `expressionPrefix` parameter and updated the single private call site (rule: unused method parameter, L100).
- `commons/util-el` — `ExpressionParser.validateSuffixFound`: extracted `template.substring(prefixIndex)` into a local `unparsed` variable, eliminating the duplicate substring call and the eager method invocation passed as a logger argument (rule: invoke method only conditionally, L104).
- No public API surface changed; `validateSuffixFound` is `private static` with a single caller inside `parseExpressions`.
- `mvn spotless:check -pl commons/util-el` passes locally; existing tests in `commons/util-el` exercise both branches of `validateSuffixFound` (missing-suffix path) so behaviour is covered by the current suite.

### Related issue(s)

See also #2058
