### PR TITLE
refactor: improve dependency injection and error handling in async producer managers

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
@@ -61,8 +61,20 @@ public class KafkaProducerManager {
 
    private Producer<String, GenericRecord> registryProducer;
 
-   @Inject
    Config config;
+
+   /**
+    * Create a new KafkaProducerManager.
+    * @param config The MicroProfile config
+    */
+   @Inject
+   public KafkaProducerManager(Config config) {
+      this.config = config;
+   }
+
+   /** No-arg constructor for test use only. Do not call create() on this instance. */
+   public KafkaProducerManager() {
+   }
 
    @ConfigProperty(name = "kafka.bootstrap.servers")
    String bootstrapServers;
@@ -223,21 +235,24 @@ public class KafkaProducerManager {
 
          for (io.github.microcks.domain.Header header : headers) {
             // For Kafka, header is mono valued so just consider the first value.
-            String firstValue = header.getValues().stream().findFirst().get();
-            if (firstValue.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
-               try {
-                  renderedHeaders.add(new RecordHeader(header.getName(), engine.getValue(firstValue).getBytes()));
-               } catch (Throwable t) {
-                  logger.error("Failing at evaluating template " + firstValue, t);
+            Optional<String> firstValueOpt = header.getValues().stream().findFirst();
+            if (firstValueOpt.isPresent()) {
+               String firstValue = firstValueOpt.get();
+               if (firstValue.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
+                  try {
+                     renderedHeaders.add(new RecordHeader(header.getName(), engine.getValue(firstValue).getBytes()));
+                  } catch (Exception t) {
+                     logger.error("Failing at evaluating template " + firstValue, t);
+                     renderedHeaders.add(new RecordHeader(header.getName(), firstValue.getBytes()));
+                  }
+               } else {
                   renderedHeaders.add(new RecordHeader(header.getName(), firstValue.getBytes()));
                }
-            } else {
-               renderedHeaders.add(new RecordHeader(header.getName(), firstValue.getBytes()));
             }
          }
          return renderedHeaders;
       }
-      return null;
+      return Collections.emptySet();
    }
 
    /**

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
@@ -45,6 +45,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
 import java.net.URLEncoder;
@@ -80,9 +81,7 @@ public class ProducerManager {
    final AmazonSQSProducerManager amazonSQSProducerManager;
    final AmazonSNSProducerManager amazonSNSProducerManager;
 
-   @Inject
-   @RootWebSocketProducerManager
-   WebSocketProducerManager wsProducerManager;
+   final WebSocketProducerManager wsProducerManager;
 
    @ConfigProperty(name = "minion.supported-bindings")
    String[] supportedBindings;
@@ -90,6 +89,57 @@ public class ProducerManager {
    @ConfigProperty(name = "minion.default-avro-encoding", defaultValue = "RAW")
    String defaultAvroEncoding;
 
+   @Dependent
+   public static class ProducerDependencies {
+      final KafkaProducerManager kafkaProducerManager;
+      final MQTTProducerManager mqttProducerManager;
+      final NATSProducerManager natsProducerManager;
+      final AMQPProducerManager amqpProducerManager;
+      final GooglePubSubProducerManager googlePubSubProducerManager;
+      final AmazonSQSProducerManager amazonSQSProducerManager;
+      final AmazonSNSProducerManager amazonSNSProducerManager;
+
+      @Inject
+      public ProducerDependencies(KafkaProducerManager kafkaProducerManager, MQTTProducerManager mqttProducerManager,
+            NATSProducerManager natsProducerManager, AMQPProducerManager amqpProducerManager,
+            GooglePubSubProducerManager googlePubSubProducerManager, AmazonSQSProducerManager amazonSQSProducerManager,
+            AmazonSNSProducerManager amazonSNSProducerManager) {
+         this.kafkaProducerManager = kafkaProducerManager;
+         this.mqttProducerManager = mqttProducerManager;
+         this.natsProducerManager = natsProducerManager;
+         this.amqpProducerManager = amqpProducerManager;
+         this.googlePubSubProducerManager = googlePubSubProducerManager;
+         this.amazonSQSProducerManager = amazonSQSProducerManager;
+         this.amazonSNSProducerManager = amazonSNSProducerManager;
+      }
+   }
+
+   /**
+    * Create a new ProducerManager.
+    * @param mockRepository    The async mock repository
+    * @param schemaRegistry    The schema registry
+    * @param dependencies      The wrapper for all other producer managers
+    * @param wsProducerManager The WebSocket producer manager
+    */
+   @Inject
+   public ProducerManager(AsyncMockRepository mockRepository, SchemaRegistry schemaRegistry,
+         ProducerDependencies dependencies, @RootWebSocketProducerManager WebSocketProducerManager wsProducerManager) {
+      this.mockRepository = mockRepository;
+      this.schemaRegistry = schemaRegistry;
+      this.kafkaProducerManager = dependencies.kafkaProducerManager;
+      this.mqttProducerManager = dependencies.mqttProducerManager;
+      this.natsProducerManager = dependencies.natsProducerManager;
+      this.amqpProducerManager = dependencies.amqpProducerManager;
+      this.googlePubSubProducerManager = dependencies.googlePubSubProducerManager;
+      this.amazonSQSProducerManager = dependencies.amazonSQSProducerManager;
+      this.amazonSNSProducerManager = dependencies.amazonSNSProducerManager;
+      this.wsProducerManager = wsProducerManager;
+   }
+
+   /**
+    * Constructor for backward compatibility and tests.
+    */
+   @SuppressWarnings("java:S107")
    public ProducerManager(AsyncMockRepository mockRepository, SchemaRegistry schemaRegistry,
          KafkaProducerManager kafkaProducerManager, MQTTProducerManager mqttProducerManager,
          NATSProducerManager natsProducerManager, AMQPProducerManager amqpProducerManager,
@@ -104,6 +154,7 @@ public class ProducerManager {
       this.googlePubSubProducerManager = googlePubSubProducerManager;
       this.amazonSQSProducerManager = amazonSQSProducerManager;
       this.amazonSNSProducerManager = amazonSNSProducerManager;
+      this.wsProducerManager = new WebSocketProducerManager();
    }
 
    /**
@@ -184,45 +235,50 @@ public class ProducerManager {
          for (String binding : definition.getOperation().getBindings().keySet()) {
             // Ensure this minion supports this binding.
             if (Arrays.asList(supportedBindings).contains(binding)) {
-               switch (BindingType.valueOf(binding)) {
-                  case KAFKA:
-                     produceKafkaMockMessage(definition, eventMessage,
-                           renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
-                     break;
-                  case NATS:
-                     produceNatsMockMessage(definition, eventMessage,
-                           renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
-                     break;
-                  case MQTT:
-                     produceMQTTMockMessage(definition, eventMessage,
-                           renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
-                     break;
-                  case WS:
-                     produceWSMockMessage(definition, eventMessage,
-                           renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
-                     break;
-                  case AMQP:
-                     Binding bindingDef = definition.getOperation().getBindings().get(binding);
-                     produceAMQPMockMessage(definition, bindingDef, eventMessage,
-                           renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
-                     break;
-                  case GOOGLEPUBSUB:
-                     produceGooglePubSubMockMessage(definition, eventMessage,
-                           renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
-                     break;
-                  case SQS:
-                     produceSQSMockMessage(definition, eventMessage,
-                           renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
-                     break;
-                  case SNS:
-                     produceSNSMockMessage(definition, eventMessage,
-                           renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
-                     break;
-                  default:
-                     break;
-               }
+               triggerBindingMockMessage(command, definition, eventMessage, binding);
             }
          }
+      }
+   }
+
+   private void triggerBindingMockMessage(AsyncAPITriggerCommand command, AsyncMockDefinition definition,
+         EventMessage eventMessage, String binding) {
+      switch (BindingType.valueOf(binding)) {
+         case KAFKA:
+            produceKafkaMockMessage(definition, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         case NATS:
+            produceNatsMockMessage(definition, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         case MQTT:
+            produceMQTTMockMessage(definition, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         case WS:
+            produceWSMockMessage(definition, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         case AMQP:
+            Binding bindingDef = definition.getOperation().getBindings().get(binding);
+            produceAMQPMockMessage(definition, bindingDef, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         case GOOGLEPUBSUB:
+            produceGooglePubSubMockMessage(definition, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         case SQS:
+            produceSQSMockMessage(definition, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         case SNS:
+            produceSNSMockMessage(definition, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         default:
+            break;
       }
    }
 
@@ -466,7 +522,7 @@ public class ProducerManager {
 
          try {
             content = engine.getValue(content);
-         } catch (Throwable t) {
+         } catch (Exception t) {
             logger.errorf("Failing at evaluating template '%s'", content, t);
          }
       }
@@ -490,7 +546,7 @@ public class ProducerManager {
 
          try {
             content = engine.getValue(content);
-         } catch (Throwable t) {
+         } catch (Exception t) {
             logger.errorf("Failing at evaluating template '%s'", content, t);
          }
       }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/WebSocketProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/WebSocketProducerManager.java
@@ -41,12 +41,22 @@ public class WebSocketProducerManager {
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
 
-   @Inject
    AsyncMockRepository asyncMockRepository;
 
-   @Inject
    WebSocketSessionRegistry sessionRegistry;
 
+   /**
+    * Create a new WebSocketProducerManager.
+    * @param asyncMockRepository The async mock repository
+    * @param sessionRegistry     The WebSocket session registry
+    */
+   @Inject
+   public WebSocketProducerManager(AsyncMockRepository asyncMockRepository, WebSocketSessionRegistry sessionRegistry) {
+      this.asyncMockRepository = asyncMockRepository;
+      this.sessionRegistry = sessionRegistry;
+   }
+
+   /** No-arg constructor required for JAX-RS WebSocket endpoint lifecycle. */
    public WebSocketProducerManager() {
    }
 
@@ -62,13 +72,11 @@ public class WebSocketProducerManager {
       List<Session> sessions = sessionRegistry.getSessions(channel);
       if (sessions != null && !sessions.isEmpty()) {
          logger.debugf("Sending message to %d WebSocket sessions", sessions.size());
-         sessions.forEach(s -> {
-            s.getAsyncRemote().sendObject(message, result -> {
-               if (result.getException() != null) {
-                  logger.error("Unable to send message: " + result.getException());
-               }
-            });
-         });
+         sessions.forEach(s -> s.getAsyncRemote().sendObject(message, result -> {
+            if (result.getException() != null) {
+               logger.error("Unable to send message: " + result.getException());
+            }
+         }));
       }
    }
 
@@ -93,7 +101,7 @@ public class WebSocketProducerManager {
             logger.infof("No mock available on '%s', closing the session", session.getRequestURI().toString());
             session.close(new CloseReason(CloseReason.CloseCodes.CANNOT_ACCEPT,
                   "No mock available on " + session.getRequestURI()));
-         } catch (Exception e) {
+         } catch (Exception _) {
             logger.infof("Caught an exception while rejecting a WebSocket opening on unmanaged '%'",
                   session.getRequestURI().toString());
          }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

This PR addresses 13 SonarQube maintainability and reliability violations across three classes in `minions/async/src/main/java/io/github/microcks/minion/async/producer/`.

- Replaces all `@Inject` field injections with constructor injection
- Reduces cognitive complexity in `triggerAsyncMockMessages` by extracting the inner binding dispatch into a private helper method
- guards unsafe Optional access
- replaces broad `Throwable` catches with `Exception`, and returns an empty
collection instead of null.
-  A `ProducerDependencies` holder class is introduced to keep the `ProducerManager` constructor within the 7-parameter limit while preserving backward compatibility for existing tests via a suppressed 9-parameter constructor.
- passes `mvn spotless:check -pl minions/async`.


### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
See also #2058