### PR TITLE
chore: handle return value of File.delete in ReferenceResolver

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/ReferenceResolver.java
+++ b/webapp/src/main/java/io/github/microcks/util/ReferenceResolver.java
@@ -184,7 +184,9 @@ public class ReferenceResolver {
    public void cleanResolvedReferences() {
       if (cleanResolvedFiles) {
          for (File referenceFile : resolvedReferences.values()) {
-            referenceFile.delete();
+            if (!referenceFile.delete()) {
+               log.warn("Failed to delete file: " + referenceFile.getAbsolutePath());
+            }
          }
       }
       resolvedReferences.clear();


### PR DESCRIPTION
 Refs #2058

Fix Sonar issue by handling the return value of File.delete().

- Check deletion success
- Log warning if deletion fails

No functional changes.