### PR TITLE
fix: NPE risk in `ExamplesExporter.exportHeaders()` when header values are empty

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/metadata/ExamplesExporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/metadata/ExamplesExporter.java
@@ -171,7 +171,8 @@ public class ExamplesExporter implements MockRepositoryExporter {
       if (message.getHeaders() != null && !message.getHeaders().isEmpty()) {
          ObjectNode headersNode = messageNode.putObject("headers");
          for (Header header : message.getHeaders()) {
-            headersNode.put(header.getName(), header.getValues().stream().findFirst().get());
+            header.getValues().stream().findFirst()
+                  .ifPresent(value -> headersNode.put(header.getName(), value));
          }
       }
    }


### PR DESCRIPTION
### Summary

Prevent a runtime exception when exporting headers by safely handling empty header value sets in `ExamplesExporter`. This updates `exportHeaders()` to avoid unsafe `Optional#get()` usage.

---

### Sites changed

ExamplesExporter#exportHeaders

---

### Notes

Replaces unsafe `findFirst().get()` with `ifPresent(...)` to avoid `NoSuchElementException` when a header has no values. Behavior remains unchanged for valid inputs; empty headers are now safely skipped instead of causing a crash.

See #2058 
