### PR TITLE
fix: return proper HTTP status codes for import failures

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/ImportController.java
+++ b/webapp/src/main/java/io/github/microcks/web/ImportController.java
@@ -26,6 +26,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * A Controller for importing new definitions into microcks repository.
  * @author laurent
@@ -50,18 +52,26 @@ public class ImportController {
    @PostMapping(value = "/import")
    public ResponseEntity<byte[]> importRepository(@RequestParam(value = "file") MultipartFile file) {
       log.debug("Importing new services and resources definitions");
-      if (!file.isEmpty()) {
-         log.debug("Content type of {} is {}", file.getOriginalFilename(), file.getContentType());
-         if (MediaType.APPLICATION_JSON_VALUE.equals(file.getContentType())) {
-            try {
-               byte[] bytes = file.getBytes();
-               String json = new String(bytes);
-               importExportService.importRepository(json);
-            } catch (Exception e) {
-               log.error(e.getMessage());
-            }
-         }
+
+      if (file.isEmpty()) {
+         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
       }
-      return new ResponseEntity<>(HttpStatus.CREATED);
+
+      log.debug("Content type of {} is {}", file.getOriginalFilename(), file.getContentType());
+
+      if (!MediaType.APPLICATION_JSON_VALUE.equals(file.getContentType())) {
+         return new ResponseEntity<>(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+      }
+
+      try {
+         byte[] bytes = file.getBytes();
+         String json = new String(bytes, StandardCharsets.UTF_8);
+         importExportService.importRepository(json);
+
+         return new ResponseEntity<>(HttpStatus.CREATED);
+      } catch (Exception e) {
+         log.error("Exception while importing repository", e);
+         return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+      }
    }
 }

--- a/webapp/src/test/java/io/github/microcks/web/ImportControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/ImportControllerIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@AutoConfigureMockMvc
+public class ImportControllerIT extends AbstractBaseIT {
+
+   @Autowired
+   public MockMvc mockMvc;
+
+   @Test
+   public void shouldReturnBadRequestWhenFileIsEmpty() throws Exception {
+      MockMultipartFile file = new MockMultipartFile("file", "empty.json", MediaType.APPLICATION_JSON_VALUE,
+            new byte[0]);
+
+      mockMvc.perform(MockMvcRequestBuilders.multipart("/api/import").file(file))
+            .andExpect(MockMvcResultMatchers.status().isBadRequest());
+   }
+
+   @Test
+   public void shouldReturnUnsupportedMediaTypeWhenContentTypeIsInvalid() throws Exception {
+      MockMultipartFile file = new MockMultipartFile("file", "test.txt", MediaType.TEXT_PLAIN_VALUE,
+            "invalid".getBytes());
+
+      mockMvc.perform(MockMvcRequestBuilders.multipart("/api/import").file(file))
+            .andExpect(MockMvcResultMatchers.status().isUnsupportedMediaType());
+   }
+
+   @Test
+   public void shouldReturnInternalServerErrorWhenImportFails() throws Exception {
+      MockMultipartFile file = new MockMultipartFile("file", "broken.json", MediaType.APPLICATION_JSON_VALUE,
+            "{}".getBytes());
+
+      mockMvc.perform(MockMvcRequestBuilders.multipart("/api/import").file(file))
+            .andExpect(MockMvcResultMatchers.status().isInternalServerError());
+   }
+}


### PR DESCRIPTION
## Description

This changes the `/api/import` endpoint so it no longer returns `201 Created` for every request, even when the import fails.

Before this change:

* empty uploads still returned `201`
* unsupported content types still returned `201`
* exceptions during import were swallowed and the API still responded with success

With this update:

* empty files now return `400 Bad Request`
* unsupported content types return `415 Unsupported Media Type`
* import exceptions return `500 Internal Server Error`
* successful imports still return `201 Created`

I also updated the controller to use `StandardCharsets.UTF_8` when converting uploaded bytes to String.

## Tests

Added integration tests covering:

* empty file upload
* invalid content type
* import failure path returning `500`

Test command used:

```bash
mvn -pl webapp -am -Dtest=ImportControllerIT -Dsurefire.failIfNoSpecifiedTests=false test
```

Fixes #2135
