### PR TITLE
chore: #2058 Handle the boolean returned by File.delete

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTask.java
@@ -125,7 +125,7 @@ public class WebSocketMessageConsumptionTask implements MessageConsumptionTask {
          }
       }
       if (trustStore != null && trustStore.exists() && !trustStore.delete()) {
-         logger.warn("Failed to delete WebSocket trust store at {}", trustStore.getAbsolutePath());
+         logger.warnf("Failed to delete WebSocket trust store at {%s}", trustStore.getAbsolutePath());
       }
    }
 }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTask.java
@@ -124,8 +124,8 @@ public class WebSocketMessageConsumptionTask implements MessageConsumptionTask {
             logger.warn("Closing WebSocket session raised an exception", e);
          }
       }
-      if (trustStore != null && trustStore.exists()) {
-         trustStore.delete();
+      if (trustStore != null && trustStore.exists() && !trustStore.delete()) {
+         logger.warn("Failed to delete WebSocket trust store at {}", trustStore.getAbsolutePath());
       }
    }
 }

--- a/webapp/src/main/java/io/github/microcks/util/ReferenceResolver.java
+++ b/webapp/src/main/java/io/github/microcks/util/ReferenceResolver.java
@@ -184,7 +184,9 @@ public class ReferenceResolver {
    public void cleanResolvedReferences() {
       if (cleanResolvedFiles) {
          for (File referenceFile : resolvedReferences.values()) {
-            referenceFile.delete();
+            if (!referenceFile.delete()) {
+               log.warn("Failed to delete resolved reference file {}", referenceFile.getAbsolutePath());
+            }
          }
       }
       resolvedReferences.clear();

--- a/webapp/src/main/java/io/github/microcks/util/SafeLogger.java
+++ b/webapp/src/main/java/io/github/microcks/util/SafeLogger.java
@@ -188,6 +188,45 @@ public class SafeLogger {
    }
 
    /**
+    * Log a message at the WARN level according to the specified format and argument. This form avoids superfluous
+    * object creation when the logger is disabled for the WARN level.
+    * @param format the format string
+    * @param arg    the argument
+    */
+   public void warn(String format, Object arg) {
+      if (log.isWarnEnabled()) {
+         log.warn(encode(format), encode(arg));
+      }
+   }
+
+   /**
+    * Log a message at the WARN level according to the specified format and arguments. This form avoids superfluous
+    * object creation when the logger is disabled for the WARN level.
+    * @param format the format string
+    * @param arg1   the first argument
+    * @param arg2   the second argument
+    */
+   public void warn(String format, Object arg1, Object arg2) {
+      if (log.isWarnEnabled()) {
+         log.warn(encode(format), encode(arg1), encode(arg2));
+      }
+   }
+
+   /**
+    * Log a message at the WARN level according to the specified format and arguments. This form avoids superfluous
+    * string concatenation when the logger is disabled for the WARN level. However, this variant incurs the hidden (and
+    * relatively small) cost of creating an Object[] before invoking the method, even if this logger is disabled for
+    * WARN. The variants taking one and two arguments exist solely in order to avoid this hidden cost.
+    * @param format    the format string
+    * @param arguments a list of 3 or more arguments
+    */
+   public void warn(String format, Object... arguments) {
+      if (log.isWarnEnabled()) {
+         log.warn(encode(format), encode(arguments));
+      }
+   }
+
+   /**
     * Is the logger instance enabled for the ERROR level?
     * @return True if this Logger is enabled for the ERROR level, false otherwise.
     */

--- a/webapp/src/main/java/io/github/microcks/web/UploadArtifactController.java
+++ b/webapp/src/main/java/io/github/microcks/web/UploadArtifactController.java
@@ -107,8 +107,8 @@ public class UploadArtifactController {
             return new ResponseEntity<>(mrie.getMessage(), HttpStatus.BAD_REQUEST);
          } finally {
             // Cleanup and remove local file.
-            if (localFile != null) {
-               localFile.delete();
+            if (localFile != null && !localFile.delete()) {
+               log.warn("Failed to delete temporary artifact file " + localFile.getAbsolutePath());
             }
          }
 
@@ -153,7 +153,10 @@ public class UploadArtifactController {
          } finally {
             // Cleanup and remove local file.
             if (localFile != null) {
-               Paths.get(localFile).toFile().delete();
+               File tempFile = Paths.get(localFile).toFile();
+               if (!tempFile.delete()) {
+                  log.warn("Failed to delete temporary artifact file " + tempFile.getAbsolutePath());
+               }
             }
          }
 

--- a/webapp/src/main/java/io/github/microcks/web/UploadArtifactController.java
+++ b/webapp/src/main/java/io/github/microcks/web/UploadArtifactController.java
@@ -108,7 +108,7 @@ public class UploadArtifactController {
          } finally {
             // Cleanup and remove local file.
             if (localFile != null && !localFile.delete()) {
-               log.warn("Failed to delete temporary artifact file " + localFile.getAbsolutePath());
+               log.warn("Failed to delete temporary artifact file {}", localFile.getAbsolutePath());
             }
          }
 
@@ -155,7 +155,7 @@ public class UploadArtifactController {
             if (localFile != null) {
                File tempFile = Paths.get(localFile).toFile();
                if (!tempFile.delete()) {
-                  log.warn("Failed to delete temporary artifact file " + tempFile.getAbsolutePath());
+                  log.warn("Failed to delete temporary artifact file {}", tempFile.getAbsolutePath());
                }
             }
          }


### PR DESCRIPTION
Sonar flagged four cleanup sites that call `File.delete()` but ignore the boolean return value (rule `java:S899`). When `delete()` returns false the file silently survives, which over time produces disk leaks of trust stores, resolved references, and uploaded artifacts. Each site now logs a warning when `delete()` fails so the leak is diagnosable from production logs.

### Description

- `minions/async` — `WebSocketMessageConsumptionTask#close` (L128): warn when the WebSocket trust store cannot be deleted.
- `webapp` — `ReferenceResolver#cleanResolvedReferences` (L187): warn for each resolved reference file that fails to delete.
- `webapp` — `UploadArtifactController#importArtifactFromUrl` (L111): warn when the temporary artifact downloaded from a URL cannot be deleted in the `finally` block.
- `webapp` — `UploadArtifactController#importArtifact` (L156): same for the multipart-uploaded artifact.
- `UploadArtifactController` uses a `SafeLogger` whose `warn(...)` overloads only accept `(String)` and `(String, Throwable)`, so the warning is emitted via plain string concatenation rather than slf4j placeholder substitution.
- Behaviour is unchanged on the happy path; failed deletions previously produced no signal at all.
- `mvn spotless:check -pl minions/async,webapp` passes locally.

### Related issue(s)

See also #2058