### PR TITLE
chore: #2058 Guard Optional access with isPresent() before get()

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
@@ -223,16 +223,19 @@ public class KafkaProducerManager {
 
          for (io.github.microcks.domain.Header header : headers) {
             // For Kafka, header is mono valued so just consider the first value.
-            String firstValue = header.getValues().stream().findFirst().get();
-            if (firstValue.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
-               try {
-                  renderedHeaders.add(new RecordHeader(header.getName(), engine.getValue(firstValue).getBytes()));
-               } catch (Throwable t) {
-                  logger.error("Failing at evaluating template " + firstValue, t);
+            Optional<String> firstValueOpt = header.getValues().stream().findFirst();
+            if (firstValueOpt.isPresent()) {
+               String firstValue = firstValueOpt.get();
+               if (firstValue.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
+                  try {
+                     renderedHeaders.add(new RecordHeader(header.getName(), engine.getValue(firstValue).getBytes()));
+                  } catch (Throwable t) {
+                     logger.error("Failing at evaluating template " + firstValue, t);
+                     renderedHeaders.add(new RecordHeader(header.getName(), firstValue.getBytes()));
+                  }
+               } else {
                   renderedHeaders.add(new RecordHeader(header.getName(), firstValue.getBytes()));
                }
-            } else {
-               renderedHeaders.add(new RecordHeader(header.getName(), firstValue.getBytes()));
             }
          }
          return renderedHeaders;

--- a/webapp/src/main/java/io/github/microcks/service/TestRunnerService.java
+++ b/webapp/src/main/java/io/github/microcks/service/TestRunnerService.java
@@ -74,6 +74,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -197,8 +198,14 @@ public class TestRunnerService {
 
       for (TestCaseResult testCaseResult : testResult.getTestCaseResults()) {
          // Retrieve operation corresponding to testCase.
-         Operation operation = service.getOperations().stream()
-               .filter(o -> o.getName().equals(testCaseResult.getOperationName())).findFirst().get();
+         Optional<Operation> operationOpt = service.getOperations().stream()
+               .filter(o -> o.getName().equals(testCaseResult.getOperationName())).findFirst();
+         if (!operationOpt.isPresent()) {
+            log.warn("No operation named '{}' found on service '{}', skipping test case",
+                  testCaseResult.getOperationName(), service.getName());
+            continue;
+         }
+         Operation operation = operationOpt.get();
          String testCaseId = IdBuilder.buildTestCaseId(testResult, operation);
 
          // Prepare collection of requests to launch.

--- a/webapp/src/main/java/io/github/microcks/util/metadata/ExamplesExporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/metadata/ExamplesExporter.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Mock repository exporter that exports Microcks domain objects definitions into the APIExamples YAML format.
@@ -171,7 +172,10 @@ public class ExamplesExporter implements MockRepositoryExporter {
       if (message.getHeaders() != null && !message.getHeaders().isEmpty()) {
          ObjectNode headersNode = messageNode.putObject("headers");
          for (Header header : message.getHeaders()) {
-            headersNode.put(header.getName(), header.getValues().stream().findFirst().get());
+            Optional<String> firstValueOpt = header.getValues().stream().findFirst();
+            if (firstValueOpt.isPresent()) {
+               headersNode.put(header.getName(), firstValueOpt.get());
+            }
          }
       }
    }

--- a/webapp/src/main/java/io/github/microcks/util/soapui/assertions/SchemaConformanceAssertion.java
+++ b/webapp/src/main/java/io/github/microcks/util/soapui/assertions/SchemaConformanceAssertion.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Assertion that checks if response content is actually conformance to a Schema definition.
@@ -60,7 +61,14 @@ public class SchemaConformanceAssertion implements SoapUIAssertion {
          log.debug("Asserting Soap response is valid against WSDL");
 
          // Validate against Soap message against WSDL.
-         Resource wsdl = context.resources().stream().filter(r -> r.getType() == ResourceType.WSDL).findFirst().get();
+         Optional<Resource> wsdlOpt = context.resources().stream().filter(r -> r.getType() == ResourceType.WSDL)
+               .findFirst();
+         if (!wsdlOpt.isPresent()) {
+            log.warn("No WSDL resource found for SOAP service, cannot validate response");
+            errorMessages = List.of("No WSDL resource available for SOAP validation");
+            return AssertionStatus.FAILED;
+         }
+         Resource wsdl = wsdlOpt.get();
          QName partQName = new QName(context.service().getXmlNS(), context.operation().getOutputName());
          errorMessages = SoapMessageValidator.validateSoapMessage(wsdl.getContent(), partQName,
                exchange.responseContent(), context.resourceUrl());


### PR DESCRIPTION
Sonar flagged four call sites that invoke `Optional#get()` without a preceding presence check (rule `java:S3655`). Any of these would throw `NoSuchElementException` at runtime if the Optional is empty. Each site is now guarded using the codebase's existing convention of `Optional<T> xxxOpt = ...; if (xxxOpt.isPresent()) { ... }`.

### Description

- `minions/async` — `KafkaProducerManager#renderEventMessageHeaders` (L226): wrap header value extraction in an `isPresent` guard so headers with no values are simply skipped instead of crashing the producer.
- `webapp` — `TestRunnerService#runTests` (L200): if a `TestCaseResult` references an operation that no longer exists on the service, log a warning and skip that test case rather than aborting the entire test run with `NoSuchElementException`.
- `webapp` — `ExamplesExporter#exportHeaders` (L174): wrap header value extraction in an `isPresent` guard so headers with no values are omitted from the exported document instead of crashing the export.
- `webapp` — `SchemaConformanceAssertion#assertResponse` (L63): if no WSDL resource is available for a SOAP service, log a warning and return `AssertionStatus.FAILED` with a clear error message rather than crashing the assertion.
- Happy path is unchanged in every case; only the previously unreachable empty-Optional path now degrades gracefully.
- `mvn spotless:check -pl minions/async,webapp` passes locally.

### Related issue(s)

See also #2058