### PR TITLE
fix: skip OpenAPI examples with unresolved path parameters

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/metadata/ExamplesExporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/metadata/ExamplesExporter.java
@@ -172,8 +172,7 @@ public class ExamplesExporter implements MockRepositoryExporter {
       if (message.getHeaders() != null && !message.getHeaders().isEmpty()) {
          ObjectNode headersNode = messageNode.putObject("headers");
          for (Header header : message.getHeaders()) {
-            header.getValues().stream().findFirst()
-                  .ifPresent(value -> headersNode.put(header.getName(), value));
+            header.getValues().stream().findFirst().ifPresent(value -> headersNode.put(header.getName(), value));
          }
       }
    }

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -639,6 +639,16 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
          // Do we have to complete request with path parameters?
          Multimap<String, String> pathParameters = pathParametersByExample.get(exampleName);
          if (pathParameters != null) {
+            // For URI_PARTS/URI_ELEMENTS, verify all required path parameters have example values.
+            // If any {param} placeholder remains unresolved, the example is incomplete and must be skipped
+            // to avoid storing a dispatch criteria that can never match an incoming request at runtime.
+            if (DispatchStyles.URI_PARTS.equals(operation.getDispatcher())
+                  || DispatchStyles.URI_ELEMENTS.equals(operation.getDispatcher())) {
+               String resourcePathPattern = operation.getName().split(" ")[1];
+               if (URIBuilder.buildURIFromPattern(resourcePathPattern, pathParameters).contains("{")) {
+                  continue;
+               }
+            }
             completeRequestWithPathParameters(request, pathParameters);
          } else if (DispatchStyles.URI_PARTS.equals(operation.getDispatcher())
                || DispatchStyles.URI_ELEMENTS.equals(operation.getDispatcher())) {

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
@@ -809,28 +809,9 @@ class OpenAPIImporterTest {
                fail("No exception should be thrown when importing message definitions.");
             }
 
-            // TODO: below should be a failure. We currently detect 1 message as we should have 0
-            // cause car path parameters is missing. We should add a test into URIBuilder.buildFromParamsMap()
-            // to check that we have at least the number of params what we have into uri pattern.
-            //assertEquals(0, messages.size());
-
-            for (Exchange exchange : exchanges) {
-               if (exchange instanceof RequestResponsePair) {
-                  RequestResponsePair entry = (RequestResponsePair) exchange;
-                  Request request = entry.getRequest();
-                  Response response = entry.getResponse();
-                  assertNotNull(request);
-                  assertNotNull(response);
-                  assertEquals("laurent_307_passengers", request.getName());
-                  assertEquals("laurent_307_passengers", response.getName());
-                  assertEquals("/owner=laurent", response.getDispatchCriteria());
-                  assertEquals("200", response.getStatus());
-                  assertEquals("application/json", response.getMediaType());
-                  assertNotNull(response.getContent());
-               } else {
-                  fail("Exchange has the wrong type. Expecting RequestResponsePair");
-               }
-            }
+            // The 'car' path parameter has no examples, so the example is incomplete
+            // and must not be imported (it would produce a dispatch criteria that never matches).
+            assertEquals(0, exchanges.size());
          } else {
             fail("Unknown operation name: " + operation.getName());
          }


### PR DESCRIPTION
## 1. SUMMARY

This PR improves OpenAPI import behavior by rejecting examples with unresolved path parameters for `URI_PARTS` and `URI_ELEMENTS` dispatch styles. The update adds validation in `OpenAPIImporter` to prevent broken mocks from being imported and updates the related test to verify incomplete examples are skipped.

---

## 2. FIX

```java id="xsdfe2"
// Before
completeRequestWithPathParameters(request, pathParameters);

// After
if (URIBuilder.buildURIFromPattern(resourcePathPattern, pathParameters).contains("{")) {
   continue;
}
completeRequestWithPathParameters(request, pathParameters);
```
