### PR TITLE
fix #2058: Make non-static reply transient or serializable.

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/Operation.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/Operation.java
@@ -42,7 +42,7 @@ public class Operation implements Serializable, BindingsHolder {
    private Map<String, Binding> bindings;
    private Map<String, CallbackInfo> callbackInfos;
    private List<TriggerInfo> triggerInfos;
-   private ReplyInfo reply;
+   private transient ReplyInfo reply;
 
    private boolean override = false;
    private String dispatcher;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

This PR resolves Sonar rule java:S1948 in Operation by marking the non-static reply field as transient.

Operation implements Serializable, and reply (ReplyInfo) was flagged as a non-serializable field. Making it transient ensures serialization safety while keeping runtime behavior unchanged for normal operation handling.

### Related issue(s): #2058

