### PR TITLE
fix: windows compatibility issues

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLMcpToolConverter.java
+++ b/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLMcpToolConverter.java
@@ -97,7 +97,7 @@ public class GraphQLMcpToolConverter extends McpToolConverter {
          if (operationDefinition != null) {
             // #1 Look for a description in the operation definition.
             if (operationDefinition.getDescription() != null) {
-               return operationDefinition.getDescription().content;
+               return operationDefinition.getDescription().content.trim();
             } else if (operationDefinition.getComments() != null && !operationDefinition.getComments().isEmpty()) {
                // #2 Look for comments in the operation definition.
                StringBuilder result = new StringBuilder();

--- a/webapp/src/main/java/io/github/microcks/util/grpc/ProtobufImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/grpc/ProtobufImporter.java
@@ -39,7 +39,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -79,7 +78,9 @@ public class ProtobufImporter implements MockRepositoryImporter {
    public ProtobufImporter(String protoFilePath, ReferenceResolver referenceResolver) throws IOException {
       this.referenceResolver = referenceResolver;
 
-      String fileSeparator = FileSystems.getDefault().getSeparator();
+      // Use forward slashes throughout: protoc requires '/' for the file argument so it can be
+      // made relative to --proto_path, and Java's Path API on Windows also accepts '/'.
+      String fileSeparator = "/";
 
       // Move proto file to a unique subdir that matches its package name (to avoid conflicts)
       // This will allow protoc to find the relative imports we will download later on.
@@ -102,7 +103,7 @@ public class ProtobufImporter implements MockRepositoryImporter {
 
          // Prepare file, path and name for easier process.
          File protoFile = new File(protoFilePath);
-         protoDirectory = protoPath.getParent().resolve(uuid + fileSeparator).toFile().getAbsolutePath();
+         protoDirectory = protoPath.getParent().resolve(uuid).toFile().getAbsolutePath();
          protoFileName = packagePath + fileSeparator + protoFile.getName();
 
          // Now switch the proto and file paths.


### PR DESCRIPTION
### Description

When building Microcks on my Windows 11 machine, I am facing some unit tests failures In the `webapp` module:

```text
[ERROR] Failures: 
[ERROR]   ServiceServiceTest.testImportServiceDefinitionMainGrpcAndSecondaryExamples:717 No MockRepositoryImportException should have be thrown
[ERROR]   ServiceServiceTest.testImportServiceDefinitionMainGrpcAndSecondaryPostman:641 No MockRepositoryImportException should have be thrown
[ERROR]   MockRepositoryImporterFactoryTest.testGetMockRepositoryImporter:155 Getting importer for Protobuf should not fail!
[ERROR]   GraphQLMcpToolConverterTest.testGetToolDescription:137 expected: <Adds enterprise members to an organization within the enterprise.> but was: <
>dds enterprise members to an organization within the enterprise.                                                                                                                                                                  
[ERROR]   ProtobufImporterTest.testProtobufWithComplexRemoteDependenciesImport:280 Exception should not be thrown
[ERROR]   ProtobufImporterTest.testProtobufWithComplexRemoteDependenciesImport2:317 Exception should not be thrown
[ERROR]   ProtobufImporterTest.testProtobufWithDependenciesImport:107 Exception should not be thrown
[ERROR]   ProtobufImporterTest.testProtobufWithEnumDependenciesImport:174 Exception should not be thrown
[ERROR]   ProtobufImporterTest.testProtobufWithOptionsImport:205 Exception should not be thrown
[ERROR]   ProtobufImporterTest.testSimpleProtobufImport:48 Exception should not be thrown
[ERROR] Errors: 
[ERROR]   GrpcMcpToolConverterTest.setUp:73 » MockRepositoryImport Protobuf schema file parsing error on target\test-classes\io\github\microcks\util\grpc\61586c7d-ec18-4e6f-9cc7-edf59fb28db2\org\acme\petstore\v1\petstore-v1.proto: C:\dev\git\oss\microcks\webapp\target\test-classes\io\github\microcks\util\grpc\61586c7d-ec18-4e6f-9cc7-edf59fb28db2\org\acme\petstore\v1\petstore-v1.proto.pbb (The system cannot find the file specified)                    
[INFO] 
[ERROR] Tests run: 414, Failures: 10, Errors: 1, Skipped: 0
[INFO] 
[ERROR] There are test failures.
```

Both are related to Windows specific characters: 
- `CRLF` characters in the MCP tool description: used `.trim()` to get rid of them (like it is done in the second `if` branch)
- `\` that does not work with `protoc`

### Related issue(s)

Fixes #2138 