### PR TITLE
refactor #2058 : use java.nio.file.Files.delete for better error reporting

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTask.java
@@ -124,7 +124,7 @@ public class WebSocketMessageConsumptionTask implements MessageConsumptionTask {
             logger.warn("Closing WebSocket session raised an exception", e);
          }
       }
-      if (trustStore != null && trustStore.exists() && !trustStore.delete()) {
+      if (trustStore != null && trustStore.exists() && !Files.deleteIfExists(trustStore.toPath())) {
          logger.warnf("Failed to delete WebSocket trust store at {%s}", trustStore.getAbsolutePath());
       }
    }


### PR DESCRIPTION
### Description

This change switches cleanup to `java.nio.file.Files` delete so failures are more informative.
Instead of a simple true/false result, delete throws specific exceptions, which helps identify the exact reason deletion failed (for example: file missing, permission denied, or file in use).

### Related issue(s) #2058