### PR TITLE
chore: #2058 Re-interrupt thread when catching InterruptedException

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
@@ -128,6 +128,7 @@ public class AsyncAPITestManager {
                logger.debugf("Consumption ends and we got {%d} messages to validate", outputs.size());
             } catch (InterruptedException e) {
                logger.infof("AsyncAPITestThread for {%s} was interrupted", specification.getTestResultId());
+               Thread.currentThread().interrupt();
             } catch (ExecutionException e) {
                logger.errorf(e, "AsyncAPITestThread for {%s} raise an ExecutionException",
                      specification.getTestResultId());

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/NATSMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/NATSMessageConsumptionTask.java
@@ -136,6 +136,7 @@ public class NATSMessageConsumptionTask implements MessageConsumptionTask {
             subscriber.close();
          } catch (InterruptedException e) {
             logger.warn("Closing NATS subscriber raised an exception", e);
+            Thread.currentThread().interrupt();
          }
       }
    }

--- a/webapp/src/main/java/io/github/microcks/web/MockControllerCommons.java
+++ b/webapp/src/main/java/io/github/microcks/web/MockControllerCommons.java
@@ -348,8 +348,9 @@ public class MockControllerCommons {
             synchronized (semaphore) {
                try {
                   semaphore.wait(waitDelay - duration);
-               } catch (Exception e) {
+               } catch (InterruptedException e) {
                   log.debug("Delay semaphore was interrupted");
+                  Thread.currentThread().interrupt();
                }
             }
          }


### PR DESCRIPTION
### Description

- `minions/async` — `AsyncAPITestManager.AsyncAPITestThread#run` (L129): re-interrupt after logging that the test thread was interrupted.
- `minions/async` — `NATSMessageConsumptionTask#close` (L137): re-interrupt after logging the close-time exception so callers can still observe cancellation.
- `webapp` — `MockControllerCommons#waitForDelay` (L350): narrow the overly broad `catch (Exception)` to `catch (InterruptedException)` — `Object#wait()` only declares `InterruptedException`, and the surrounding `synchronized (semaphore)` block guarantees we hold the monitor, so the catch was wider than necessary — then re-interrupt.
- No behavioural change on the normal exception-free path. Interrupted threads will now correctly propagate the interrupt signal up the stack.
- `mvn spotless:check -pl minions/async,webapp` passes locally.

### Related issue(s)

See also #2058