### PR TITLE
add missing default case to switch in McpController [Fix]

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/McpController.java
+++ b/webapp/src/main/java/io/github/microcks/web/McpController.java
@@ -215,6 +215,9 @@ public class McpController {
          case McpSchema.METHOD_TOOLS_CALL -> {
             result = handleToolsCallRequest(request, headers, service);
          }
+         default -> {
+            // Unrecognized methods fall through; result remains null yielding a 'Method not found' response
+         }
       }
 
       McpSchema.JSONRPCResponse response = null;


### PR DESCRIPTION
### Summary
Add a missing `default` case to the switch statement in `McpController.java`, addressing the maintainability finding raised by SonarCloud and aggregated under #2058.

### Sites changed
- `McpController#handleMcpRequest`

### Notes
This rule (`java:S131` - switch statements should have a `default` case) flagged the `request.method()` switch block. I added a `default -> { }` block with an inline comment explaining that unrecognized methods fall through safely. This intentionally leaves `result` null, which correctly triggers the existing `-32601 Method not found` JSON RPC error response below it.
