### PR TITLE
chore: hide implicit constructor in TemplateEngineFactory

### DIFF
--- a/commons/util-el/src/main/java/io/github/microcks/util/el/TemplateEngineFactory.java
+++ b/commons/util-el/src/main/java/io/github/microcks/util/el/TemplateEngineFactory.java
@@ -23,6 +23,11 @@ import io.github.microcks.util.el.function.*;
  */
 public class TemplateEngineFactory {
 
+   private TemplateEngineFactory() {
+      // Utility class 
+   }
+
+
    /**
     * Helper method for getting a {@code TemplateEngine} initialized with built-in functions.
     * @return A new TemplateEngine instance.


### PR DESCRIPTION
Refs #2058

Fix Sonar rule for utility classes by preventing instantiation of TemplateEngineFactory.

- Add private constructor to hide implicit public constructor
- Align with utility class design pattern

No functional changes.