### PR TITLE
bump microcks-postman-runtime to 0.7.2 [Fix]

### DIFF
--- a/install/docker-compose/docker-compose-devmode.yml
+++ b/install/docker-compose/docker-compose-devmode.yml
@@ -11,7 +11,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/install/docker-compose/docker-compose-with-proxy.yml
+++ b/install/docker-compose/docker-compose-with-proxy.yml
@@ -28,7 +28,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/install/docker-compose/docker-compose.yml
+++ b/install/docker-compose/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -106,7 +106,7 @@ postman:
   image:
     registry: quay.io
     repository: microcks/microcks-postman-runtime
-    tag: 0.7.1
+    tag: 0.7.2
     digest:
   replicas: 1
   resources:

--- a/install/podman-compose/podman-compose-devmode.yml
+++ b/install/podman-compose/podman-compose-devmode.yml
@@ -14,7 +14,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/install/podman-compose/podman-compose.yml
+++ b/install/podman-compose/podman-compose.yml
@@ -14,7 +14,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]


### PR DESCRIPTION
### Description

- Bump `microcks-postman-runtime` image tag from `0.7.1` to `0.7.2` across all Docker Compose configurations (`docker-compose.yml`, `docker-compose-devmode.yml`, `docker-compose-with-proxy.yml`)
- Bump `microcks-postman-runtime` image tag from `0.7.1` to `0.7.2` across all Podman Compose configurations (`podman-compose.yml`, `podman-compose-devmode.yml`)
- Bump `microcks-postman-runtime` Helm chart default tag from `0.7.1` to `0.7.2` in `install/kubernetes/microcks/values.yaml`

This integrates the latest [0.7.2 release](https://github.com/microcks/microcks-postman-runtime/releases/tag/0.7.2) which lowers CVEs and includes an up-to-date body parser library.

### Related issue(s)

Fixes #2054
