### PR TITLE
fix: #2058 return empty map instead of null in Metadata domain

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/Metadata.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/Metadata.java
@@ -46,7 +46,7 @@ public class Metadata {
    /** @return An immutable version of annotations map. */
    public Map<String, String> getAnnotations() {
       if (annotations == null) {
-         return null;
+         return Collections.emptyMap();
       }
       return Collections.unmodifiableMap(annotations);
    }
@@ -76,7 +76,7 @@ public class Metadata {
    /** @return An immutable version of labels map. */
    public Map<String, String> getLabels() {
       if (labels == null) {
-         return null;
+         return Collections.emptyMap();
       }
       return Collections.unmodifiableMap(labels);
    }


### PR DESCRIPTION
## Description

1. Return `Collections.emptyMap()`from getAnnotations() when annotations are not set.
2. Return `Collections.emptyMap()` from getLabels() when labels are not set.
3. Keep both getters behavior consistent by always returning immutable, non-null maps to avoid extra null checks for callers.


### Related issue(s)
Part of #2058