### PR TITLE
chore: #2080 Skip sonar-cloud-analysis job on pull requests from forks

### DIFF
--- a/.github/workflows/sonar-cloud-analysis.yml
+++ b/.github/workflows/sonar-cloud-analysis.yml
@@ -10,7 +10,7 @@ on:
 permissions: read-all
 jobs:
   build:
-    if: github.repository_owner == 'microcks'
+    if: github.repository_owner == 'microcks' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

fixes #2080.

The existing `if: github.repository_owner == "microcks"` guard on the `sonar-cloud-analysis` workflow does not actually exclude fork PRs `github.repository_owner` resolves to the owner of the base repository (always `microcks`), not the head of the PR. As a result, every fork PR triggers the job and fails because GitHub Actions doesn't pass repository secrets to PRs from forks, so `SONAR_TOKEN` ends up empty and the scanner reports "Project not found."

This PR augments the guard so that, for `pull_request` events, the PR head repo must match the base repo. `push` and `schedule` events keep running unconditionally because they always have access to secrets.

## Behaviour after the fix

| Trigger | Today | After |
|---|---|---|
| `push` to master | runs  | runs |
| `schedule` (cron) | runs  | runs  |
| `pull_request` from same-repo branch (maintainer) | runs  | runs |
| `pull_request` from fork | runs and fails  | **skipped cleanly**  |

Skipped jobs surface as a neutral status in the PR check list, so contributors and reviewers don't have to dig through logs to confirm the failure was the SonarCloud-on-fork-PR limitation rather than the contribution itself.

## Test plan

- [ ] On merge: a same-repo PR (or push to master) still triggers `sonar-cloud-analysis / Build and analyze`.
- [ ] After merge, the next fork PR opened against this repo shows `sonar-cloud-analysis / Build and analyze` as **skipped**, not failing.

## Related issue(s)

Resolves #2080
