### PR TITLE
chore: #2058 Suppress java:S1206 on StringToStringsMap SoapUI port

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/script/StringToStringsMap.java
+++ b/webapp/src/main/java/io/github/microcks/util/script/StringToStringsMap.java
@@ -27,6 +27,11 @@ import java.util.Map;
 /**
  * A minimalist implementation of com.eviware.soapui.support.types.StringToStringsMap to ensure a compatibility layer
  * withe SoapUI scripting.
+ * <p>
+ * Behavioural parity with the SoapUI upstream class is the explicit goal of this port. Any apparent bug or fragility
+ * here (e.g. equals/hashCode contract violations flagged by Sonar) should first be checked against the SoapUI source -
+ * if the upstream behaves the same way, do not "fix" it here, since SoapUI scripts hosted by Microcks would then
+ * diverge from real SoapUI. Suppress the Sonar finding with a comment instead.
  * @author laurent
  */
 public class StringToStringsMap extends HashMap<String, List<String>> {
@@ -92,6 +97,10 @@ public class StringToStringsMap extends HashMap<String, List<String>> {
       this.equalsOnThis = equalsOnThis;
    }
 
+   // hashCode is intentionally not overridden here to mirror the SoapUI upstream class this is ported from
+   // (see class Javadoc). Suppress the matching Sonar finding rather than diverging from SoapUI behaviour.
+   @SuppressWarnings("java:S1206")
+   @Override
    public boolean equals(Object o) {
       return this.equalsOnThis ? this == o : super.equals(o);
    }


### PR DESCRIPTION
`StringToStringsMap` is a manual port of `com.eviware.soapui.support.types.StringToStringsMap`, kept in-tree so SoapUI scripts hosted by Microcks behave the same way as in real SoapUI without taking a dependency on the outdated SoapUI library.

The upstream class (e.g. [oysteing/soapui copy](https://github.com/oysteing/soapui/blob/master/src/java/com/eviware/soapui/support/types/StringToStringsMap.java)) overrides `equals(Object)` with a mode switch driven by an `equalsOnThis` flag and does **not** override `hashCode`. That equals/hashCode contract violation is exactly what Sonar's `java:S1206` flags here.

Replacing #2068, which tried to fix the contract by overriding `hashCode`. As @lbroudoux pointed out on that PR, fixing it would make Microcks-hosted SoapUI scripts diverge from real SoapUI — the opposite of this file's stated purpose. The right move is to suppress the Sonar finding with explanation, not to fix the code.

### Description

- Added `@SuppressWarnings("java:S1206")` to the existing `equals` override, along with an inline comment that points future readers to the SoapUI port rationale.
- Strengthened the class Javadoc with an explicit warning: any apparent bug or fragility here should first be checked against the SoapUI source, and if the upstream behaves the same way the finding should be suppressed rather than fixed.
- No behavioural change.

### Related issue(s)

See also #2058. Replaces #2068.