### PR TITLE
chore: #2058 Harden pip install in health-check workflow

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -54,7 +54,7 @@ jobs:
         if: matrix.method == 'podman'
         run: |
           sudo apt-get update && sudo apt-get install -y podman python3-pip
-          pip3 install --user podman-compose
+          pip3 install --user --only-binary :all: podman-compose==1.5.0
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install Microcks (${{ matrix.method }}/${{ matrix.mode }})


### PR DESCRIPTION
Address two Sonar security findings on `.github/workflows/health-check.yml` line 57:
- Using dependencies without locking resolved versions
- Omitting `--only-binary :all:` can lead to the execution of setup scripts

### Description

- `.github/workflows/health-check.yml` — pinned `podman-compose` to `==1.5.0` (latest stable on PyPI as of writing) so the resolved version is deterministic across CI runs and a compromised newer release cannot land silently.
- Same line — added `--only-binary :all:` so pip is limited to pre-built wheels and cannot execute arbitrary code via `setup.py` during install.
- Both flags scoped to this single dependency install; no other workflow steps are affected.
- The job already runs in a fresh GitHub-hosted runner with `permissions: read-all` (workflow-level), so the blast radius of the previous unhardened install was limited — but pinning + binary-only is the right defensive posture for any CI install step.

### Related issue(s)

See also #2058