### PR TITLE
chore: #2058 restrict permissions in api-check workflow

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -7,7 +7,8 @@ on:
         required: true
   schedule:
     - cron: '0 5 * * *'  # Everyday at 5am UTC
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   run-api-tests-uber:


### PR DESCRIPTION
 Fix Sonar security issue by replacing broad "read-all" permission with scoped "contents: read".

Impact:
- Improves security by following least privilege principle
- No functional behavior change

See #2058 