### PR TITLE
remove System.out.println from test classes [Fix]

### DIFF
--- a/commons/util/src/test/java/io/github/microcks/util/asyncapi/AsyncAPISchemaValidatorTest.java
+++ b/commons/util/src/test/java/io/github/microcks/util/asyncapi/AsyncAPISchemaValidatorTest.java
@@ -409,7 +409,6 @@ class AsyncAPISchemaValidatorTest {
             "/channels/smartylighting~1streetlights~1event~1lighting~1measured/subscribe/message");
       assertFalse(errors.isEmpty());
       assertEquals(2, errors.size());
-      System.out.println(errors);
       // First error is because payload does not have any ref to components.
       assertEquals(
             "property 'location' is not defined in the schema and the schema does not allow additional properties",
@@ -569,9 +568,7 @@ class AsyncAPISchemaValidatorTest {
       List<String> errors = AsyncAPISchemaValidator.validateJsonMessage(asyncAPISpec, contentNode,
             "/channels/user~1signedup/subscribe/message",
             "https://raw.githubusercontent.com/microcks/microcks/1.7.x/commons/util/src/test/resources/io/github/microcks/util/asyncapi/");
-      for (String error : errors) {
-         System.out.println("Validation error: " + error);
-      }
+
       assertTrue(errors.isEmpty());
    }
 

--- a/commons/util/src/test/java/io/github/microcks/util/openapi/OpenAPISchemaValidatorTest.java
+++ b/commons/util/src/test/java/io/github/microcks/util/openapi/OpenAPISchemaValidatorTest.java
@@ -375,9 +375,7 @@ class OpenAPISchemaValidatorTest {
       // Validate the content for Get /forecast/{region} response message.
       errors = OpenAPISchemaValidator.validateJsonMessage(openAPISpec, contentNode,
             "/paths/~1forecast~1{region}/get/responses/200", "application/json");
-      for (String error : errors) {
-         System.out.println("Validation error: " + error);
-      }
+
       assertTrue(errors.isEmpty());
 
       // Now try with an external relative ref.


### PR DESCRIPTION
### Summary
Removed leftover `System.out.println` debug statements from test classes, addressing the code smell raised by SonarCloud and aggregated under #2058.

### Sites changed
- `AsyncAPISchemaValidatorTest`
- `OpenAPISchemaValidatorTest`

### Notes
This rule (`java:S106` - Standard outputs should not be used directly to log anything) flagged these debug print statements. Since these were just leftover prints inside tests that provide no long-term logging value, they have been cleanly removed (along with their enclosing `for` loops).