### PR TITLE
refactor: replace generic exceptions with custom AsyncAPISchemaException in asyncapi util classes

### DIFF
--- a/commons/util/src/main/java/io/github/microcks/util/asyncapi/AsyncAPISchemaException.java
+++ b/commons/util/src/main/java/io/github/microcks/util/asyncapi/AsyncAPISchemaException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.util.asyncapi;
+
+/**
+ * Custom checked exception to represent errors when parsing or validating AsyncAPI schema definitions.
+ */
+public class AsyncAPISchemaException extends Exception {
+
+   public AsyncAPISchemaException(String message) {
+      super(message);
+   }
+
+   public AsyncAPISchemaException(String message, Throwable cause) {
+      super(message, cause);
+   }
+}

--- a/commons/util/src/main/java/io/github/microcks/util/asyncapi/AsyncAPISchemaUtil.java
+++ b/commons/util/src/main/java/io/github/microcks/util/asyncapi/AsyncAPISchemaUtil.java
@@ -68,15 +68,17 @@ public class AsyncAPISchemaUtil {
 
    /**
     * Retrieve the Avro schema corresponding to a message using its JSON pointer in Spec. Complete the {@code schemaMap}
-    * if provided. Raise a simple exception with message if problem while navigating the spec.
+    * if provided. Raise an {@link AsyncAPISchemaException} with message if problem while navigating the spec.
+    * @throws AsyncAPISchemaException if a problem occurs while navigating the spec
     */
    public static Schema retrieveMessageAvroSchema(JsonNode specificationNode, String messagePathPointer,
-         SchemaMap schemaMap) throws Exception {
+         SchemaMap schemaMap) throws AsyncAPISchemaException {
       // Extract Json node for message pointer.
       JsonNode messageNode = specificationNode.at(messagePathPointer);
       if (messageNode == null || messageNode.isMissingNode()) {
          log.debug("messagePathPointer {} is not a valid JSON Pointer", messagePathPointer);
-         throw new Exception("messagePathPointer does not represent a valid JSON Pointer in AsyncAPI specification");
+         throw new AsyncAPISchemaException(
+               "messagePathPointer does not represent a valid JSON Pointer in AsyncAPI specification");
       }
       // Message node can be just a reference.
       messageNode = followRefIfAny(messageNode, specificationNode);
@@ -99,7 +101,7 @@ public class AsyncAPISchemaUtil {
 
    /** Build an array of Avro schemas for messages expressed as a direct oneOf structure. */
    private static Schema buildOneOfMessagesAvroSchemas(JsonNode specificationNode, ArrayNode oneOfMessageNode,
-         SchemaMap schemaMap) throws Exception {
+         SchemaMap schemaMap) throws AsyncAPISchemaException {
       // Initialize a oneOf schema with array.
       Schema[] schemas = new Schema[oneOfMessageNode.size()];
 
@@ -115,11 +117,12 @@ public class AsyncAPISchemaUtil {
    }
 
    /** Build an Avro schema for spring message definition. */
-   private static Schema buildSingleMessageAvroSchema(JsonNode messageNode, SchemaMap schemaMap) throws Exception {
+   private static Schema buildSingleMessageAvroSchema(JsonNode messageNode, SchemaMap schemaMap)
+         throws AsyncAPISchemaException {
       // Check that message node has a payload attribute.
       if (!messageNode.has(ASYNC_SCHEMA_PAYLOAD_ELEMENT)) {
          log.debug("messageNode {} has no 'payload' attribute", messageNode);
-         throw new Exception("message definition has no valid payload in AsyncAPI specification");
+         throw new AsyncAPISchemaException("message definition has no valid payload in AsyncAPI specification");
       }
 
       // Navigate to payload definition.
@@ -143,7 +146,7 @@ public class AsyncAPISchemaUtil {
          }
          if (schemaContent == null) {
             log.info("No schema content found in SchemaMap. {} is not found", ref);
-            throw new Exception("no schema content found for " + ref + " in used SchemaMap.");
+            throw new AsyncAPISchemaException("no schema content found for " + ref + " in used SchemaMap.");
          }
       } else {
          // Schema is specified within the payload definition.

--- a/commons/util/src/main/java/io/github/microcks/util/asyncapi/AsyncAPISchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/asyncapi/AsyncAPISchemaValidator.java
@@ -185,7 +185,7 @@ public class AsyncAPISchemaValidator {
          } else {
             schemaNode = retrieveSingleMessageSchemaNode(specificationNode, messageNode);
          }
-      } catch (Exception e) {
+      } catch (AsyncAPISchemaException e) {
          // Just return exception message as validation message.
          return Collections.singletonList(e.getMessage());
       }
@@ -214,7 +214,7 @@ public class AsyncAPISchemaValidator {
       Schema avroSchema;
       try {
          avroSchema = retrieveMessageAvroSchema(specificationNode, messagePathPointer, schemaMap);
-      } catch (Exception e) {
+      } catch (AsyncAPISchemaException e) {
          return List.of(e.getMessage());
       }
 
@@ -251,7 +251,7 @@ public class AsyncAPISchemaValidator {
       Schema avroSchema = null;
       try {
          avroSchema = retrieveMessageAvroSchema(specificationNode, messagePathPointer, schemaMap);
-      } catch (Exception e) {
+      } catch (AsyncAPISchemaException e) {
          return List.of(e.getMessage());
       }
 
@@ -365,7 +365,7 @@ public class AsyncAPISchemaValidator {
 
    /** Build a Json schema node for messages expressed as a direct oneOf structure. */
    private static JsonNode buildOneOfMessageSchemaNode(JsonNode specificationNode, ArrayNode oneOfMessageNode)
-         throws Exception {
+         throws AsyncAPISchemaException {
       // Initialize a oneOf schema with array.
       ObjectMapper mapper = new ObjectMapper();
       ObjectNode schemaNode = mapper.createObjectNode();
@@ -385,11 +385,11 @@ public class AsyncAPISchemaValidator {
 
    /** Retrieve the Json schema node corresponding to a single message definition. */
    private static JsonNode retrieveSingleMessageSchemaNode(JsonNode specificationNode, JsonNode messageNode)
-         throws Exception {
+         throws AsyncAPISchemaException {
       // Check that message node has a payload attribute.
       if (!messageNode.has(ASYNC_SCHEMA_PAYLOAD_ELEMENT)) {
          log.debug("messageNode {} has no 'payload' attribute", messageNode);
-         throw new Exception("message definition has no valid payload in AsyncAPI specification");
+         throw new AsyncAPISchemaException("message definition has no valid payload in AsyncAPI specification");
       }
       // Navigate to payload definition.
       messageNode = messageNode.path(ASYNC_SCHEMA_PAYLOAD_ELEMENT);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
This PR addresses SonarQube maintainability violation "`java:S112` : *Generic exceptions should never be thrown*" - in `AsyncAPISchemaUtil` and `AsyncAPISchemaValidator`  classes under `commons/util/src/main/java/io/github/microcks/util/asyncapi`.

- Introduced a custom checked exception `AsyncAPISchemaException` to replace all generic `Exception` throws across both classes. 
- Update `AsyncAPISchemaUtil`: replace throws Exception in `retrieveMessageAvroSchema`, `buildOneOfMessagesAvroSchemas` and `buildSingleMessageAvroSchema`
- Update `AsyncAPISchemaValidator`: replace throws Exception with `AsyncAPISchemaException`
- `mvn spotless:check -pl commons/util` passes locally.

### Related issue(s)
See also #2058 
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->