### PR TITLE
chore: #2058 Catch Exception instead of Throwable in AsyncAPITestManager

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
@@ -138,16 +138,16 @@ public class AsyncAPITestManager {
                logger.infof("AsyncAPITestThread for {%s} was timed-out", specification.getTestResultId());
                testCaseReturn.addTestReturn(new TestReturn(TestReturn.FAILURE_CODE, specification.getTimeoutMS(),
                      "Timeout: no message received in " + specification.getTimeoutMS() + " ms", null, null));
-            } catch (Throwable t) {
+            } catch (Exception e) {
                // We faced a low-level issue... add an empty test return with failure and message.
-               logger.error("Caught a low-level throwable", t);
+               logger.error("Caught a low-level exception", e);
                testCaseReturn
                      .addTestReturn(new TestReturn(TestReturn.FAILURE_CODE, System.currentTimeMillis() - startTime,
-                           "Exception: low-level failure: " + t.getMessage(), null, null));
+                           "Exception: low-level failure: " + e.getMessage(), null, null));
             } finally {
                try {
                   messageConsumptionTask.close();
-               } catch (Throwable t) {
+               } catch (Exception _) {
                   // This was best effort, just ignore the exception...
                }
                executorService.shutdown();


### PR DESCRIPTION
### Description

- `minions/async` — `AsyncAPITestManager#runTest`: outer catch around `executorService.invokeAny` narrowed from `Throwable` to `Exception`; variable renamed `t` → `e` and the log message and test-return reason text updated to match (rule: `java:S1181`, L141).
- `minions/async` — `AsyncAPITestManager#runTest`: finally-block catch around `messageConsumptionTask.close()` narrowed from `Throwable` to `Exception`. The variable is unused (best-effort cleanup), so the unnamed pattern `_` is used (JEP 456, Java 22+), matching the convention introduced in #2059 (rule: `java:S1181`, L150).
- No behavioural change for the normal `Exception` path. JVM `Error`s will now propagate instead of being silently turned into `FAILURE` test returns, which is the intended behaviour for fatal conditions like `OutOfMemoryError`.
- `mvn spotless:check -pl minions/async` passes locally.

### Related issue(s)

See also #2058