### PR TITLE
correct indexOf boundary checks for charset parsing

### DIFF
--- a/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
@@ -288,7 +288,7 @@ public class OpenAPISchemaValidator {
 
          // If no match here, it's maybe contentType contains charset but not the spec.
          // Remove charset information and try again.
-         if (contentType.contains("charset=") && contentType.indexOf(";") > 0) {
+         if (contentType.contains("charset=") && contentType.indexOf(";") >= 0) {
             return getMessageContentNode(responseCodeNode, contentType.substring(0, contentType.indexOf(";")));
          }
       }

--- a/install/docker-compose/docker-compose-devmode.yml
+++ b/install/docker-compose/docker-compose-devmode.yml
@@ -11,7 +11,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/install/docker-compose/docker-compose-with-proxy.yml
+++ b/install/docker-compose/docker-compose-with-proxy.yml
@@ -28,7 +28,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/install/docker-compose/docker-compose.yml
+++ b/install/docker-compose/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -106,7 +106,7 @@ postman:
   image:
     registry: quay.io
     repository: microcks/microcks-postman-runtime
-    tag: 0.7.1
+    tag: 0.7.2
     digest:
   replicas: 1
   resources:

--- a/install/podman-compose/podman-compose-devmode.yml
+++ b/install/podman-compose/podman-compose-devmode.yml
@@ -14,7 +14,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/install/podman-compose/podman-compose.yml
+++ b/install/podman-compose/podman-compose.yml
@@ -14,7 +14,7 @@ services:
       retries: 3
 
   postman:
-    image: quay.io/microcks/microcks-postman-runtime:0.7.1
+    image: quay.io/microcks/microcks-postman-runtime:0.7.2
     container_name: microcks-postman-runtime
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]

--- a/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLTestRunner.java
@@ -101,7 +101,7 @@ public class GraphQLTestRunner extends HttpTestRunner {
          log.debug("Response media-type is {}", httpResponse.getHeaders().getContentType());
          contentType = httpResponse.getHeaders().getContentType().toString();
          // Sanitize charset information from media-type.
-         if (contentType.contains("charset=") && contentType.indexOf(";") > 0) {
+         if (contentType.contains("charset=") && contentType.indexOf(";") >= 0) {
             contentType = contentType.substring(0, contentType.indexOf(";"));
          }
       }


### PR DESCRIPTION
Replace `indexOf > 0` with `indexOf >= 0` boundary checks when parsing charset from media-type, addressing 2 of the maintainability bugs raised by SonarCloud and aggregated under #2058.

## Sites changed
OpenAPISchemaValidator#getMessageContentNode
GraphQLTestRunner#extractTestReturnCode
Each site was incorrectly using `indexOf > 0` to check for the presence of the `;` separator, ignoring cases where `;` could potentially be at the 0th index.

## Notes
This rule (java:S2692 for indexOf bound checks) is part of the Sonar quality chores.
I did not include other indexOf issues or cognitive complexity issues in this PR — they are different rules or require non-trivial replacement. Happy to do them as a follow-up.


