### PR TITLE
fix: OAS 3.0 exclusiveMinimum/Maximum parsing exception

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -17,7 +17,7 @@ Don't forget to indicate your Java, Maven and/or Docker version.
 
 ### Build the whole project
 
-You need to have [Apache Maven](https://maven.apache.org) (version >= 3.5) up and running as well as a valid Java Development Kit (version >= 21) install to build the project.
+You need to have [Apache Maven](https://maven.apache.org) (version >= 3.5) up and running as well as a valid Java Development Kit (version >= 25) install to build the project.
 
 ```
 $ git clone https://github.com/microcks/microcks.git

--- a/commons/util/src/main/java/io/github/microcks/util/JsonSchemaDialect.java
+++ b/commons/util/src/main/java/io/github/microcks/util/JsonSchemaDialect.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.util;
+
+/**
+ * Identifies the JSON Schema draft dialect to use when validating a payload. Decouples Microcks utility APIs from the
+ * underlying validator implementation so callers don't have to depend on a specific library type.
+ */
+public enum JsonSchemaDialect {
+   /** JSON Schema draft-04 — required by OpenAPI 3.0.x. */
+   DRAFT_4,
+   /** JSON Schema draft 2020-12 — used by OpenAPI 3.1.x and the default elsewhere. */
+   DRAFT_2020_12
+}

--- a/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidator.java
@@ -151,7 +151,7 @@ public class JsonSchemaValidator {
     * @return The list of validation failure messages. If empty, json object is valid !
     */
    public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace) {
-      return validateJson(schemaNode, jsonNode, namespace, SpecVersion.VersionFlag.V202012);
+      return validateJson(schemaNode, jsonNode, namespace, JsonSchemaDialect.DRAFT_2020_12);
    }
 
    /**
@@ -160,17 +160,17 @@ public class JsonSchemaValidator {
     * semantics regarding additional or unknown attributes: schema must explicitly set <code>additionalProperties</code>
     * to false if you want to consider unknown attributes as validation errors. It returns a list of validation error
     * messages.
-    * @param schemaNode  The Json schema specification as a Jackson node
-    * @param jsonNode    The Json object as a Jackson node
-    * @param namespace   Namespace definition to resolve relative dependencies in Json schema
-    * @param versionFlag The Json schema draft version to use for validation (e.g. V4 for OAS 3.0, V202012 for OAS 3.1)
+    * @param schemaNode The Json schema specification as a Jackson node
+    * @param jsonNode   The Json object as a Jackson node
+    * @param namespace  Namespace definition to resolve relative dependencies in Json schema
+    * @param dialect    The JSON Schema dialect to validate against (DRAFT_4 for OAS 3.0, DRAFT_2020_12 for OAS 3.1)
     * @return The list of validation failure messages. If empty, json object is valid !
     */
    public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace,
-         SpecVersion.VersionFlag versionFlag) {
+         JsonSchemaDialect dialect) {
       List<String> errors = new ArrayList<>();
 
-      final JsonSchema jsonSchemaNode = extractJsonSchemaNode(schemaNode, namespace, versionFlag);
+      final JsonSchema jsonSchemaNode = extractJsonSchemaNode(schemaNode, namespace, toVersionFlag(dialect));
 
       Set<ValidationMessage> messages = jsonSchemaNode.validate(jsonNode, executionContext -> {
          executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
@@ -216,6 +216,13 @@ public class JsonSchemaValidator {
          case V7 -> JsonMetaSchema.getV7();
          case V201909 -> JsonMetaSchema.getV201909();
          case V202012 -> JsonMetaSchema.getV202012();
+      };
+   }
+
+   private static SpecVersion.VersionFlag toVersionFlag(JsonSchemaDialect dialect) {
+      return switch (dialect) {
+         case DRAFT_4 -> SpecVersion.VersionFlag.V4;
+         case DRAFT_2020_12 -> SpecVersion.VersionFlag.V202012;
       };
    }
 }

--- a/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/JsonSchemaValidator.java
@@ -37,7 +37,7 @@ import java.util.Set;
 
 /**
  * Helper class for validating Json objects against their Json schema. Supported version of Json schema is
- * http://json-schema.org/draft-07/schema.
+ * http://json-schema.org/draft/2020-12/schema.
  * @author laurent
  */
 public class JsonSchemaValidator {
@@ -45,8 +45,6 @@ public class JsonSchemaValidator {
    /** A commons logger for diagnostic messages. */
    private static final Logger log = LoggerFactory.getLogger(JsonSchemaValidator.class);
 
-   public static final String JSON_V4_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-04/schema#";
-   public static final String JSON_V7_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-07/schema#";
    public static final String JSON_V12_SCHEMA_IDENTIFIER = "http://json-schema.org/draft/2020-12/schema#";
    public static final String JSON_SCHEMA_IDENTIFIER_ELEMENT = "$schema";
 
@@ -153,9 +151,26 @@ public class JsonSchemaValidator {
     * @return The list of validation failure messages. If empty, json object is valid !
     */
    public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace) {
+      return validateJson(schemaNode, jsonNode, namespace, SpecVersion.VersionFlag.V202012);
+   }
+
+   /**
+    * Validate a Json object representing by its text against a schema object representing byt its text too. Validation
+    * is a deep one: its pursue checking children nodes on a failed parent. Validation is respectful of Json schema spec
+    * semantics regarding additional or unknown attributes: schema must explicitly set <code>additionalProperties</code>
+    * to false if you want to consider unknown attributes as validation errors. It returns a list of validation error
+    * messages.
+    * @param schemaNode  The Json schema specification as a Jackson node
+    * @param jsonNode    The Json object as a Jackson node
+    * @param namespace   Namespace definition to resolve relative dependencies in Json schema
+    * @param versionFlag The Json schema draft version to use for validation (e.g. V4 for OAS 3.0, V202012 for OAS 3.1)
+    * @return The list of validation failure messages. If empty, json object is valid !
+    */
+   public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace,
+         SpecVersion.VersionFlag versionFlag) {
       List<String> errors = new ArrayList<>();
 
-      final JsonSchema jsonSchemaNode = extractJsonSchemaNode(schemaNode, namespace);
+      final JsonSchema jsonSchemaNode = extractJsonSchemaNode(schemaNode, namespace, versionFlag);
 
       Set<ValidationMessage> messages = jsonSchemaNode.validate(jsonNode, executionContext -> {
          executionContext.getExecutionConfig().setFormatAssertionsEnabled(true);
@@ -180,20 +195,10 @@ public class JsonSchemaValidator {
       return mapper.readTree(jsonText);
    }
 
-   /**
-    * Get a Jackson JsonNode representation for Json schema.
-    * @param schemaText The Json schema specification as a string
-    * @return The Jackson JsonSchema corresponding to json schema string
-    * @throws IOException if json string representation cannot be parsed
-    */
-   public static JsonSchema getSchemaNode(String schemaText) throws IOException {
-      final JsonNode schemaNode = getJsonNode(schemaText);
-      return extractJsonSchemaNode(schemaNode, null);
-   }
-
-   private static JsonSchema extractJsonSchemaNode(JsonNode jsonNode, String namespace) {
-      JsonMetaSchema jsonMetaSchema = JsonMetaSchema.builder(JsonMetaSchema.getV202012()).build();
-      JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012,
+   private static JsonSchema extractJsonSchemaNode(JsonNode jsonNode, String namespace,
+         SpecVersion.VersionFlag versionFlag) {
+      JsonMetaSchema jsonMetaSchema = JsonMetaSchema.builder(metaSchemaFor(versionFlag)).build();
+      JsonSchemaFactory jsonSchemaFactory = JsonSchemaFactory.getInstance(versionFlag,
             builder -> builder.metaSchema(jsonMetaSchema));
 
       if (namespace != null) {
@@ -202,5 +207,15 @@ public class JsonSchemaValidator {
       }
 
       return jsonSchemaFactory.getSchema(jsonNode);
+   }
+
+   private static JsonMetaSchema metaSchemaFor(SpecVersion.VersionFlag versionFlag) {
+      return switch (versionFlag) {
+         case V4 -> JsonMetaSchema.getV4();
+         case V6 -> JsonMetaSchema.getV6();
+         case V7 -> JsonMetaSchema.getV7();
+         case V201909 -> JsonMetaSchema.getV201909();
+         case V202012 -> JsonMetaSchema.getV202012();
+      };
    }
 }

--- a/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.networknt.schema.SpecVersion;
+import io.github.microcks.util.JsonSchemaDialect;
 import io.github.microcks.util.JsonSchemaValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,7 +146,7 @@ public class OpenAPISchemaValidator {
     * @return The list of validation failures. If empty, json object is valid !
     */
    public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace) {
-      return validateJson(schemaNode, jsonNode, namespace, SpecVersion.VersionFlag.V202012);
+      return validateJson(schemaNode, jsonNode, namespace, JsonSchemaDialect.DRAFT_2020_12);
    }
 
    /**
@@ -155,16 +155,16 @@ public class OpenAPISchemaValidator {
     * spec semantics regarding additional or unknown attributes: schema must explicitly set
     * <code>additionalProperties</code> to false if you want to consider unknown attributes as validation errors. It
     * returns a list of validation error messages.
-    * @param schemaNode  The OpenAPI schema specification as a Jackson node
-    * @param jsonNode    The Json object as a Jackson node
-    * @param namespace   Namespace definition to resolve relative dependencies in Json schema
-    * @param versionFlag The Json schema draft version to validate against (V4 for OAS 3.0, V202012 for OAS 3.1)
+    * @param schemaNode The OpenAPI schema specification as a Jackson node
+    * @param jsonNode   The Json object as a Jackson node
+    * @param namespace  Namespace definition to resolve relative dependencies in Json schema
+    * @param dialect    The JSON Schema dialect to validate against (DRAFT_4 for OAS 3.0, DRAFT_2020_12 for OAS 3.1)
     * @return The list of validation failures. If empty, json object is valid !
     */
    public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace,
-         SpecVersion.VersionFlag versionFlag) {
+         JsonSchemaDialect dialect) {
       var convertedSchemaNode = convertOpenAPISchemaToJsonSchema(schemaNode);
-      return JsonSchemaValidator.validateJson(convertedSchemaNode, jsonNode, namespace, versionFlag);
+      return JsonSchemaValidator.validateJson(convertedSchemaNode, jsonNode, namespace, dialect);
    }
 
    /**
@@ -231,23 +231,22 @@ public class OpenAPISchemaValidator {
       ((ObjectNode) schemaNode).set(JSON_SCHEMA_COMPONENTS_ELEMENT,
             specificationNode.path(JSON_SCHEMA_COMPONENTS_ELEMENT).deepCopy());
 
-      return validateJson(schemaNode, jsonNode, namespace, resolveSpecVersion(specificationNode));
+      return validateJson(schemaNode, jsonNode, namespace, resolveDialect(specificationNode));
    }
 
    /**
-    * Resolve the JSON schema draft version to use when validating a message against the given OpenAPI specification.
-    * OpenAPI 3.0.x relies on a schema dialect derived from JSON Schema draft-04 (boolean
-    * <code>exclusiveMinimum</code>/<code>exclusiveMaximum</code>) — V4 is the only networknt
-    * <code>SpecVersion.VersionFlag</code> that accepts that form. For OpenAPI 3.1.x and any other / missing version, we
-    * keep the default V202012.
+    * Resolve the JSON Schema dialect to use when validating a message against the given OpenAPI specification. OpenAPI
+    * 3.0.x relies on a schema dialect derived from JSON Schema draft-04 (boolean
+    * <code>exclusiveMinimum</code>/<code>exclusiveMaximum</code>). For OpenAPI 3.1.x and any other / missing version,
+    * we keep the default draft 2020-12.
     */
-   private static SpecVersion.VersionFlag resolveSpecVersion(JsonNode specificationNode) {
+   private static JsonSchemaDialect resolveDialect(JsonNode specificationNode) {
       String openApiVersion = specificationNode.path("openapi").asText("");
       if (openApiVersion.startsWith("3.0.")) {
-         log.info("Detected OpenAPI specification version {}, parsing it using schema V4", openApiVersion);
-         return SpecVersion.VersionFlag.V4;
+         log.debug("Detected OpenAPI specification version {}, parsing it using JSON Schema draft-04", openApiVersion);
+         return JsonSchemaDialect.DRAFT_4;
       }
-      return SpecVersion.VersionFlag.V202012;
+      return JsonSchemaDialect.DRAFT_2020_12;
    }
 
    /**

--- a/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
+++ b/commons/util/src/main/java/io/github/microcks/util/openapi/OpenAPISchemaValidator.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.networknt.schema.SpecVersion;
 import io.github.microcks.util.JsonSchemaValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,8 +146,25 @@ public class OpenAPISchemaValidator {
     * @return The list of validation failures. If empty, json object is valid !
     */
    public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace) {
-      schemaNode = convertOpenAPISchemaToJsonSchema(schemaNode);
-      return JsonSchemaValidator.validateJson(schemaNode, jsonNode, namespace);
+      return validateJson(schemaNode, jsonNode, namespace, SpecVersion.VersionFlag.V202012);
+   }
+
+   /**
+    * Validate a Json object representing by its text against a schema object representing byt its text too. Validation
+    * is a deep one: its pursue checking children nodes on a failed parent. Validation is respectful of OpenAPI schema
+    * spec semantics regarding additional or unknown attributes: schema must explicitly set
+    * <code>additionalProperties</code> to false if you want to consider unknown attributes as validation errors. It
+    * returns a list of validation error messages.
+    * @param schemaNode  The OpenAPI schema specification as a Jackson node
+    * @param jsonNode    The Json object as a Jackson node
+    * @param namespace   Namespace definition to resolve relative dependencies in Json schema
+    * @param versionFlag The Json schema draft version to validate against (V4 for OAS 3.0, V202012 for OAS 3.1)
+    * @return The list of validation failures. If empty, json object is valid !
+    */
+   public static List<String> validateJson(JsonNode schemaNode, JsonNode jsonNode, String namespace,
+         SpecVersion.VersionFlag versionFlag) {
+      var convertedSchemaNode = convertOpenAPISchemaToJsonSchema(schemaNode);
+      return JsonSchemaValidator.validateJson(convertedSchemaNode, jsonNode, namespace, versionFlag);
    }
 
    /**
@@ -213,7 +231,23 @@ public class OpenAPISchemaValidator {
       ((ObjectNode) schemaNode).set(JSON_SCHEMA_COMPONENTS_ELEMENT,
             specificationNode.path(JSON_SCHEMA_COMPONENTS_ELEMENT).deepCopy());
 
-      return validateJson(schemaNode, jsonNode, namespace);
+      return validateJson(schemaNode, jsonNode, namespace, resolveSpecVersion(specificationNode));
+   }
+
+   /**
+    * Resolve the JSON schema draft version to use when validating a message against the given OpenAPI specification.
+    * OpenAPI 3.0.x relies on a schema dialect derived from JSON Schema draft-04 (boolean
+    * <code>exclusiveMinimum</code>/<code>exclusiveMaximum</code>) — V4 is the only networknt
+    * <code>SpecVersion.VersionFlag</code> that accepts that form. For OpenAPI 3.1.x and any other / missing version, we
+    * keep the default V202012.
+    */
+   private static SpecVersion.VersionFlag resolveSpecVersion(JsonNode specificationNode) {
+      String openApiVersion = specificationNode.path("openapi").asText("");
+      if (openApiVersion.startsWith("3.0.")) {
+         log.info("Detected OpenAPI specification version {}, parsing it using schema V4", openApiVersion);
+         return SpecVersion.VersionFlag.V4;
+      }
+      return SpecVersion.VersionFlag.V202012;
    }
 
    /**

--- a/commons/util/src/test/java/io/github/microcks/util/openapi/OpenAPISchemaValidatorTest.java
+++ b/commons/util/src/test/java/io/github/microcks/util/openapi/OpenAPISchemaValidatorTest.java
@@ -46,7 +46,7 @@ class OpenAPISchemaValidatorTest {
          // Validate Json according schema.
          valid = OpenAPISchemaValidator.isJsonValid(schemaText, jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Assert Json object is valid.
@@ -66,7 +66,7 @@ class OpenAPISchemaValidatorTest {
          // Validate Json according schema.
          valid = OpenAPISchemaValidator.isJsonValid(schemaText, jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Assert Json object is valid.
@@ -86,7 +86,7 @@ class OpenAPISchemaValidatorTest {
          // Validate Json according schema.
          valid = OpenAPISchemaValidator.isJsonValid(schemaText, jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Assert Json object is not valid.
@@ -97,7 +97,7 @@ class OpenAPISchemaValidatorTest {
       try {
          errors = OpenAPISchemaValidator.validateJson(schemaText, jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
       assertEquals(1, errors.size());
       assertEquals("required property 'name' not found", errors.get(0));
@@ -117,7 +117,7 @@ class OpenAPISchemaValidatorTest {
          // Validate Json according schema.
          valid = OpenAPISchemaValidator.isJsonValid(schemaText, jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Assert Json object is not valid.
@@ -128,7 +128,7 @@ class OpenAPISchemaValidatorTest {
       try {
          errors = OpenAPISchemaValidator.validateJson(schemaText, jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
       assertEquals(1, errors.size());
       assertEquals("property 'energy' is not defined in the schema and the schema does not allow additional properties",
@@ -150,8 +150,7 @@ class OpenAPISchemaValidatorTest {
          // Validate Json according schema.
          valid = OpenAPISchemaValidator.isJsonValid(schemaText, jsonText);
       } catch (Exception e) {
-         e.printStackTrace();
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Assert Json object is valid.
@@ -174,7 +173,7 @@ class OpenAPISchemaValidatorTest {
          valid = OpenAPISchemaValidator.isJsonValid(schemaText, jsonText,
                "https://raw.githubusercontent.com/microcks/microcks/1.6.x/commons/util/src/test/resources/io/github/microcks/util/openapi/");
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Assert Json object is valid.
@@ -196,8 +195,7 @@ class OpenAPISchemaValidatorTest {
          // Validate Json according schema.
          valid = OpenAPISchemaValidator.isJsonValid(schemaText, jsonText);
       } catch (Exception e) {
-         e.printStackTrace();
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Assert Json object is not valid.
@@ -207,7 +205,7 @@ class OpenAPISchemaValidatorTest {
       try {
          errors = OpenAPISchemaValidator.validateJson(schemaText, jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
       // Don't know why but when a failure occurs, validator also complains
       // about components reference not being found.
@@ -236,7 +234,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts response message.
@@ -251,7 +249,7 @@ class OpenAPISchemaValidatorTest {
          // Extract JSON nodes using OpenAPISchemaValidator methods.
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts/{accountId} response message.
@@ -281,7 +279,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts response message.
@@ -296,7 +294,7 @@ class OpenAPISchemaValidatorTest {
          // Extract JSON nodes using OpenAPISchemaValidator methods.
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts/{accountId} response message.
@@ -311,7 +309,7 @@ class OpenAPISchemaValidatorTest {
          // Extract JSON nodes using OpenAPISchemaValidator methods.
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts/{accountId} response message.
@@ -350,7 +348,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /forecast/{region} response message.
@@ -369,7 +367,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /forecast/{region} response message.
@@ -389,7 +387,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /forecast/{region} response message but without specifying a namespace.
@@ -426,7 +424,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /forecast response message but without specifying a namespace.
@@ -458,7 +456,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts response message.
@@ -474,7 +472,7 @@ class OpenAPISchemaValidatorTest {
          // Extract JSON nodes using OpenAPISchemaValidator methods.
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts/{accountId} response message.
@@ -511,7 +509,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts response message.
@@ -539,7 +537,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts response message.
@@ -548,7 +546,6 @@ class OpenAPISchemaValidatorTest {
 
       assertEquals(expected, errors.isEmpty());
    }
-
 
    @ParameterizedTest()
    @CsvSource(value = { "null | {\"seasonData\":null} | true",
@@ -570,7 +567,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts response message.
@@ -600,7 +597,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts response message.
@@ -649,7 +646,7 @@ class OpenAPISchemaValidatorTest {
          openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
          contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
       } catch (Exception e) {
-         fail("Exception should not be thrown");
+         fail("Exception should not be thrown", e);
       }
 
       // Validate the content for Get /accounts response message.
@@ -657,4 +654,97 @@ class OpenAPISchemaValidatorTest {
             "/paths/~1queen~1members/get/responses/200", "application/json");
       assertTrue(errors.isEmpty());
    }
+
+   @Test
+   void testValidateOpenAPI30BooleanExclusiveBoundsValid() {
+      String openAPIText = null;
+      String jsonText = """
+            {
+              "name": "307",
+              "year": 2003
+            }
+            """;
+      JsonNode openAPISpec = null;
+      JsonNode contentNode = null;
+
+      try {
+         // Load full specification from file.
+         openAPIText = FileUtils.readFileToString(
+               new File("target/test-classes/io/github/microcks/util/openapi/car-exclusive-bounds-openapi-3.0.yaml"),
+               StandardCharsets.UTF_8);
+         // Extract JSON nodes using OpenAPISchemaValidator methods.
+         openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
+         contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
+      } catch (Exception e) {
+         fail("Exception should not be thrown", e);
+      }
+
+      // Validate the content for Post /cars response message.
+      List<String> errors = OpenAPISchemaValidator.validateJsonMessage(openAPISpec, contentNode,
+            "/paths/~1cars/post/requestBody", "application/json");
+      assertTrue(errors.isEmpty(), () -> "Expected no validation errors but got: " + errors);
+   }
+
+   @Test
+   void testValidateOpenAPI30BooleanExclusiveMinimumViolated() {
+      String openAPIText = null;
+      String jsonText = """
+            {
+              "name": "307",
+              "year": 1950
+            }
+            """;
+      JsonNode openAPISpec = null;
+      JsonNode contentNode = null;
+
+      try {
+         // Load full specification from file.
+         openAPIText = FileUtils.readFileToString(
+               new File("target/test-classes/io/github/microcks/util/openapi/car-exclusive-bounds-openapi-3.0.yaml"),
+               StandardCharsets.UTF_8);
+         // Extract JSON nodes using OpenAPISchemaValidator methods.
+         openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
+         contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
+      } catch (Exception e) {
+         fail("Exception should not be thrown", e);
+      }
+
+      // Validate the content for Post /cars response message.
+      List<String> errors = OpenAPISchemaValidator.validateJsonMessage(openAPISpec, contentNode,
+            "/paths/~1cars/post/requestBody", "application/json");
+      assertAll(() -> assertFalse(errors.isEmpty()),
+            () -> assertEquals("must have a minimum value of 1950", errors.getFirst()));
+   }
+
+   @Test
+   void testValidateOpenAPI30BooleanExclusiveMaximumViolated() {
+      String openAPIText = null;
+      String jsonText = """
+            {
+              "name": "307",
+              "year": 2100
+            }
+            """;
+      JsonNode openAPISpec = null;
+      JsonNode contentNode = null;
+
+      try {
+         // Load full specification from file.
+         openAPIText = FileUtils.readFileToString(
+               new File("target/test-classes/io/github/microcks/util/openapi/car-exclusive-bounds-openapi-3.0.yaml"),
+               StandardCharsets.UTF_8);
+         // Extract JSON nodes using OpenAPISchemaValidator methods.
+         openAPISpec = OpenAPISchemaValidator.getJsonNodeForSchema(openAPIText);
+         contentNode = OpenAPISchemaValidator.getJsonNode(jsonText);
+      } catch (Exception e) {
+         fail("Exception should not be thrown", e);
+      }
+
+      // Validate the content for Post /cars response message.
+      List<String> errors = OpenAPISchemaValidator.validateJsonMessage(openAPISpec, contentNode,
+            "/paths/~1cars/post/requestBody", "application/json");
+      assertAll(() -> assertFalse(errors.isEmpty()),
+            () -> assertEquals("must have a maximum value of 2100", errors.getFirst()));
+   }
+
 }

--- a/commons/util/src/test/resources/io/github/microcks/util/openapi/car-exclusive-bounds-openapi-3.0.yaml
+++ b/commons/util/src/test/resources/io/github/microcks/util/openapi/car-exclusive-bounds-openapi-3.0.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.3
+info:
+  title: Cars API
+  version: '1.0'
+paths:
+  /cars:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Car'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Car'
+
+components:
+  schemas:
+    Car:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        year:
+          type: integer
+          minimum: 1950
+          exclusiveMinimum: true
+          maximum: 2100
+          exclusiveMaximum: true


### PR DESCRIPTION
### Description

When Microcks parses an OAS 3.0 specification with `exclusiveMinimum` and/or `exclusiveMaximum` set as `booleans` (as expected for OAS 3.0), it throws a `JsonSchemaException`.

The fix is the following:
- Update `JsonSchemaValidator` to allow providing a schema version, keeping `V202012` as default
- Update `OpenAPISchemaValidator` to extract the `openapi` field, and force the schema `V4` if it starts with `3.0.`

Fix tested locally using compose, adding my application to it, and triggering the `OPEN API SCHEMA` conformance test.
Attaching the logs before/after the fix:
- [microcks-logs-before-fix.txt](https://github.com/user-attachments/files/28308420/microcks-logs-before-fix.txt)
- [microcks-logs-after-fix.txt](https://github.com/user-attachments/files/28308419/microcks-logs-after-fix.txt)

Small bonus: The project requires Java 25, but the `BUILDING.md` was mentioning 21

### Related issue(s)

Fixes #2129 