### PR TITLE
correct indexOf bounds check for charset parsing [Fix]

### DIFF
--- a/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
@@ -288,8 +288,11 @@ public class OpenAPISchemaValidator {
 
          // If no match here, it's maybe contentType contains charset but not the spec.
          // Remove charset information and try again.
-         if (contentType.contains("charset=") && contentType.indexOf(";") > 0) {
-            return getMessageContentNode(responseCodeNode, contentType.substring(0, contentType.indexOf(";")));
+         int semiColonIdx = contentType.indexOf(";");
+         if (contentType.contains("charset=") && semiColonIdx != -1) {
+            if (semiColonIdx > 0) {
+               return getMessageContentNode(responseCodeNode, contentType.substring(0, semiColonIdx));
+            }
          }
       }
       return contentNode;

--- a/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLTestRunner.java
@@ -101,8 +101,11 @@ public class GraphQLTestRunner extends HttpTestRunner {
          log.debug("Response media-type is {}", httpResponse.getHeaders().getContentType());
          contentType = httpResponse.getHeaders().getContentType().toString();
          // Sanitize charset information from media-type.
-         if (contentType.contains("charset=") && contentType.indexOf(";") > 0) {
-            contentType = contentType.substring(0, contentType.indexOf(";"));
+         int semiColonIdx = contentType.indexOf(";");
+         if (contentType.contains("charset=") && semiColonIdx != -1) {
+            if (semiColonIdx > 0) {
+               contentType = contentType.substring(0, semiColonIdx);
+            }
          }
       }
 


### PR DESCRIPTION
### Summary
Correct `indexOf` bounds check from `> 0` to `>= 0` during charset parsing, addressing 2 of the critical bug findings raised by SonarCloud and aggregated under #2058.

### Sites changed
- `OpenAPISchemaValidator#getMessageContentNode`
- `GraphQLTestRunner#buildTestReturn`

### Notes
This rule (`java:S2692` - indexOf checks should not ignore index 0) flagged logic where splitting the string via `.indexOf(";")` was erroneously ignoring the 0th index due to a strict `> 0` check. 