### PR TITLE
feat(openapi): #2037 Update overlay export shape for standard mergers

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIOverlayExporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIOverlayExporter.java
@@ -113,32 +113,27 @@ public class OpenAPIOverlayExporter implements MockRepositoryExporter {
    }
 
    private void exportRequest(ArrayNode actions, Operation operation, Request request) {
+      String[] operationParts = operation.getName().split(" ");
+      String pathPart = operationParts[1];
+      String methodPart = operationParts[0].toLowerCase();
+
       // Export the parameters part of the exchange if present.
       if (request.getQueryParameters() != null && !request.getQueryParameters().isEmpty()) {
          for (Parameter parameter : request.getQueryParameters()) {
             // Export the query parameter part of the exchange.
             ObjectNode parameterNode = actions.addObject();
-
-            String[] operationParts = operation.getName().split(" ");
-
-            parameterNode.put("target", "$.paths['" + operationParts[1] + "']." + operationParts[0].toLowerCase()
-                  + ".parameters[?@.name=='" + parameter.getName() + "'].examples");
-            ObjectNode updateNode = parameterNode.putObject("update");
-            ObjectNode exampleNode = updateNode.putObject(request.getName());
-            exampleNode.put("value", parameter.getValue());
+            parameterNode.put("target",
+                  "$.paths['" + pathPart + "']." + methodPart + ".parameters[?@.name=='" + parameter.getName() + "']");
+            createExampleUpdate(parameterNode, request.getName(), parameter.getValue());
          }
       }
 
       // Export the requestBody part of the exchange if present.
       if (request.getContent() != null) {
          ObjectNode requestNode = actions.addObject();
-         String[] operationParts = operation.getName().split(" ");
-
-         requestNode.put("target", "$.paths['" + operationParts[1] + "']." + operationParts[0].toLowerCase()
-               + ".requestBody.content['" + getContentType(request) + "'].examples");
-         ObjectNode updateNode = requestNode.putObject("update");
-         ObjectNode exampleNode = updateNode.putObject(request.getName());
-         exampleNode.put("value", request.getContent());
+         requestNode.put("target",
+               "$.paths['" + pathPart + "']." + methodPart + ".requestBody.content['" + getContentType(request) + "']");
+         createExampleUpdate(requestNode, request.getName(), request.getContent());
       }
    }
 
@@ -154,15 +149,34 @@ public class OpenAPIOverlayExporter implements MockRepositoryExporter {
    }
 
    private void exportResponse(ArrayNode actions, Operation operation, Response response) {
+      String[] operationParts = operation.getName().split(" ");
+      String pathPart = operationParts[1];
+      String methodPart = operationParts[0].toLowerCase();
+
       // Export the response part of the exchange.
       ObjectNode responseNode = actions.addObject();
+      responseNode.put("target", "$.paths['" + pathPart + "']." + methodPart + ".responses['" + response.getStatus()
+            + "'].content['" + response.getMediaType() + "']");
+      createExampleUpdate(responseNode, response.getName(), response.getContent());
+   }
 
-      String[] operationParts = operation.getName().split(" ");
+   /**
+    * Build the {@code update} block for an overlay action targeting a parameter, requestBody or response. The shape
+    * matches what standard OpenAPI overlay mergers (e.g. github.com/speakeasy-api/openapi/overlay/loader) deep-merge
+    * cleanly into the target node, regardless of whether an {@code examples} sub-node already exists there.
+    * @param actionNode The overlay action root, into which an {@code update} object will be added.
+    * @param name       The example's human-readable name, used both as the slugified key and as the {@code summary}.
+    * @param value      The example's value payload.
+    */
+   private void createExampleUpdate(ObjectNode actionNode, String name, String value) {
+      ObjectNode updateNode = actionNode.putObject("update");
+      ObjectNode examplesNode = updateNode.putObject("examples");
+      ObjectNode exampleNode = examplesNode.putObject(toExampleKey(name));
+      exampleNode.put("value", value);
+      exampleNode.put("summary", name);
+   }
 
-      responseNode.put("target", "$.paths['" + operationParts[1] + "']." + operationParts[0].toLowerCase()
-            + ".responses." + response.getStatus() + ".content['" + response.getMediaType() + "'].examples");
-      ObjectNode updateNode = responseNode.putObject("update");
-      ObjectNode exampleNode = updateNode.putObject(response.getName());
-      exampleNode.put("value", response.getContent());
+   private String toExampleKey(String name) {
+      return name.toLowerCase().replace(" ", "-");
    }
 }

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIOverlayExporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIOverlayExporterTest.java
@@ -47,48 +47,58 @@ public class OpenAPIOverlayExporterTest {
          """;
 
    private static final String EXPECTED_EXPORT_ACTION_1 = """
-         - target: "$.paths['/pastry/{name}'].patch.parameters[?@.name=='name'].examples"
+         - target: "$.paths['/pastry/{name}'].patch.parameters[?@.name=='name']"
            update:
-             Eclair Cafe:
-               value: Eclair Cafe
+             examples:
+               eclair-cafe:
+                 value: Eclair Cafe
+                 summary: Eclair Cafe
          """;
    private static final String EXPECTED_EXPORT_ACTION_2 = """
-         - target: "$.paths['/pastry/{name}'].patch.requestBody.content['application/json'].examples"
+         - target: "$.paths['/pastry/{name}'].patch.requestBody.content['application/json']"
            update:
-             Eclair Cafe:
-               value: |-
-                 {
-                   "price": 2.6
-                 }
+             examples:
+               eclair-cafe:
+                 value: |-
+                   {
+                     "price": 2.6
+                   }
+                 summary: Eclair Cafe
          """;
    private static final String EXPECTED_EXPORT_ACTION_3 = """
-         - target: "$.paths['/pastry/{name}'].patch.responses.200.content['application/json'].examples"
+         - target: "$.paths['/pastry/{name}'].patch.responses['200'].content['application/json']"
            update:
-             Eclair Cafe:
-               value: |-
-                 {
-                   "name": "Eclair Cafe",
-                   "description": "Delicieux Eclair au Cafe pas calorique du tout",
-                   "size": "M",
-                   "price": 2.6,
-                   "status": "available"
-                 }
+             examples:
+               eclair-cafe:
+                 value: |-
+                   {
+                     "name": "Eclair Cafe",
+                     "description": "Delicieux Eclair au Cafe pas calorique du tout",
+                     "size": "M",
+                     "price": 2.6,
+                     "status": "available"
+                   }
+                 summary: Eclair Cafe
          """;
    private static final String EXPECTED_EXPORT_ACTION_4 = """
-         - target: "$.paths['/pastry/{name}'].get.parameters[?@.name=='name'].examples"
+         - target: "$.paths['/pastry/{name}'].get.parameters[?@.name=='name']"
            update:
-             Eclair Chocolat:
-               value: Eclair Chocolat
+             examples:
+               eclair-chocolat:
+                 value: Eclair Chocolat
+                 summary: Eclair Chocolat
          """;
    private static final String EXPECTED_EXPORT_ACTION_5 = """
-         - target: "$.paths['/pastry/{name}'].get.responses.200.content['application/json'].examples"
+         - target: "$.paths['/pastry/{name}'].get.responses['200'].content['application/json']"
            update:
-             Eclair Chocolat:
-               value: |-
-                 {
-                   "name": "Eclair Chocolat",
-                   "price": 2.5
-                 }
+             examples:
+               eclair-chocolat:
+                 value: |-
+                   {
+                     "name": "Eclair Chocolat",
+                     "price": 2.5
+                   }
+                 summary: Eclair Chocolat
          """;
 
    @Test


### PR DESCRIPTION
## Summary

Resolves #2037.

The previous overlay export targeted ....examples directly and placed each example as a top-level key under update. Standard OpenAPI overlay mergers (e.g. https://github.com/speakeasy-api/openapi/overlay/loader) struggle with this structure when the target node does not already contain an examples map, since the merger cannot create intermediate paths.

This PR restructures each emitted action so that:
- The target points to the parent node (parameter, requestBody content type, or response content type)
- The update explicitly includes an examples wrapper

This allows mergers to deep-merge cleanly, regardless of whether examples already exists.

### New format
```
yaml - target: "$.paths['/p'].post.requestBody.content['application/json']"   update:     examples:       my-example:         value: ...         summary: My Example 
```

## Design Decisions

### Backward Compatibility
Replaced the existing format in-place instead of introducing a new exporter (OPENAPI_OVERLAY_V2).

Reason:
- The previous format was incompatible with standard overlay mergers
- The new format remains compliant with the same overlay: 1.0.0 specification

---

### Summary Source
- Uses the request/response name
- Microcks does not currently store a separate description for examples
- Name provides the best available semantic value

---

### Slugification
Uses:
java name.toLowerCase().replace(" ", "-") 

- Matches the original proposal
- YAML is serialized via Jackson → UTF-8 safe
- Non-ASCII characters (e.g. Éclair Café → éclair-café) are preserved correctly

---

### Existing Examples Handling
- Shape correctness is validated via snapshot tests (OpenAPIOverlayExporterTest)
- Merge behavior is delegated to the overlay merger
- Exporter responsibility is limited to emitting a valid structure

---

## Notable Cleanups

- Extracted shared logic into:
  java   createExampleUpdate(actionNode, name, value)   
  This removes duplication across:
  - Query parameters
  - Request bodies
  - Responses

- Updated response path format:
    .responses.200.content[...]    → .responses['200'].content[...]  
  This aligns with consistent JSONPath bracket notation.

---

## Test Plan

- Updated OpenAPIOverlayExporterTest
  - All EXPECTED_EXPORT_ACTION_* snapshots rewritten to match new structure
  - Snapshot tests ensure future regressions are caught

- Verified locally:
    mvn spotless:check -pl webapp  

- Post-merge validation:
  - Export overlay from Microcks
  - Merge using speakeasy-api/openapi/overlay/loader
  - Confirm:
    - New examples are added
    - Existing examples remain intact

---

## Related Issues

- Resolves #2037