### PR TITLE
chore: #2058 Override equals/hashCode/toString in ResponseResult

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/ResponseResult.java
+++ b/webapp/src/main/java/io/github/microcks/web/ResponseResult.java
@@ -18,6 +18,9 @@ package io.github.microcks.web;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * A thin wrapper around a response result.
  * @param status  The HTTP status code
@@ -25,4 +28,27 @@ import org.springframework.http.HttpStatusCode;
  * @param content The content of the response
  */
 public record ResponseResult(HttpStatusCode status, HttpHeaders headers, byte[] content) {
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (!(o instanceof ResponseResult other)) {
+         return false;
+      }
+      return Objects.equals(status, other.status) && Objects.equals(headers, other.headers)
+            && Arrays.equals(content, other.content);
+   }
+
+   @Override
+   public int hashCode() {
+      return 31 * Objects.hash(status, headers) + Arrays.hashCode(content);
+   }
+
+   @Override
+   public String toString() {
+      return "ResponseResult[status=" + status + ", headers=" + headers + ", content=byte["
+            + (content == null ? 0 : content.length) + "]]";
+   }
 }


### PR DESCRIPTION
`ResponseResult` is a Java record with a `byte[] content` field. Java's auto-generated record accessors use reference semantics on arrays — two records with byte-for-byte identical content are **not** `.equals()` to each other, their `hashCode()` values diverge, and `toString()` prints `content=[B@1a2b`. Sonar flags this with rule `java:S6218` ("override equals/hashCode/toString to consider array's content").

### Description

- `equals`: compare `status` and `headers` via `Objects.equals` and `content` via `Arrays.equals`, so two records with identical bytes compare equal.
- `hashCode`: combine `Objects.hash(status, headers)` with `Arrays.hashCode(content)`, so equal records share a `hashCode`.
- `toString`: print the content as `byte[<length>]` rather than dumping the whole array (which may be megabytes for binary responses) or emitting the unhelpful default `[B@hashref`.
- No behavioural change for callers that don't use equality, hashing, or `toString` on `ResponseResult`; strict improvement everywhere else.
- `mvn spotless:check -pl webapp` passes locally.

### Related issue(s)

See also #2058