### PR TITLE
test: migrate webapp ITs to RestTestClient

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -267,14 +267,6 @@
       <version>${spring-boot.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- SB4 moved TestRestTemplate to its own module. @SpringBootTest no longer
-         auto-provides a bean — test classes need @AutoConfigureTestRestTemplate. -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-resttestclient</artifactId>
-      <version>${spring-boot.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>de.bwaldvogel</groupId>
       <artifactId>mongo-java-server</artifactId>

--- a/webapp/src/test/java/io/github/microcks/MicrocksApplicationFuzz.java
+++ b/webapp/src/test/java/io/github/microcks/MicrocksApplicationFuzz.java
@@ -23,21 +23,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.MockMvcPrint;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
+import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -57,7 +55,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
  * @author laurent
  */
 @AutoConfigureMockMvc(print = MockMvcPrint.NONE)
-@AutoConfigureTestRestTemplate
 @SpringBootTest(classes = MicrocksApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("fuzz")
 @TestPropertySource(locations = { "classpath:/config/fuzz.properties" })
@@ -87,14 +84,14 @@ public class MicrocksApplicationFuzz {
    @Autowired
    protected MockMvc mockMvc;
 
-   @Autowired
-   protected TestRestTemplate restTemplate;
+   protected RestTestClient restClient;
 
    private boolean beforeCalled = false;
 
    @BeforeEach
    void beforeEach() {
       beforeCalled = true;
+      restClient = RestTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
 
       // Upload PetStore reference artifact.
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/petstore-openapi.json", true);
@@ -142,17 +139,18 @@ public class MicrocksApplicationFuzz {
       MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
       body.add("file", new FileSystemResource(new File(artifactFilePath)));
 
-      HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
-      ResponseEntity<String> response;
+      EntityExchangeResult<String> response;
       if (isMainArtifact) {
-         response = restTemplate.postForEntity("/api/artifact/upload", requestEntity, String.class);
+         response = restClient.post().uri("/api/artifact/upload").headers(httpHeaders -> httpHeaders.addAll(headers))
+               .body(body).exchange().expectBody(String.class).returnResult();
       } else {
-         response = restTemplate.postForEntity("/api/artifact/upload?mainArtifact=false", requestEntity, String.class);
+         response = restClient.post().uri("/api/artifact/upload?mainArtifact=false")
+               .headers(httpHeaders -> httpHeaders.addAll(headers)).body(body).exchange().expectBody(String.class)
+               .returnResult();
       }
 
-      assertEquals(201, response.getStatusCode().value());
-      log.info("Just uploaded: {}", response.getBody());
+      assertEquals(201, response.getStatus().value());
+      log.info("Just uploaded: {}", response.getResponseBody());
    }
 
    protected static ResultActions apiTest(MockMvc mockMvc, MockHttpServletRequestBuilder requestBuilder)

--- a/webapp/src/test/java/io/github/microcks/web/AbstractBaseIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/AbstractBaseIT.java
@@ -18,24 +18,30 @@ package io.github.microcks.web;
 import io.github.microcks.MicrocksApplication;
 import io.github.microcks.repository.ServiceRepository;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.HttpClientSettings;
+import org.springframework.boot.http.client.HttpRedirects;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
+import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
 import org.testcontainers.mongodb.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -48,7 +54,6 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author laurent
  */
 @SpringBootTest(classes = MicrocksApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureTestRestTemplate
 @ActiveProfiles("it")
 @TestPropertySource(locations = { "classpath:/config/test.properties" })
 public abstract class AbstractBaseIT {
@@ -59,8 +64,11 @@ public abstract class AbstractBaseIT {
    @LocalServerPort
    private int port;
 
-   @Autowired
-   protected TestRestTemplate restTemplate;
+   protected RestTestClient restClient;
+
+   protected RestTestClient noRedirectRestClient;
+
+   protected RestClient streamingRestClient;
 
    @Autowired
    protected ServiceRepository serviceRepository;
@@ -87,6 +95,17 @@ public abstract class AbstractBaseIT {
       return "http://localhost:" + port;
    }
 
+   @BeforeEach
+   void initRestClients() {
+      restClient = RestTestClient.bindToServer().baseUrl(getServerUrl()).build();
+
+      var noRedirectRequestFactory = ClientHttpRequestFactoryBuilder.httpClient()
+            .withHttpClientSettings(HttpClientSettings.defaults().withRedirects(HttpRedirects.DONT_FOLLOW)).build();
+      noRedirectRestClient = RestTestClient.bindToServer(noRedirectRequestFactory).baseUrl(getServerUrl()).build();
+
+      streamingRestClient = RestClient.builder().baseUrl(getServerUrl()).build();
+   }
+
    /** */
    protected void uploadArtifactFile(String artifactFilePath, boolean isMainArtifact) {
       HttpHeaders headers = new HttpHeaders();
@@ -95,22 +114,62 @@ public abstract class AbstractBaseIT {
       MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
       body.add("file", new FileSystemResource(new File(artifactFilePath)));
 
-      HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
-      ResponseEntity<String> response;
+      EntityExchangeResult<String> response;
       if (isMainArtifact) {
-         response = restTemplate.postForEntity("/api/artifact/upload", requestEntity, String.class);
+         response = restClient.post().uri("/api/artifact/upload").headers(httpHeaders -> httpHeaders.addAll(headers))
+               .body(body).exchange().expectBody(String.class).returnResult();
       } else {
-         response = restTemplate.postForEntity("/api/artifact/upload?mainArtifact=false", requestEntity, String.class);
+         response = restClient.post().uri("/api/artifact/upload?mainArtifact=false")
+               .headers(httpHeaders -> httpHeaders.addAll(headers)).body(body).exchange().expectBody(String.class)
+               .returnResult();
       }
 
-      assertEquals(201, response.getStatusCode().value());
-      log.info("Just uploaded: {}", response.getBody());
+      assertEquals(201, response.getStatus().value());
+      log.info("Just uploaded: {}", response.getResponseBody());
    }
 
-   protected void assertResponseIsOkAndContains(ResponseEntity<String> response, String substring) {
-      assertEquals(200, response.getStatusCode().value());
-      assertNotNull(response.getBody());
-      assertTrue(response.getBody().contains(substring));
+   protected void assertResponseIsOkAndContains(EntityExchangeResult<String> response, String substring) {
+      assertEquals(200, response.getStatus().value());
+      assertNotNull(response.getResponseBody());
+      assertTrue(response.getResponseBody().contains(substring));
+   }
+
+   protected <T> EntityExchangeResult<T> getForEntity(String uri, Class<T> responseType) {
+      return restClient.get().uri(uri).exchange().expectBody(responseType).returnResult();
+   }
+
+   protected <T> EntityExchangeResult<T> postForEntity(String uri, Object body, Class<T> responseType) {
+      return restClient.post().uri(uri).body(body).exchange().expectBody(responseType).returnResult();
+   }
+
+   protected <T> EntityExchangeResult<T> postForEntity(String uri, HttpEntity<?> requestEntity, Class<T> responseType) {
+      return restClient.post().uri(uri).headers(headers -> headers.addAll(requestEntity.getHeaders()))
+            .body(requestEntity.getBody()).exchange().expectBody(responseType).returnResult();
+   }
+
+   protected <T> EntityExchangeResult<T> exchange(String uri, HttpMethod method, HttpEntity<?> requestEntity,
+         Class<T> responseType) {
+      return request(method, uri, requestEntity).expectBody(responseType).returnResult();
+   }
+
+   protected <T> EntityExchangeResult<T> exchange(String uri, HttpMethod method, HttpEntity<?> requestEntity,
+         ParameterizedTypeReference<T> responseType) {
+      return request(method, uri, requestEntity).expectBody(responseType).returnResult();
+   }
+
+   protected <T> EntityExchangeResult<T> getForEntityWithoutRedirects(String uri, Class<T> responseType) {
+      return noRedirectRestClient.get().uri(uri).exchange().expectBody(responseType).returnResult();
+   }
+
+   private RestTestClient.ResponseSpec request(HttpMethod method, String uri, HttpEntity<?> requestEntity) {
+      if (requestEntity == null) {
+         return restClient.method(method).uri(uri).exchange();
+      }
+      if (requestEntity.getBody() == null) {
+         return restClient.method(method).uri(uri).headers(headers -> headers.addAll(requestEntity.getHeaders()))
+               .exchange();
+      }
+      return restClient.method(method).uri(uri).headers(headers -> headers.addAll(requestEntity.getHeaders()))
+            .body(requestEntity.getBody()).exchange();
    }
 }

--- a/webapp/src/test/java/io/github/microcks/web/DynamicMockRestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/DynamicMockRestControllerIT.java
@@ -26,7 +26,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -57,8 +57,8 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
          headers.setContentType(MediaType.APPLICATION_JSON);
 
          HttpEntity<GenericResourceServiceDTO> request = new HttpEntity<>(dto, headers);
-         ResponseEntity<String> response = restTemplate.postForEntity("/api/services/generic", request, String.class);
-         assertEquals(201, response.getStatusCode().value(), "Generic REST service should be created");
+         EntityExchangeResult<String> response = postForEntity("/api/services/generic", request, String.class);
+         assertEquals(201, response.getStatus().value(), "Generic REST service should be created");
       }
    }
 
@@ -66,13 +66,13 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testCreateResource() throws Exception {
       String body = "{\"productId\": \"ABC123\", \"quantity\": 2, \"price\": 19.99}";
 
-      ResponseEntity<String> response = restTemplate.postForEntity(
+      EntityExchangeResult<String> response = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
 
-      assertEquals(201, response.getStatusCode().value());
-      assertNotNull(response.getBody());
+      assertEquals(201, response.getStatus().value());
+      assertNotNull(response.getResponseBody());
 
-      JsonNode node = mapper.readTree(response.getBody());
+      JsonNode node = mapper.readTree(response.getResponseBody());
       assertTrue(node.has("id"), "Created resource should contain an 'id' field");
       assertEquals("ABC123", node.get("productId").asText());
       assertEquals(2, node.get("quantity").asInt());
@@ -82,20 +82,20 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testCreateResourceWithInvalidJson() {
       String invalidBody = "this is not json";
 
-      ResponseEntity<String> response = restTemplate.postForEntity(
+      EntityExchangeResult<String> response = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, invalidBody, String.class);
 
-      assertEquals(422, response.getStatusCode().value());
+      assertEquals(422, response.getStatus().value());
    }
 
    @Test
    void testCreateResourceForUnknownService() {
       String body = "{\"foo\": \"bar\"}";
 
-      ResponseEntity<String> response = restTemplate
-            .postForEntity("/dynarest/UnknownService/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
+      EntityExchangeResult<String> response = postForEntity(
+            "/dynarest/UnknownService/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
 
-      assertEquals(400, response.getStatusCode().value());
+      assertEquals(400, response.getStatus().value());
    }
 
    @Test
@@ -103,19 +103,17 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       // First, create two resources.
       String body1 = "{\"productId\": \"FIND1\", \"quantity\": 1}";
       String body2 = "{\"productId\": \"FIND2\", \"quantity\": 5}";
-      restTemplate.postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body1,
-            String.class);
-      restTemplate.postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body2,
-            String.class);
+      postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body1, String.class);
+      postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body2, String.class);
 
       // Now list resources.
-      ResponseEntity<String> response = restTemplate
-            .getForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, String.class);
+      EntityExchangeResult<String> response = getForEntity(
+            "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, String.class);
 
-      assertEquals(200, response.getStatusCode().value());
-      assertNotNull(response.getBody());
+      assertEquals(200, response.getStatus().value());
+      assertNotNull(response.getResponseBody());
 
-      JsonNode array = mapper.readTree(response.getBody());
+      JsonNode array = mapper.readTree(response.getResponseBody());
       assertTrue(array.isArray(), "Response should be a JSON array");
       assertTrue(array.size() >= 2, "Should have at least 2 resources");
    }
@@ -125,19 +123,19 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       // Create a few resources for pagination.
       for (int i = 0; i < 3; i++) {
          String body = "{\"productId\": \"PAGE" + i + "\"}";
-         restTemplate.postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body,
+         postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body,
                String.class);
       }
 
       // Request with small page size.
-      ResponseEntity<String> response = restTemplate.getForEntity(
+      EntityExchangeResult<String> response = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "?page=0&size=2",
             String.class);
 
-      assertEquals(200, response.getStatusCode().value());
-      assertNotNull(response.getBody());
+      assertEquals(200, response.getStatus().value());
+      assertNotNull(response.getResponseBody());
 
-      JsonNode array = mapper.readTree(response.getBody());
+      JsonNode array = mapper.readTree(response.getResponseBody());
       assertTrue(array.isArray());
       assertTrue(array.size() <= 2, "Page size should be respected");
    }
@@ -146,22 +144,22 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testGetResourceById() throws Exception {
       // Create a resource first.
       String body = "{\"productId\": \"GET1\", \"quantity\": 10}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      EntityExchangeResult<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
-      assertEquals(201, createResponse.getStatusCode().value());
+      assertEquals(201, createResponse.getStatus().value());
 
-      JsonNode created = mapper.readTree(createResponse.getBody());
+      JsonNode created = mapper.readTree(createResponse.getResponseBody());
       String resourceId = created.get("id").asText();
 
       // Now get the resource by id.
-      ResponseEntity<String> response = restTemplate.getForEntity(
+      EntityExchangeResult<String> response = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
 
-      assertEquals(200, response.getStatusCode().value());
-      assertNotNull(response.getBody());
+      assertEquals(200, response.getStatus().value());
+      assertNotNull(response.getResponseBody());
 
-      JsonNode node = mapper.readTree(response.getBody());
+      JsonNode node = mapper.readTree(response.getResponseBody());
       assertEquals("GET1", node.get("productId").asText());
       assertEquals(10, node.get("quantity").asInt());
       assertEquals(resourceId, node.get("id").asText());
@@ -169,22 +167,22 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
 
    @Test
    void testGetResourceByIdNotFound() {
-      ResponseEntity<String> response = restTemplate.getForEntity(
+      EntityExchangeResult<String> response = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/nonexistent-id-12345",
             String.class);
 
-      assertEquals(404, response.getStatusCode().value());
+      assertEquals(404, response.getStatus().value());
    }
 
    @Test
    void testUpdateResource() throws Exception {
       // Create a resource.
       String body = "{\"productId\": \"UPD1\", \"quantity\": 3}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      EntityExchangeResult<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
-      assertEquals(201, createResponse.getStatusCode().value());
+      assertEquals(201, createResponse.getStatus().value());
 
-      JsonNode created = mapper.readTree(createResponse.getBody());
+      JsonNode created = mapper.readTree(createResponse.getResponseBody());
       String resourceId = created.get("id").asText();
 
       // Update the resource.
@@ -193,22 +191,22 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> requestEntity = new HttpEntity<>(updatedBody, headers);
 
-      ResponseEntity<String> response = restTemplate.exchange(
+      EntityExchangeResult<String> response = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.PUT, requestEntity, String.class);
 
-      assertEquals(200, response.getStatusCode().value());
-      assertNotNull(response.getBody());
+      assertEquals(200, response.getStatus().value());
+      assertNotNull(response.getResponseBody());
 
-      JsonNode node = mapper.readTree(response.getBody());
+      JsonNode node = mapper.readTree(response.getResponseBody());
       assertEquals(42, node.get("quantity").asInt());
 
       // Verify the update by retrieving the resource.
-      ResponseEntity<String> getResponse = restTemplate.getForEntity(
+      EntityExchangeResult<String> getResponse = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
-      assertEquals(200, getResponse.getStatusCode().value());
-      JsonNode retrieved = mapper.readTree(getResponse.getBody());
+      assertEquals(200, getResponse.getStatus().value());
+      JsonNode retrieved = mapper.readTree(getResponse.getResponseBody());
       assertEquals(42, retrieved.get("quantity").asInt());
    }
 
@@ -216,11 +214,11 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testUpdateResourceWithInvalidJson() throws Exception {
       // Create a resource first.
       String body = "{\"productId\": \"UPD_INV\", \"quantity\": 1}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      EntityExchangeResult<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
-      assertEquals(201, createResponse.getStatusCode().value());
+      assertEquals(201, createResponse.getStatus().value());
 
-      JsonNode created = mapper.readTree(createResponse.getBody());
+      JsonNode created = mapper.readTree(createResponse.getResponseBody());
       String resourceId = created.get("id").asText();
 
       // Try to update with invalid JSON.
@@ -228,11 +226,11 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> requestEntity = new HttpEntity<>("this is not json", headers);
 
-      ResponseEntity<String> response = restTemplate.exchange(
+      EntityExchangeResult<String> response = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.PUT, requestEntity, String.class);
 
-      assertEquals(422, response.getStatusCode().value());
+      assertEquals(422, response.getStatus().value());
    }
 
    @Test
@@ -242,64 +240,64 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> requestEntity = new HttpEntity<>(updatedBody, headers);
 
-      ResponseEntity<String> response = restTemplate.exchange(
+      EntityExchangeResult<String> response = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/nonexistent-id-12345",
             HttpMethod.PUT, requestEntity, String.class);
 
-      assertEquals(404, response.getStatusCode().value());
+      assertEquals(404, response.getStatus().value());
    }
 
    @Test
    void testDeleteResource() throws Exception {
       // Create a resource.
       String body = "{\"productId\": \"DEL1\", \"quantity\": 7}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      EntityExchangeResult<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
-      assertEquals(201, createResponse.getStatusCode().value());
+      assertEquals(201, createResponse.getStatus().value());
 
-      JsonNode created = mapper.readTree(createResponse.getBody());
+      JsonNode created = mapper.readTree(createResponse.getResponseBody());
       String resourceId = created.get("id").asText();
 
       // Delete the resource.
-      ResponseEntity<String> response = restTemplate.exchange(
+      EntityExchangeResult<String> response = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.DELETE, null, String.class);
 
-      assertEquals(204, response.getStatusCode().value());
+      assertEquals(204, response.getStatus().value());
 
       // Verify it's deleted.
-      ResponseEntity<String> getResponse = restTemplate.getForEntity(
+      EntityExchangeResult<String> getResponse = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
-      assertEquals(404, getResponse.getStatusCode().value());
+      assertEquals(404, getResponse.getStatus().value());
    }
 
    @Test
    void testDeleteResourceForUnknownService() {
-      ResponseEntity<String> response = restTemplate.exchange(
+      EntityExchangeResult<String> response = exchange(
             "/dynarest/UnknownService/" + SERVICE_VERSION + "/" + RESOURCE + "/some-id", HttpMethod.DELETE, null,
             String.class);
 
-      assertEquals(400, response.getStatusCode().value());
+      assertEquals(400, response.getStatus().value());
    }
 
    @Test
    void testFullCrudLifecycle() throws Exception {
       // CREATE
       String body = "{\"name\": \"Widget\", \"status\": \"new\"}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      EntityExchangeResult<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
-      assertEquals(201, createResponse.getStatusCode().value());
-      JsonNode created = mapper.readTree(createResponse.getBody());
+      assertEquals(201, createResponse.getStatus().value());
+      JsonNode created = mapper.readTree(createResponse.getResponseBody());
       String resourceId = created.get("id").asText();
       assertNotNull(resourceId);
 
       // READ
-      ResponseEntity<String> getResponse = restTemplate.getForEntity(
+      EntityExchangeResult<String> getResponse = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
-      assertEquals(200, getResponse.getStatusCode().value());
-      JsonNode retrieved = mapper.readTree(getResponse.getBody());
+      assertEquals(200, getResponse.getStatus().value());
+      JsonNode retrieved = mapper.readTree(getResponse.getResponseBody());
       assertEquals("Widget", retrieved.get("name").asText());
       assertEquals("new", retrieved.get("status").asText());
 
@@ -309,32 +307,32 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> updateEntity = new HttpEntity<>(updatedBody, headers);
 
-      ResponseEntity<String> updateResponse = restTemplate.exchange(
+      EntityExchangeResult<String> updateResponse = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.PUT, updateEntity, String.class);
-      assertEquals(200, updateResponse.getStatusCode().value());
-      JsonNode updated = mapper.readTree(updateResponse.getBody());
+      assertEquals(200, updateResponse.getStatus().value());
+      JsonNode updated = mapper.readTree(updateResponse.getResponseBody());
       assertEquals("shipped", updated.get("status").asText());
 
       // LIST - should contain the resource
-      ResponseEntity<String> listResponse = restTemplate
-            .getForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, String.class);
-      assertEquals(200, listResponse.getStatusCode().value());
-      JsonNode list = mapper.readTree(listResponse.getBody());
+      EntityExchangeResult<String> listResponse = getForEntity(
+            "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, String.class);
+      assertEquals(200, listResponse.getStatus().value());
+      JsonNode list = mapper.readTree(listResponse.getResponseBody());
       assertTrue(list.isArray());
       assertFalse(list.isEmpty());
 
       // DELETE
-      ResponseEntity<String> deleteResponse = restTemplate.exchange(
+      EntityExchangeResult<String> deleteResponse = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.DELETE, null, String.class);
-      assertEquals(204, deleteResponse.getStatusCode().value());
+      assertEquals(204, deleteResponse.getStatus().value());
 
       // VERIFY DELETED
-      ResponseEntity<String> deletedGetResponse = restTemplate.getForEntity(
+      EntityExchangeResult<String> deletedGetResponse = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
-      assertEquals(404, deletedGetResponse.getStatusCode().value());
+      assertEquals(404, deletedGetResponse.getStatus().value());
    }
 
    @Test
@@ -343,12 +341,12 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       long delay = 200L;
 
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate.postForEntity(
+      EntityExchangeResult<String> response = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "?delay=" + delay, body,
             String.class);
       long elapsed = System.currentTimeMillis() - startTime;
 
-      assertEquals(201, response.getStatusCode().value());
+      assertEquals(201, response.getStatus().value());
       assertTrue(elapsed >= delay, "Response should be delayed by at least " + delay + "ms, was " + elapsed + "ms");
    }
 
@@ -356,11 +354,11 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testServiceNameWithEncodedSpaces() {
       // The service name contains spaces, test with '+' encoding.
       String body = "{\"productId\": \"ENC1\"}";
-      ResponseEntity<String> response = restTemplate
-            .postForEntity("/dynarest/DynaMock+API/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
+      EntityExchangeResult<String> response = postForEntity(
+            "/dynarest/DynaMock+API/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
 
-      assertEquals(201, response.getStatusCode().value());
-      assertNotNull(response.getBody());
+      assertEquals(201, response.getStatus().value());
+      assertNotNull(response.getResponseBody());
    }
 
    /** Encode service name for URL path (spaces as +). */

--- a/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
@@ -24,7 +24,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.RegularExpressionValueMatcher;
 import org.skyscreamer.jsonassert.comparator.CustomComparator;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -45,8 +45,8 @@ class GraphQLControllerIT extends AbstractBaseIT {
       // Check its different mocked operations.
       String query = "{\"query\": \"query allFilms {\\n" + "  allFilms {\\n" + "    films {\\n" + "      id\\n"
             + "      title\\n" + "    }\\n" + "  }\\n" + "}\"}";
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      EntityExchangeResult<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
       try {
          JSONAssert.assertEquals("{\n" + "  \"data\": {\n" + "    \"allFilms\": {\n" + "      \"films\": [\n"
                + "        {\n" + "          \"id\": \"ZmlsbXM6MQ==\",\n" + "          \"title\": \"A New Hope\"\n"
@@ -58,7 +58,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
                + "          \"id\": \"ZmlsbXM6NQ==\",\n" + "          \"title\": \"Attack of the Clones\"\n"
                + "        },\n" + "        {\n" + "          \"id\": \"ZmlsbXM6Ng==\",\n"
                + "          \"title\": \"Revenge of the Sith\"\n" + "        }\n" + "      ]\n" + "    }\n" + "  }\n"
-               + "}", response.getBody(), JSONCompareMode.LENIENT);
+               + "}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -66,12 +66,12 @@ class GraphQLControllerIT extends AbstractBaseIT {
       // Check query with inlined argument.
       query = "{\"query\": \"query film($id: String) {\\n" + "  film(id: \\\"ZmlsbXM6MQ==\\\") {\\n" + "    id\\n"
             + "    title\\n" + "    episodeID\\n" + "    starCount\\n" + "  }\\n" + "}\"}";
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
       try {
          JSONAssert.assertEquals("{\n" + "  \"data\": {\n" + "    \"film\": {\n" + "      \"id\": \"ZmlsbXM6MQ==\",\n"
                + "      \"title\": \"A New Hope\",\n" + "      \"episodeID\": 4,\n" + "      \"starCount\": 432\n"
-               + "    }\n" + "  }\n" + "}", response.getBody(), JSONCompareMode.LENIENT);
+               + "    }\n" + "  }\n" + "}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -80,12 +80,12 @@ class GraphQLControllerIT extends AbstractBaseIT {
       query = "{\"query\": \"query film($id: String) {\\n" + "  film(id: $id) {\\n" + "    id\\n" + "    title\\n"
             + "    episodeID\\n" + "    starCount\\n" + "  }\\n" + "}\", \"variables\": {\"id\": \"ZmlsbXM6MQ==\"}"
             + "}";
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
       try {
          JSONAssert.assertEquals("{\n" + "  \"data\": {\n" + "    \"film\": {\n" + "      \"id\": \"ZmlsbXM6MQ==\",\n"
                + "      \"title\": \"A New Hope\",\n" + "      \"episodeID\": 4,\n" + "      \"starCount\": 432\n"
-               + "    }\n" + "  }\n" + "}", response.getBody(), JSONCompareMode.LENIENT);
+               + "    }\n" + "  }\n" + "}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -94,12 +94,12 @@ class GraphQLControllerIT extends AbstractBaseIT {
       query = "{\"query\": \"query film($id: String) {\\n" + "  film(id: \\\"ZmlsbXM6MQ==\\\") {\\n"
             + "    ...filmFields\\n" + "  }\\n" + "  }\\n" + "  fragment filmFields on Film {\\n" + "    id\\n"
             + "    title\\n" + "    episodeID\\n" + "    starCount\\n" + "  }\\n" + "\"}";
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
       try {
          JSONAssert.assertEquals("{\n" + "  \"data\": {\n" + "    \"film\": {\n" + "      \"id\": \"ZmlsbXM6MQ==\",\n"
                + "      \"title\": \"A New Hope\",\n" + "      \"episodeID\": 4,\n" + "      \"starCount\": 432\n"
-               + "    }\n" + "  }\n" + "}", response.getBody(), JSONCompareMode.LENIENT);
+               + "    }\n" + "  }\n" + "}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -109,15 +109,18 @@ class GraphQLControllerIT extends AbstractBaseIT {
             + "    episodeID\\n" + "    rating\\n" + "  }\\n" + "  film_two: film(id: \\\"ZmlsbXM6Mg==\\\") {\\n"
             + "    id\\n" + "    title\\n" + "    episodeID\\n" + "    director\\n" + "    starCount\\n" + "  }\\n"
             + "}\"}";
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\n" + "  \"data\": {\n" + "    \"film_one\": {\n"
-               + "      \"id\": \"ZmlsbXM6MQ==\",\n" + "      \"title\": \"A New Hope\",\n"
-               + "      \"episodeID\": 4,\n" + "      \"rating\": 4.3\n" + "    },\n" + "    \"film_two\": {\n"
-               + "      \"id\": \"ZmlsbXM6Mg==\",\n" + "      \"title\": \"The Empire Strikes Back\",\n"
-               + "      \"episodeID\": 5,\n" + "      \"director\": \"Irvin Kershner\",\n"
-               + "      \"starCount\": 433\n" + "    }\n" + "  }\n" + "}", response.getBody(), JSONCompareMode.LENIENT);
+         JSONAssert
+               .assertEquals(
+                     "{\n" + "  \"data\": {\n" + "    \"film_one\": {\n" + "      \"id\": \"ZmlsbXM6MQ==\",\n"
+                           + "      \"title\": \"A New Hope\",\n" + "      \"episodeID\": 4,\n"
+                           + "      \"rating\": 4.3\n" + "    },\n" + "    \"film_two\": {\n"
+                           + "      \"id\": \"ZmlsbXM6Mg==\",\n" + "      \"title\": \"The Empire Strikes Back\",\n"
+                           + "      \"episodeID\": 5,\n" + "      \"director\": \"Irvin Kershner\",\n"
+                           + "      \"starCount\": 433\n" + "    }\n" + "  }\n" + "}",
+                     response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -126,8 +129,8 @@ class GraphQLControllerIT extends AbstractBaseIT {
       query = "{\"query\": \"{\\n" + "  film(id: \\\"ZmlsbXM6MQ==\\\") {\\n" + "    id\\n" + "    title\\n"
             + "    episodeID\\n" + "    rating\\n" + "  }\\n" + "  allFilms {\\n" + "    films {\\n" + "      id\\n"
             + "      title\\n" + "    }\\n" + "  }\\n" + "}\"}";
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
       try {
          JSONAssert.assertEquals("{\n" + "  \"data\": {\n" + "    \"film\": {\n" + "      \"id\": \"ZmlsbXM6MQ==\",\n"
                + "      \"title\": \"A New Hope\",\n" + "      \"episodeID\": 4,\n" + "      \"rating\": 4.3\n"
@@ -141,7 +144,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
                + "          \"id\": \"ZmlsbXM6NQ==\",\n" + "          \"title\": \"Attack of the Clones\"\n"
                + "        },\n" + "        {\n" + "          \"id\": \"ZmlsbXM6Ng==\",\n"
                + "          \"title\": \"Revenge of the Sith\"\n" + "        }\n" + "      ]\n" + "    }\n" + "  }\n"
-               + "}", response.getBody(), JSONCompareMode.LENIENT);
+               + "}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -149,14 +152,14 @@ class GraphQLControllerIT extends AbstractBaseIT {
       // Check query with __typename and inlined argument.
       query = "{\"query\": \"query film($id: String) {\\n" + "  __typename\\n  film(id: \\\"ZmlsbXM6MQ==\\\") {\\n"
             + "    id\\n" + "    title\\n" + "    episodeID\\n" + "    starCount\\n" + "  }\\n" + "}\"}";
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
       try {
          JSONAssert.assertEquals(
                "{\n" + "  \"data\": {\n" + "  \"__typename\":\"Query\", \"film\": {\n"
                      + "      \"id\": \"ZmlsbXM6MQ==\",\n" + "      \"title\": \"A New Hope\",\n"
                      + "      \"episodeID\": 4,\n" + "      \"starCount\": 432\n" + "    }\n" + "  }\n" + "}",
-               response.getBody(), JSONCompareMode.LENIENT);
+               response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -171,19 +174,19 @@ class GraphQLControllerIT extends AbstractBaseIT {
             + "    id\\n" + "    title\\n" + "    episodeID\\n" + "    director\\n" + "    starCount\\n"
             + "    rating\\n" + "  }\\n" + "}\", \"variables\": {\"filmId\": \"notavailable\"}" + "}";
 
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertNotNull(response.getBody(), "Response body should not be null");
-      assertTrue(response.getBody().contains("\"errors\""));
-      assertTrue(response.getBody().contains("\"extensions\""));
+      EntityExchangeResult<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertNotNull(response.getResponseBody(), "Response body should not be null");
+      assertTrue(response.getResponseBody().contains("\"errors\""));
+      assertTrue(response.getResponseBody().contains("\"extensions\""));
       try {
          JSONAssert.assertEquals("{\n" + "  \"errors\": [\n" + "    {\n"
                + "      \"message\": \"The system is not available, due to maintenance, please try again later.\",\n"
                + "      \"extensions\": {\n" + "        \"code\": \"MAINTENANCE_MODE\"\n" + "      }\n" + "    }\n"
                + "  ],\n" + "  \"data\": {\n" + "    \"addStar\": null\n" + "  },\n" + "  \"extensions\": {\n"
                + "    \"correlationId\": {\n" + "      \"traceId\": \"123e4567-e89b-12d3-a456-426614174000\"\n"
-               + "    }\n" + "  }\n" + "}", response.getBody(),
+               + "    }\n" + "  }\n" + "}", response.getResponseBody(),
                new CustomComparator(JSONCompareMode.LENIENT,
                      new Customization("extensions.correlationId.traceId", new RegularExpressionValueMatcher<>(
                            "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"))));
@@ -212,7 +215,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
       // Execute and assert that it was proxy.
       String query = """
             {"query": "query film($id: String) {film(id: \\"ZmlsbXM6Mg==\\") {id title episodeID starCount comment}}"}""";
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      EntityExchangeResult<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertResponseIsOkAndContains(response, "\"comment\":\"Original!!!\"");
    }
 
@@ -239,15 +242,15 @@ class GraphQLControllerIT extends AbstractBaseIT {
       // Execute and assert that it wasn't proxy.
       String query = """
             {"query": "query film($id: String) {film(id: \\"ZmlsbXM6Mg==\\") {id title episodeID starCount comment}}"}""";
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
-      assertEquals(200, response.getStatusCode().value());
-      assertNotNull(response.getBody());
-      assertFalse(response.getBody().contains("\"comment\":\"Original!!!\""));
+      EntityExchangeResult<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatus().value());
+      assertNotNull(response.getResponseBody());
+      assertFalse(response.getResponseBody().contains("\"comment\":\"Original!!!\""));
 
       // Execute and assert that it was proxy.
       query = """
             {"query": "query film($id: String) {film(id: \\"ZmlsbXM6MA==\\") {id title episodeID starCount comment}}"}""";
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertResponseIsOkAndContains(response, "\"comment\":\"Original!!!\"");
    }
 }

--- a/webapp/src/test/java/io/github/microcks/web/McpControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/McpControllerIT.java
@@ -24,7 +24,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.BufferedReader;
@@ -70,172 +70,8 @@ class McpControllerIT extends AbstractBaseIT {
       // Define the runnable for the SSE client.
       Runnable sseClientRunnable = () -> {
          try {
-            restTemplate.execute("/mcp/Petstore+API/1.0.0/sse", HttpMethod.GET, request -> {}, response -> {
-               String line;
-               try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody()));) {
-                  while ((line = bufferedReader.readLine()) != null) {
-                     parseAndStoreMcpSseFrame(line, sseFrames);
-                  }
-               } catch (IOException e) {
-                  System.err.println("Caught exception while reading SSE response: " + e.getMessage());
-               }
-               return response;
-            });
-         } catch (Exception e) {
-            System.err.println("Caught exception while executing SSE client: " + e.getMessage());
-         }
-      };
-      sseClientExecutor.execute(sseClientRunnable);
-
-      // SSE emitter is async so wait a few millis before checking.
-      Thread.sleep(250);
-
-      // Check we got 3 frames and that we're able to extract the message endpoint.
-      assertEquals(3, sseFrames.size());
-
-      String messageEndpoint = null;
-      for (McpSSEFrame frame : sseFrames) {
-         if (frame.key().equals("event")) {
-            assertEquals("endpoint", frame.value());
-         } else if (frame.key().equals("data")) {
-            messageEndpoint = frame.value();
-         } else if (frame.key().equals("id")) {
-            // Got and id frame, ignore it.
-         } else {
-            fail("Unknown SSE frame: " + frame.key());
-         }
-      }
-      assertNotNull(messageEndpoint);
-
-      // Now clear the frames and send an initialize request to the message endpoint.
-      sseFrames.clear();
-      String initializeRequest = """
-            {
-               "jsonrpc": "2.0",
-               "method": "initialize",
-               "params": {
-                  "protocolVersion": "2024-11-05",
-                  "capabilities": {},
-                  "clientInfo": {
-                     "name": "test-client",
-                     "version": "1.0.0"
-                  }
-               }
-            }
-            """;
-
-      HttpHeaders headers = new HttpHeaders();
-      headers.setContentType(MediaType.APPLICATION_JSON);
-      headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
-
-      ResponseEntity<String> response = restTemplate.postForEntity(messageEndpoint,
-            new HttpEntity<>(initializeRequest, headers), String.class);
-
-      // SSE emitter is async so wait a few millis before checking.
-      Thread.sleep(200);
-
-      // Check we got 3 frames and that we're able to extract the message endpoint.
-      assertEquals(3, sseFrames.size());
-
-      for (McpSSEFrame frame : sseFrames) {
-         if (frame.key().equals("event")) {
-            assertEquals("message", frame.value());
-         } else if (frame.key().equals("data")) {
-            McpSchema.JSONRPCResponse rpcResponse = mapper.readValue(frame.value(), McpSchema.JSONRPCResponse.class);
-            McpSchema.InitializeResult result = mapper.convertValue(rpcResponse.result(),
-                  McpSchema.InitializeResult.class);
-            assertEquals("Petstore API MCP server", result.serverInfo().name());
-            assertEquals("1.0.0", result.serverInfo().version());
-         } else if (frame.key().equals("id")) {
-            // Got and id frame, ignore it.
-         } else {
-            fail("Unknown SSE frame: " + frame.key());
-         }
-      }
-
-      // Now clear the frames and send a tools/list request to the message endpoint.
-      sseFrames.clear();
-      String toolsListRequest = """
-            {
-               "jsonrpc": "2.0",
-               "method": "tools/list"
-            }
-            """;
-
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
-
-      // SSE emitter is async so wait a few millis before checking.
-      Thread.sleep(200);
-
-      // Check we got 3 frames and that we're able to extract the message endpoint.
-      assertEquals(3, sseFrames.size());
-
-      for (McpSSEFrame frame : sseFrames) {
-         if (frame.key().equals("event")) {
-            assertEquals("message", frame.value());
-         } else if (frame.key().equals("data")) {
-            McpSchema.JSONRPCResponse rpcResponse = mapper.readValue(frame.value(), McpSchema.JSONRPCResponse.class);
-            McpSchema.ListToolsResult result = mapper.convertValue(rpcResponse.result(),
-                  McpSchema.ListToolsResult.class);
-            assertEquals(4, result.tools().size());
-         } else if (frame.key().equals("id")) {
-            // Got and id frame, ignore it.
-         } else {
-            fail("Unknown SSE frame: " + frame.key());
-         }
-      }
-
-      // Now clear the frames and finallu send a tools/call request to the message endpoint.
-      sseFrames.clear();
-      String toolsCallRequest = """
-            {
-               "jsonrpc": "2.0",
-               "method": "tools/call",
-               "params": {
-                  "name": "get_pets_id",
-                  "arguments": {
-                     "id": "2"
-                  }
-               }
-            }
-            """;
-
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
-
-      // SSE emitter is async so wait a few millis before checking.
-      Thread.sleep(200);
-
-      // Check we got 3 frames and that we're able to extract the message endpoint.
-      assertEquals(3, sseFrames.size());
-
-      for (McpSSEFrame frame : sseFrames) {
-         if (frame.key().equals("event")) {
-            assertEquals("message", frame.value());
-         } else if (frame.key().equals("data")) {
-            McpSchema.JSONRPCResponse rpcResponse = mapper.readValue(frame.value(), McpSchema.JSONRPCResponse.class);
-            McpSchema.CallToolResult result = mapper.convertValue(rpcResponse.result(), McpSchema.CallToolResult.class);
-            assertTrue(result.content().getFirst() instanceof McpSchema.TextContent);
-            McpSchema.TextContent content = (McpSchema.TextContent) result.content().getFirst();
-            assertEquals("{\"id\":2,\"name\":\"Tigresse\"}", content.text());
-         } else if (frame.key().equals("id")) {
-            // Got and id frame, ignore it.
-         } else {
-            fail("Unknown SSE frame: " + frame.key());
-         }
-      }
-   }
-
-   @Test
-   void testGrpcHttpSSEEndpoint() throws Exception {
-      // Update Petstore from the tutorial reference artifact.
-      uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/petstore-v1.proto", true);
-      uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/petstore-v1-examples.yaml", false);
-
-      // Define the runnable for the SSE client.
-      Runnable sseClientRunnable = () -> {
-         try {
-            restTemplate.execute("/mcp/org.acme.petstore.v1.PetstoreService/v1/sse", HttpMethod.GET, request -> {},
-                  response -> {
+            streamingRestClient.get().uri("/mcp/Petstore+API/1.0.0/sse").accept(MediaType.TEXT_EVENT_STREAM)
+                  .exchange((request, response) -> {
                      String line;
                      try (BufferedReader bufferedReader = new BufferedReader(
                            new InputStreamReader(response.getBody()));) {
@@ -245,7 +81,7 @@ class McpControllerIT extends AbstractBaseIT {
                      } catch (IOException e) {
                         System.err.println("Caught exception while reading SSE response: " + e.getMessage());
                      }
-                     return response;
+                     return null;
                   });
          } catch (Exception e) {
             System.err.println("Caught exception while executing SSE client: " + e.getMessage());
@@ -294,7 +130,173 @@ class McpControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
 
-      ResponseEntity<String> response = restTemplate.postForEntity(messageEndpoint,
+      EntityExchangeResult<String> response = postForEntity(messageEndpoint,
+            new HttpEntity<>(initializeRequest, headers), String.class);
+
+      // SSE emitter is async so wait a few millis before checking.
+      Thread.sleep(200);
+
+      // Check we got 3 frames and that we're able to extract the message endpoint.
+      assertEquals(3, sseFrames.size());
+
+      for (McpSSEFrame frame : sseFrames) {
+         if (frame.key().equals("event")) {
+            assertEquals("message", frame.value());
+         } else if (frame.key().equals("data")) {
+            McpSchema.JSONRPCResponse rpcResponse = mapper.readValue(frame.value(), McpSchema.JSONRPCResponse.class);
+            McpSchema.InitializeResult result = mapper.convertValue(rpcResponse.result(),
+                  McpSchema.InitializeResult.class);
+            assertEquals("Petstore API MCP server", result.serverInfo().name());
+            assertEquals("1.0.0", result.serverInfo().version());
+         } else if (frame.key().equals("id")) {
+            // Got and id frame, ignore it.
+         } else {
+            fail("Unknown SSE frame: " + frame.key());
+         }
+      }
+
+      // Now clear the frames and send a tools/list request to the message endpoint.
+      sseFrames.clear();
+      String toolsListRequest = """
+            {
+               "jsonrpc": "2.0",
+               "method": "tools/list"
+            }
+            """;
+
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
+
+      // SSE emitter is async so wait a few millis before checking.
+      Thread.sleep(200);
+
+      // Check we got 3 frames and that we're able to extract the message endpoint.
+      assertEquals(3, sseFrames.size());
+
+      for (McpSSEFrame frame : sseFrames) {
+         if (frame.key().equals("event")) {
+            assertEquals("message", frame.value());
+         } else if (frame.key().equals("data")) {
+            McpSchema.JSONRPCResponse rpcResponse = mapper.readValue(frame.value(), McpSchema.JSONRPCResponse.class);
+            McpSchema.ListToolsResult result = mapper.convertValue(rpcResponse.result(),
+                  McpSchema.ListToolsResult.class);
+            assertEquals(4, result.tools().size());
+         } else if (frame.key().equals("id")) {
+            // Got and id frame, ignore it.
+         } else {
+            fail("Unknown SSE frame: " + frame.key());
+         }
+      }
+
+      // Now clear the frames and finallu send a tools/call request to the message endpoint.
+      sseFrames.clear();
+      String toolsCallRequest = """
+            {
+               "jsonrpc": "2.0",
+               "method": "tools/call",
+               "params": {
+                  "name": "get_pets_id",
+                  "arguments": {
+                     "id": "2"
+                  }
+               }
+            }
+            """;
+
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
+
+      // SSE emitter is async so wait a few millis before checking.
+      Thread.sleep(200);
+
+      // Check we got 3 frames and that we're able to extract the message endpoint.
+      assertEquals(3, sseFrames.size());
+
+      for (McpSSEFrame frame : sseFrames) {
+         if (frame.key().equals("event")) {
+            assertEquals("message", frame.value());
+         } else if (frame.key().equals("data")) {
+            McpSchema.JSONRPCResponse rpcResponse = mapper.readValue(frame.value(), McpSchema.JSONRPCResponse.class);
+            McpSchema.CallToolResult result = mapper.convertValue(rpcResponse.result(), McpSchema.CallToolResult.class);
+            assertTrue(result.content().getFirst() instanceof McpSchema.TextContent);
+            McpSchema.TextContent content = (McpSchema.TextContent) result.content().getFirst();
+            assertEquals("{\"id\":2,\"name\":\"Tigresse\"}", content.text());
+         } else if (frame.key().equals("id")) {
+            // Got and id frame, ignore it.
+         } else {
+            fail("Unknown SSE frame: " + frame.key());
+         }
+      }
+   }
+
+   @Test
+   void testGrpcHttpSSEEndpoint() throws Exception {
+      // Update Petstore from the tutorial reference artifact.
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/petstore-v1.proto", true);
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/grpc/petstore-v1-examples.yaml", false);
+
+      // Define the runnable for the SSE client.
+      Runnable sseClientRunnable = () -> {
+         try {
+            streamingRestClient.get().uri("/mcp/org.acme.petstore.v1.PetstoreService/v1/sse")
+                  .accept(MediaType.TEXT_EVENT_STREAM).exchange((request, response) -> {
+                     String line;
+                     try (BufferedReader bufferedReader = new BufferedReader(
+                           new InputStreamReader(response.getBody()));) {
+                        while ((line = bufferedReader.readLine()) != null) {
+                           parseAndStoreMcpSseFrame(line, sseFrames);
+                        }
+                     } catch (IOException e) {
+                        System.err.println("Caught exception while reading SSE response: " + e.getMessage());
+                     }
+                     return null;
+                  });
+         } catch (Exception e) {
+            System.err.println("Caught exception while executing SSE client: " + e.getMessage());
+         }
+      };
+      sseClientExecutor.execute(sseClientRunnable);
+
+      // SSE emitter is async so wait a few millis before checking.
+      Thread.sleep(250);
+
+      // Check we got 3 frames and that we're able to extract the message endpoint.
+      assertEquals(3, sseFrames.size());
+
+      String messageEndpoint = null;
+      for (McpSSEFrame frame : sseFrames) {
+         if (frame.key().equals("event")) {
+            assertEquals("endpoint", frame.value());
+         } else if (frame.key().equals("data")) {
+            messageEndpoint = frame.value();
+         } else if (frame.key().equals("id")) {
+            // Got and id frame, ignore it.
+         } else {
+            fail("Unknown SSE frame: " + frame.key());
+         }
+      }
+      assertNotNull(messageEndpoint);
+
+      // Now clear the frames and send an initialize request to the message endpoint.
+      sseFrames.clear();
+      String initializeRequest = """
+            {
+               "jsonrpc": "2.0",
+               "method": "initialize",
+               "params": {
+                  "protocolVersion": "2024-11-05",
+                  "capabilities": {},
+                  "clientInfo": {
+                     "name": "test-client",
+                     "version": "1.0.0"
+                  }
+               }
+            }
+            """;
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
+
+      EntityExchangeResult<String> response = postForEntity(messageEndpoint,
             new HttpEntity<>(initializeRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
@@ -328,7 +330,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -366,7 +368,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -402,17 +404,19 @@ class McpControllerIT extends AbstractBaseIT {
       // Define the runnable for the SSE client.
       Runnable sseClientRunnable = () -> {
          try {
-            restTemplate.execute("/mcp/Petstore+Graph+API/1.0/sse", HttpMethod.GET, request -> {}, response -> {
-               String line;
-               try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody()));) {
-                  while ((line = bufferedReader.readLine()) != null) {
-                     parseAndStoreMcpSseFrame(line, sseFrames);
-                  }
-               } catch (IOException e) {
-                  System.err.println("Caught exception while reading SSE response: " + e.getMessage());
-               }
-               return response;
-            });
+            streamingRestClient.get().uri("/mcp/Petstore+Graph+API/1.0/sse").accept(MediaType.TEXT_EVENT_STREAM)
+                  .exchange((request, response) -> {
+                     String line;
+                     try (BufferedReader bufferedReader = new BufferedReader(
+                           new InputStreamReader(response.getBody()));) {
+                        while ((line = bufferedReader.readLine()) != null) {
+                           parseAndStoreMcpSseFrame(line, sseFrames);
+                        }
+                     } catch (IOException e) {
+                        System.err.println("Caught exception while reading SSE response: " + e.getMessage());
+                     }
+                     return null;
+                  });
          } catch (Exception e) {
             System.err.println("Caught exception while executing SSE client: " + e.getMessage());
          }
@@ -460,7 +464,7 @@ class McpControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
 
-      ResponseEntity<String> response = restTemplate.postForEntity(messageEndpoint,
+      EntityExchangeResult<String> response = postForEntity(messageEndpoint,
             new HttpEntity<>(initializeRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
@@ -491,7 +495,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -532,7 +536,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);

--- a/webapp/src/test/java/io/github/microcks/web/RestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/RestControllerIT.java
@@ -24,13 +24,12 @@ import io.github.microcks.domain.Service;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.comparator.ArraySizeComparator;
-import org.springframework.boot.http.client.HttpRedirects;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
 
 import java.util.List;
 import java.util.UUID;
@@ -56,21 +55,21 @@ class RestControllerIT extends AbstractBaseIT {
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/petstore-openapi.json", true);
 
       // Check its different mocked operations.
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/PetStore+API/1.0.0/pets", String.class);
-      assertEquals(200, response.getStatusCode().value());
+      EntityExchangeResult<String> response = getForEntity("/rest/PetStore+API/1.0.0/pets", String.class);
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("[4]", response.getBody(), new ArraySizeComparator(JSONCompareMode.LENIENT));
+         JSONAssert.assertEquals("[4]", response.getResponseBody(), new ArraySizeComparator(JSONCompareMode.LENIENT));
          JSONAssert.assertEquals(
                "[{\"id\":1,\"name\":\"Zaza\",\"tag\":\"cat\"},{\"id\":2,\"name\":\"Tigresse\",\"tag\":\"cat\"},{\"id\":3,\"name\":\"Maki\",\"tag\":\"cat\"},{\"id\":4,\"name\":\"Toufik\",\"tag\":\"cat\"}]",
-               response.getBody(), JSONCompareMode.LENIENT);
+               response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
 
-      response = restTemplate.getForEntity("/rest/PetStore+API/1.0.0/pets/1", String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = getForEntity("/rest/PetStore+API/1.0.0/pets/1", String.class);
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\"id\":1,\"name\":\"Zaza\",\"tag\":\"cat\"}", response.getBody(),
+         JSONAssert.assertEquals("{\"id\":1,\"name\":\"Zaza\",\"tag\":\"cat\"}", response.getResponseBody(),
                JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
@@ -89,13 +88,13 @@ class RestControllerIT extends AbstractBaseIT {
       // Check its validation endpoint with correct payload
       String patchedPastry = "{\"price\":2.6}";
       HttpEntity<String> requestEntity = new HttpEntity<>(patchedPastry, headers);
-      ResponseEntity<String> response = restTemplate.exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe",
+      EntityExchangeResult<String> response = exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe",
             HttpMethod.PATCH, requestEntity, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
       try {
          JSONAssert.assertEquals(
                "{\"name\":\"Eclair Cafe\",\"description\":\"Delicieux Eclair au Cafe pas calorique du tout\",\"size\":\"M\",\"price\":2.6,\"status\":\"available\"}",
-               response.getBody(), JSONCompareMode.LENIENT);
+               response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -103,10 +102,10 @@ class RestControllerIT extends AbstractBaseIT {
       // Check its validation endpoint with invalid payload
       patchedPastry = "{\"price\":\"2.6\"}";
       requestEntity = new HttpEntity<>(patchedPastry, headers);
-      response = restTemplate.exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe", HttpMethod.PATCH,
-            requestEntity, String.class);
-      assertEquals(400, response.getStatusCode().value());
-      assertEquals("[string found, number expected]", response.getBody());
+      response = exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe", HttpMethod.PATCH, requestEntity,
+            String.class);
+      assertEquals(400, response.getStatus().value());
+      assertEquals("[string found, number expected]", response.getResponseBody());
    }
 
    @Test
@@ -116,21 +115,20 @@ class RestControllerIT extends AbstractBaseIT {
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/beer-catalog-api-collection.json", false);
 
       // Check its different mocked operations.
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/Beer+Catalog+API/0.9/beer?page=0",
-            String.class);
-      assertEquals(200, response.getStatusCode().value());
+      EntityExchangeResult<String> response = getForEntity("/rest/Beer+Catalog+API/0.9/beer?page=0", String.class);
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("[3]", response.getBody(), new ArraySizeComparator(JSONCompareMode.LENIENT));
+         JSONAssert.assertEquals("[3]", response.getResponseBody(), new ArraySizeComparator(JSONCompareMode.LENIENT));
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
 
-      response = restTemplate.getForEntity("/rest/Beer+Catalog+API/0.9/beer/Weissbier", String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = getForEntity("/rest/Beer+Catalog+API/0.9/beer/Weissbier", String.class);
+      assertEquals(200, response.getStatus().value());
       try {
          JSONAssert.assertEquals("{\n" + "    \"name\": \"Weissbier\",\n" + "    \"country\": \"Germany\",\n"
                + "    \"type\": \"Wheat\",\n" + "    \"rating\": 4.1,\n" + "    \"status\": \"out_of_stock\"\n" + "}",
-               response.getBody(), JSONCompareMode.LENIENT);
+               response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -144,11 +142,11 @@ class RestControllerIT extends AbstractBaseIT {
       ObjectMapper mapper = new ObjectMapper();
 
       // Check operation with a defined mock (name: 'Millefeuille')
-      ResponseEntity<String> response = restTemplate
-            .getForEntity("/rest/pastry-details/1.0.0/pastry/Millefeuille/details", String.class);
-      assertEquals(200, response.getStatusCode().value());
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry/Millefeuille/details",
+            String.class);
+      assertEquals(200, response.getStatus().value());
       try {
-         JsonNode details = mapper.readTree(response.getBody());
+         JsonNode details = mapper.readTree(response.getResponseBody());
          String description = details.get("description").asText();
          assertTrue(description.startsWith("Detail -"));
       } catch (Exception e) {
@@ -157,8 +155,8 @@ class RestControllerIT extends AbstractBaseIT {
 
       // Check operation with an undefined defined mock (name: 'Dummy'), should now return a 400 error as
       // per issue #819 and #1132 to have a consistent behaviour, allow proxying support and this kind of stuff.
-      response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry/Dummy/details", String.class);
-      assertEquals(400, response.getStatusCode().value());
+      response = getForEntity("/rest/pastry-details/1.0.0/pastry/Dummy/details", String.class);
+      assertEquals(400, response.getStatus().value());
    }
 
    @Test
@@ -166,15 +164,15 @@ class RestControllerIT extends AbstractBaseIT {
       // Upload modified pastry-with-headers-openapi spec
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/pastry-with-headers-openapi.yaml", true);
 
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-headers/1.0.0/pastry", String.class);
-      assertEquals(200, response.getStatusCode().value());
-      assertEquals("some-static-header", response.getHeaders().getFirst("x-some-static-header"));
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-headers/1.0.0/pastry", String.class);
+      assertEquals(200, response.getStatus().value());
+      assertEquals("some-static-header", response.getResponseHeaders().getFirst("x-some-static-header"));
 
-      String someGenericHeader = response.getHeaders().getFirst("x-some-generic-header");
+      String someGenericHeader = response.getResponseHeaders().getFirst("x-some-generic-header");
       assertDoesNotThrow(() -> UUID.fromString(someGenericHeader));
 
-      response = restTemplate.getForEntity("/rest/pastry-headers/1.0.0/pastry?size=XL", String.class);
-      String requestBasedHeader = response.getHeaders().getFirst("x-request-based-header");
+      response = getForEntity("/rest/pastry-headers/1.0.0/pastry?size=XL", String.class);
+      String requestBasedHeader = response.getResponseHeaders().getFirst("x-request-based-header");
       assertEquals("XL size", requestBasedHeader);
    }
 
@@ -183,16 +181,16 @@ class RestControllerIT extends AbstractBaseIT {
       // Upload simple-oidc-redirect-openapi spec
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/simple-oidc-redirect-openapi.yaml", true);
 
-      ResponseEntity<String> response = restTemplate.withRedirects(HttpRedirects.DONT_FOLLOW)
-            .getForEntity("/rest/Simple+OIDC/1.0/login/oauth/authorize?"
+      EntityExchangeResult<String> response = getForEntityWithoutRedirects(
+            "/rest/Simple+OIDC/1.0/login/oauth/authorize?"
                   + "response_type=code&client_id=GHCLIENT&scope=openid+user:email&redirect_uri=http://localhost:8080/Login/githubLoginSuccess&state=e956e017-5e13-4c9d-b83b-6dd6337a6a86",
-                  String.class);
-      assertEquals(302, response.getStatusCode().value());
+            String.class);
+      assertEquals(302, response.getStatus().value());
 
-      String content = response.getBody();
+      String content = response.getResponseBody();
       assertNull(content);
 
-      String location = response.getHeaders().getFirst("location");
+      String location = response.getResponseHeaders().getFirst("location");
       assertNotNull(location);
       assertTrue(location.startsWith("http://localhost:8080/Login/githubLoginSuccess?"));
       assertTrue(location.contains("state=e956e017-5e13-4c9d-b83b-6dd6337a6a86"));
@@ -213,20 +211,20 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // If we have the mock, we should get the response from the mock.
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut",
-            String.class);
-      assertEquals(200, response.getStatusCode().value());
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut", String.class);
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\"name\":\"Mocked One\"}", response.getBody(), JSONCompareMode.LENIENT);
+         JSONAssert.assertEquals("{\"name\":\"Mocked One\"}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
 
       // If we don't have the mock, we should get the response from real backend.
-      response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\"name\":\"Croissant from Real One\"}", response.getBody(), JSONCompareMode.LENIENT);
+         JSONAssert.assertEquals("{\"name\":\"Croissant from Real One\"}", response.getResponseBody(),
+               JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -248,23 +246,23 @@ class RestControllerIT extends AbstractBaseIT {
 
       // If we have the mock, we should get the response from the mock.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut",
-            String.class);
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut", String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\"name\":\"Mocked One\"}", response.getBody(), JSONCompareMode.LENIENT);
+         JSONAssert.assertEquals("{\"name\":\"Mocked One\"}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
 
       // If we don't have the mock, we should get the response from real backend.
       startTime = System.currentTimeMillis();
-      response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
+      response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
       long realResponseTime = System.currentTimeMillis() - startTime;
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\"name\":\"Croissant from Real One\"}", response.getBody(), JSONCompareMode.LENIENT);
+         JSONAssert.assertEquals("{\"name\":\"Croissant from Real One\"}", response.getResponseBody(),
+               JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -277,31 +275,32 @@ class RestControllerIT extends AbstractBaseIT {
 
       // If we have the mock, we should get the response from the mock.
       startTime = System.currentTimeMillis();
-      response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut", String.class);
+      response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut", String.class);
       long mockedResponseTimeDelayed = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTimeDelayed >= delay,
             "mocked response time delayed: " + mockedResponseTimeDelayed + "ms");
       assertTrue(mockedResponseTimeDelayed >= mockedResponseTime,
             "mocked response time: " + mockedResponseTime + "ms, delayed: " + mockedResponseTimeDelayed + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\"name\":\"Mocked One\"}", response.getBody(), JSONCompareMode.LENIENT);
+         JSONAssert.assertEquals("{\"name\":\"Mocked One\"}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
 
       // If we don't have the mock, we should get the response from real backend.
       startTime = System.currentTimeMillis();
-      response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
+      response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
       long realResponseTimeDelayed = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(realResponseTimeDelayed >= delay, "real response time delayed: " + realResponseTimeDelayed + "ms");
       assertTrue(realResponseTimeDelayed >= realResponseTime,
             "real response time: " + mockedResponseTime + "ms, delayed: " + realResponseTimeDelayed + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\"name\":\"Croissant from Real One\"}", response.getBody(), JSONCompareMode.LENIENT);
+         JSONAssert.assertEquals("{\"name\":\"Croissant from Real One\"}", response.getResponseBody(),
+               JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -323,9 +322,9 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // Check that we don't fall into infinite loop and that we can't locally handle the call (error 400)
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
             String.class);
-      assertEquals(400, response.getStatusCode().value());
+      assertEquals(400, response.getStatus().value());
       verify(restController, times(1)).execute(any(), any(), any(), any(), any(), any(), any(), any());
    }
 
@@ -344,9 +343,9 @@ class RestControllerIT extends AbstractBaseIT {
             .replaceFirst("pastry-real", "not-found"));
       serviceRepository.save(service);
 
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
             String.class);
-      assertEquals(404, response.getStatusCode().value());
+      assertEquals(404, response.getStatus().value());
    }
 
    @Test
@@ -363,11 +362,10 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // Event if `donut` is defined on our mock, we should always have the response coming for real backend.
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry/donut",
-            String.class);
-      assertEquals(200, response.getStatusCode().value());
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry/donut", String.class);
+      assertEquals(200, response.getStatus().value());
       try {
-         JSONAssert.assertEquals("{\"name\":\"Real One\"}", response.getBody(), JSONCompareMode.LENIENT);
+         JSONAssert.assertEquals("{\"name\":\"Real One\"}", response.getResponseBody(), JSONCompareMode.LENIENT);
       } catch (Exception e) {
          fail("No Exception should be thrown here");
       }
@@ -381,20 +379,20 @@ class RestControllerIT extends AbstractBaseIT {
       ObjectMapper mapper = new ObjectMapper();
 
       // Check operation with a defined mock (name: 'Eclair Cafe')
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-script/1.0.0/pastry/Eclair Cafe/taste",
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-script/1.0.0/pastry/Eclair Cafe/taste",
             String.class);
-      assertEquals(200, response.getStatusCode().value());
-      assertEquals("Delicious", response.getBody());
+      assertEquals(200, response.getStatus().value());
+      assertEquals("Delicious", response.getResponseBody());
 
       // Check operation with a defined mock (name: 'Millefeuille')
-      response = restTemplate.getForEntity("/rest/pastry-script/1.0.0/pastry/Millefeuille/taste", String.class);
-      assertEquals(200, response.getStatusCode().value());
-      assertEquals("Awesome", response.getBody());
+      response = getForEntity("/rest/pastry-script/1.0.0/pastry/Millefeuille/taste", String.class);
+      assertEquals(200, response.getStatus().value());
+      assertEquals("Awesome", response.getResponseBody());
 
       // Check operation with an undefined mock (name: 'Dummy')
-      response = restTemplate.getForEntity("/rest/pastry-script/1.0.0/pastry/Dummy/taste", String.class);
-      assertEquals(200, response.getStatusCode().value());
-      assertEquals("Ok", response.getBody());
+      response = getForEntity("/rest/pastry-script/1.0.0/pastry/Dummy/taste", String.class);
+      assertEquals(200, response.getStatus().value());
+      assertEquals("Ok", response.getResponseBody());
    }
 
    @Test
@@ -404,12 +402,11 @@ class RestControllerIT extends AbstractBaseIT {
 
       // Check a delayed mocked operations.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/PetStore+API/1.0.0/pets?delay=200",
-            String.class);
+      EntityExchangeResult<String> response = getForEntity("/rest/PetStore+API/1.0.0/pets?delay=200", String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTime >= 200, "mocked response time delayed: " + mockedResponseTime + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
 
       // Now use a header to specify mock response time.
       HttpHeaders headers = new HttpHeaders();
@@ -417,12 +414,11 @@ class RestControllerIT extends AbstractBaseIT {
       HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
 
       startTime = System.currentTimeMillis();
-      response = restTemplate.exchange("/rest/PetStore+API/1.0.0/pets?delay=200", HttpMethod.GET, requestEntity,
-            String.class);
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200", HttpMethod.GET, requestEntity, String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTime >= 400, "mocked response time delayed: " + mockedResponseTime + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
    }
 
 
@@ -433,12 +429,12 @@ class RestControllerIT extends AbstractBaseIT {
 
       // Check a delayed mocked operations with fixed strategy.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate
-            .getForEntity("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", String.class);
+      EntityExchangeResult<String> response = getForEntity(
+            "/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTime >= 200, "mocked response time delayed: " + mockedResponseTime + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
 
       // Now use a header to specify mock response time with random strategy.
       HttpHeaders headers = new HttpHeaders();
@@ -448,12 +444,12 @@ class RestControllerIT extends AbstractBaseIT {
 
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set random here).
-      response = restTemplate.exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=random", HttpMethod.GET,
-            requestEntity, String.class);
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=random", HttpMethod.GET, requestEntity,
+            String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTime >= 400, "mocked response time delayed: " + mockedResponseTime + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
    }
 
    @Test
@@ -464,14 +460,14 @@ class RestControllerIT extends AbstractBaseIT {
 
       // Check a delayed mocked operations with random strategy.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate
-            .getForEntity("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=random", String.class);
+      EntityExchangeResult<String> response = getForEntity(
+            "/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=random", String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is between 0 and 200ms (random strategy)
       // Note: we can't be sure that the delay is <= 200 because of JVM scheduling but it's very likely.
       assertTrue(mockedResponseTime >= 0 && mockedResponseTime <= (200 + schedulingDelay),
             "mocked response time delayed: " + mockedResponseTime + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
 
       // Now use a header to specify mock response time with random strategy.
       HttpHeaders headers = new HttpHeaders();
@@ -481,14 +477,14 @@ class RestControllerIT extends AbstractBaseIT {
 
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set fixed here).
-      response = restTemplate.exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET,
-            requestEntity, String.class);
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET, requestEntity,
+            String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is between 0 and the delay.
       // Note: we can't be sure that the delay is <= 400 because of JVM scheduling but it's very likely.
       assertTrue(mockedResponseTime >= 0 && mockedResponseTime <= (400 + schedulingDelay),
             "mocked response time delayed: " + mockedResponseTime + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
    }
 
    @Test
@@ -499,13 +495,13 @@ class RestControllerIT extends AbstractBaseIT {
 
       // Check a delayed mocked operations with random strategy.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate
-            .getForEntity("/rest/PetStore+API/1.0.0/pets?delay=100&delayStrategy=random-20", String.class);
+      EntityExchangeResult<String> response = getForEntity(
+            "/rest/PetStore+API/1.0.0/pets?delay=100&delayStrategy=random-20", String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is between 80 and 120 (100 + or - 20%).
       assertTrue(mockedResponseTime >= 80 && mockedResponseTime <= (120 + schedulingDelay),
             "mocked response time delayed: " + mockedResponseTime + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
 
       // Now use a header to specify mock response time with random strategy.
       HttpHeaders headers = new HttpHeaders();
@@ -514,14 +510,14 @@ class RestControllerIT extends AbstractBaseIT {
       HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set fixed here).
-      response = restTemplate.exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET,
-            requestEntity, String.class);
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET, requestEntity,
+            String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is between 320 and 480 (400 + or - 20%).
       // Note: we can't be sure that the delay is <= 480 because of JVM scheduling but it's very likely.
       assertTrue(mockedResponseTime >= 320 && mockedResponseTime <= (480 + schedulingDelay),
             "mocked response time delayed: " + mockedResponseTime + "ms");
-      assertEquals(200, response.getStatusCode().value());
+      assertEquals(200, response.getStatus().value());
    }
 
 }

--- a/webapp/src/test/java/io/github/microcks/web/SoapControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/SoapControllerIT.java
@@ -21,7 +21,7 @@ import io.github.microcks.domain.Service;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,15 +52,15 @@ class SoapControllerIT extends AbstractBaseIT {
       HttpEntity<String> entity = new HttpEntity<>(request, headers);
 
       // Execute and assert.
-      ResponseEntity<String> response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      EntityExchangeResult<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      assertEquals(200, response.getStatus().value());
       assertEquals(
             "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hel=\"http://www.example.com/hello\">\n"
                   + "   <soapenv:Header/>\n" + "   <soapenv:Body>\n" + "      <hel:sayHelloResponse>\n"
                   + "         <sayHello>Hello Karla !</sayHello>\n" + "      </hel:sayHelloResponse>\n"
                   + "   </soapenv:Body>\n" + "</soapenv:Envelope>",
-            response.getBody());
-      assertEquals("application/soap+xml;charset=UTF-8", response.getHeaders().getContentType().toString());
+            response.getResponseBody());
+      assertEquals("application/soap+xml;charset=UTF-8", response.getResponseHeaders().getContentType().toString());
 
       // Create SOAP 1.1 headers for sayHello operation.
       headers = new HttpHeaders();
@@ -74,15 +74,15 @@ class SoapControllerIT extends AbstractBaseIT {
       entity = new HttpEntity<>(request, headers);
 
       // Execute and assert, content-type is different for SOAP 1.1.
-      response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      assertEquals(200, response.getStatus().value());
       assertEquals(
             "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hel=\"http://www.example.com/hello\">\n"
                   + "   <soapenv:Header/>\n" + "   <soapenv:Body>\n" + "      <hel:sayHelloResponse>\n"
                   + "         <sayHello>Hello Andrew !</sayHello>\n" + "      </hel:sayHelloResponse>\n"
                   + "   </soapenv:Body>\n" + "</soapenv:Envelope>",
-            response.getBody());
-      assertEquals("text/xml;charset=UTF-8", response.getHeaders().getContentType().toString());
+            response.getResponseBody());
+      assertEquals("text/xml;charset=UTF-8", response.getResponseHeaders().getContentType().toString());
 
       // Test exception case.
       request = "<soap-env:Envelope xmlns:soap-env=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hel=\"http://www.example.com/hello\">\n"
@@ -92,8 +92,8 @@ class SoapControllerIT extends AbstractBaseIT {
       entity = new HttpEntity<>(request, headers);
 
       // Execute and assert.
-      response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
-      assertEquals(500, response.getStatusCode().value());
+      response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      assertEquals(500, response.getStatus().value());
       assertEquals(
             "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hel=\"http://www.example.com/hello\">\n"
                   + "   <soapenv:Header/>\n" + "   <soapenv:Body>\n" + "      <soapenv:Fault>\n"
@@ -102,7 +102,7 @@ class SoapControllerIT extends AbstractBaseIT {
                   + "            <hel:HelloException>\n" + "               <code>999</code>\n"
                   + "            </hel:HelloException>\n" + "         </detail>\n" + "      </soapenv:Fault>\n"
                   + "   </soapenv:Body>\n" + "</soapenv:Envelope>",
-            response.getBody());
+            response.getResponseBody());
    }
 
    @Test
@@ -147,14 +147,13 @@ class SoapControllerIT extends AbstractBaseIT {
 
       // Execute and assert.
       for (int i = 0; i < 10; ++i) {
-         ResponseEntity<String> response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity,
-               String.class);
-         switch (response.getStatusCode().value()) {
+         EntityExchangeResult<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+         switch (response.getStatus().value()) {
             case 200:
-               assertTrue(okResponses.contains(response.getBody()));
+               assertTrue(okResponses.contains(response.getResponseBody()));
                break;
             case 500:
-               assertTrue(koResponses.contains(response.getBody()));
+               assertTrue(koResponses.contains(response.getResponseBody()));
                break;
             default:
                fail();
@@ -181,7 +180,7 @@ class SoapControllerIT extends AbstractBaseIT {
       HttpEntity<String> entity = createBaseEntityForName("Andrew");
 
       // Execute and assert.
-      ResponseEntity<String> response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      EntityExchangeResult<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertResponseIsOkAndContains(response, "<sayHello>Hello Real Andrew !</sayHello>");
    }
 
@@ -207,14 +206,14 @@ class SoapControllerIT extends AbstractBaseIT {
       HttpEntity<String> entity = createBaseEntityForName("Andrew");
 
       // Execute and assert that it wasn't proxy.
-      ResponseEntity<String> response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      EntityExchangeResult<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertResponseIsOkAndContains(response, "<sayHello>Hello Andrew !</sayHello>");
 
       // Build the request that doesn't match QUERY_MATCH.
       entity = createBaseEntityForName("Garry");
 
       // Execute and assert that it was proxy.
-      response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertResponseIsOkAndContains(response, "<sayHello>Hello Real Garry !</sayHello>");
    }
 

--- a/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -97,10 +97,10 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
-      assertEquals(201, response.getStatusCode().value());
+      EntityExchangeResult<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
+      assertEquals(201, response.getStatus().value());
 
-      TestResult testResult = response.getBody();
+      TestResult testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertNotNull(testResult.getId());
       assertTrue(testResult.isInProgress());
@@ -109,10 +109,10 @@ class TestControllerIT extends AbstractBaseIT {
       // Wait till timeout and re-fetch the result.
       waitForTestCompletion(testResult, 3);
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      assertEquals(200, response.getStatus().value());
 
-      testResult = response.getBody();
+      testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertFalse(testResult.isInProgress());
       assertTrue(testResult.isSuccess());
@@ -144,10 +144,10 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
-      assertEquals(201, response.getStatusCode().value());
+      EntityExchangeResult<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
+      assertEquals(201, response.getStatus().value());
 
-      TestResult testResult = response.getBody();
+      TestResult testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertNotNull(testResult.getId());
       assertTrue(testResult.isInProgress());
@@ -161,10 +161,10 @@ class TestControllerIT extends AbstractBaseIT {
          System.err.println(postmanRunner.getLogs());
       }
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      assertEquals(200, response.getStatus().value());
 
-      testResult = response.getBody();
+      testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertFalse(testResult.isInProgress());
       assertTrue(testResult.isSuccess());
@@ -186,10 +186,10 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
-      assertEquals(201, response.getStatusCode().value());
+      EntityExchangeResult<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
+      assertEquals(201, response.getStatus().value());
 
-      TestResult testResult = response.getBody();
+      TestResult testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertNotNull(testResult.getId());
       assertTrue(testResult.isInProgress());
@@ -198,10 +198,10 @@ class TestControllerIT extends AbstractBaseIT {
       // Wait till timeout and re-fetch the result.
       waitForTestCompletion(testResult, 3);
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      assertEquals(200, response.getStatus().value());
 
-      testResult = response.getBody();
+      testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertFalse(testResult.isInProgress());
       // 2 tests steps are ok, 1 is failing.
@@ -248,10 +248,10 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
-      assertEquals(201, response.getStatusCode().value());
+      EntityExchangeResult<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
+      assertEquals(201, response.getStatus().value());
 
-      TestResult testResult = response.getBody();
+      TestResult testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertNotNull(testResult.getId());
       assertTrue(testResult.isInProgress());
@@ -260,10 +260,10 @@ class TestControllerIT extends AbstractBaseIT {
       // Wait till timeout and re-fetch the result.
       waitForTestCompletion(testResult, 3);
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
-      assertEquals(200, response.getStatusCode().value());
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      assertEquals(200, response.getStatus().value());
 
-      testResult = response.getBody();
+      testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertFalse(testResult.isInProgress());
       assertTrue(testResult.isSuccess());
@@ -296,10 +296,10 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
-      assertEquals(201, response.getStatusCode().value());
+      EntityExchangeResult<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
+      assertEquals(201, response.getStatus().value());
 
-      TestResult testResult = response.getBody();
+      TestResult testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertNotNull(testResult.getId());
       assertTrue(testResult.isInProgress());
@@ -308,9 +308,9 @@ class TestControllerIT extends AbstractBaseIT {
       // Wait till timeout and re-fetch the result.
       waitForTestCompletion(testResult, 3);
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
-      assertEquals(200, response.getStatusCode().value());
-      testResult = response.getBody();
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      assertEquals(200, response.getStatus().value());
+      testResult = response.getResponseBody();
       assertNotNull(testResult);
       assertFalse(testResult.isInProgress());
       assertFalse(testResult.isSuccess());
@@ -319,10 +319,10 @@ class TestControllerIT extends AbstractBaseIT {
    private void waitForTestCompletion(TestResult testResult, int seconds) {
       await().atMost(seconds, TimeUnit.SECONDS).pollDelay(500, TimeUnit.MILLISECONDS)
             .pollInterval(250, TimeUnit.MILLISECONDS).until(() -> {
-               ResponseEntity<TestResult> resp = restTemplate.getForEntity("/api/tests/" + testResult.getId(),
+               EntityExchangeResult<TestResult> resp = getForEntity("/api/tests/" + testResult.getId(),
                      TestResult.class);
-               if (resp.getStatusCode().value() == 200) {
-                  TestResult tr = resp.getBody();
+               if (resp.getStatus().value() == 200) {
+                  TestResult tr = resp.getResponseBody();
                   return tr != null && !tr.isInProgress();
                }
                return false;

--- a/webapp/src/test/java/io/github/microcks/web/TracingControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TracingControllerIT.java
@@ -26,7 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.context.TestPropertySource;
 
 import java.io.BufferedReader;
@@ -85,30 +86,30 @@ class TracingControllerIT extends AbstractBaseIT {
    @DisplayName("Should retrieve spans for a specific trace ID")
    void shouldRetrieveSpansForTraceId() {
       // Given - Call GET /rest/pastry-details/1.0.0/pastry to generate traces
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
 
       // Get all trace IDs GET /api/traces that returns a List<String>
-      ResponseEntity<Set<String>> traceIdsResponse = restTemplate.exchange("/api/traces", HttpMethod.GET, null,
+      EntityExchangeResult<Set<String>> traceIdsResponse = exchange("/api/traces", HttpMethod.GET, null,
             new ParameterizedTypeReference<>() {
             });
 
-      assertThat(traceIdsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-      if (traceIdsResponse.getBody() != null && !traceIdsResponse.getBody().isEmpty()) {
+      assertThat(traceIdsResponse.getStatus()).isEqualTo(HttpStatus.OK);
+      if (traceIdsResponse.getResponseBody() != null && !traceIdsResponse.getResponseBody().isEmpty()) {
          // Get spans for the first trace ID
-         String firstTraceId = traceIdsResponse.getBody().iterator().next();
-         ResponseEntity<List<Object>> spansResponse = restTemplate.exchange("/api/traces/" + firstTraceId + "/spans",
+         String firstTraceId = traceIdsResponse.getResponseBody().iterator().next();
+         EntityExchangeResult<List<Object>> spansResponse = exchange("/api/traces/" + firstTraceId + "/spans",
                HttpMethod.GET, null, new ParameterizedTypeReference<>() {
                });
 
          // Then
-         assertThat(spansResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-         assertThat(spansResponse.getBody()).isNotEmpty();
+         assertThat(spansResponse.getStatus()).isEqualTo(HttpStatus.OK);
+         assertThat(spansResponse.getResponseBody()).isNotEmpty();
 
 
          // Verify span data structure - we expect at least one span with name "GET /rest/pastry-details/1.0.0/pastry"
-         System.out.println(spansResponse.getBody());
-         assertThat(spansResponse.getBody().toString()).contains("/rest/pastry-details/1.0.0/pastry")
+         System.out.println(spansResponse.getResponseBody());
+         assertThat(spansResponse.getResponseBody().toString()).contains("/rest/pastry-details/1.0.0/pastry")
                .contains("processInvocation").contains("explain-trace")
                .contains("Selected dispatcher and rules for this invocation")
                .contains("Received REST invocation GET /rest/pastry-details/1.0.0/pastry");
@@ -119,58 +120,57 @@ class TracingControllerIT extends AbstractBaseIT {
    @DisplayName("Should return 404 for non-existent trace ID")
    void shouldReturn404ForNonExistentTraceId() {
       // When
-      ResponseEntity<List<SpanData>> response = restTemplate.exchange("/api/traces/non-existent-trace-id/spans",
+      EntityExchangeResult<List<SpanData>> response = exchange("/api/traces/non-existent-trace-id/spans",
             HttpMethod.GET, null, new ParameterizedTypeReference<>() {
             });
 
       // Then
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
    }
 
    @Test
    @DisplayName("Should retrieve spans by operation name")
    void shouldRetrieveSpansByOperation() {
       // Given - Call GET /rest/pastry-details/1.0.0/pastry to generate traces
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
 
 
       // Try to query spans by operation (this may return empty if no specific operation traces exist)
-      ResponseEntity<List<List<Object>>> operationSpansResponse = restTemplate.exchange(
+      EntityExchangeResult<List<List<Object>>> operationSpansResponse = exchange(
             "/api/traces/operations?serviceName=pastry-details&operationName=GET /pastry", HttpMethod.GET, null,
             new ParameterizedTypeReference<>() {
             });
 
       // Should get a response containing spans
-      assertThat(operationSpansResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assertThat(operationSpansResponse.getStatus()).isEqualTo(HttpStatus.OK);
    }
 
    @Test
    @DisplayName("Should clear all traces")
    void shouldClearAllTraces() {
       // Given - Call GET /rest/pastry-details/1.0.0/pastry to generate traces
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
 
       // Check if traces exist (but don't fail if they don't)
-      restTemplate.exchange("/api/traces", HttpMethod.GET, null, new ParameterizedTypeReference<Set<String>>() {
+      exchange("/api/traces", HttpMethod.GET, null, new ParameterizedTypeReference<Set<String>>() {
       });
 
       // When - Clear all traces
-      ResponseEntity<String> clearResponse = restTemplate.exchange("/api/traces", HttpMethod.DELETE, null,
-            String.class);
+      EntityExchangeResult<String> clearResponse = exchange("/api/traces", HttpMethod.DELETE, null, String.class);
 
       // Then
-      assertThat(clearResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-      assertThat(clearResponse.getBody()).contains("All traces and spans have been cleared");
+      assertThat(clearResponse.getStatus()).isEqualTo(HttpStatus.OK);
+      assertThat(clearResponse.getResponseBody()).contains("All traces and spans have been cleared");
 
       // Verify traces are cleared
-      ResponseEntity<Set<String>> tracesAfterClear = restTemplate.exchange("/api/traces", HttpMethod.GET, null,
+      EntityExchangeResult<Set<String>> tracesAfterClear = exchange("/api/traces", HttpMethod.GET, null,
             new ParameterizedTypeReference<>() {
             });
 
-      assertThat(tracesAfterClear.getStatusCode()).isEqualTo(HttpStatus.OK);
-      assertThat(tracesAfterClear.getBody()).isEmpty();
+      assertThat(tracesAfterClear.getStatus()).isEqualTo(HttpStatus.OK);
+      assertThat(tracesAfterClear.getResponseBody()).isEmpty();
    }
 
    @Test
@@ -178,9 +178,9 @@ class TracingControllerIT extends AbstractBaseIT {
    void shouldStreamTracesViaSseEndpoint() throws Exception {
       // Define the runnable for the SSE client to listen to the stream
       Runnable sseClientRunnable = () -> {
-         restTemplate.execute(
-               "/api/traces/operations/stream?serviceName=pastry-details&operationName=GET /pastry&clientAddress=.*",
-               HttpMethod.GET, request -> {}, response -> {
+         streamingRestClient.get().uri(
+               "/api/traces/operations/stream?serviceName=pastry-details&operationName=GET /pastry&clientAddress=.*")
+               .accept(MediaType.TEXT_EVENT_STREAM).exchange((request, response) -> {
 
                   String line;
                   try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody()));) {
@@ -190,7 +190,7 @@ class TracingControllerIT extends AbstractBaseIT {
                   } catch (IOException e) {
                      System.err.println("Caught exception while reading SSE response: " + e.getMessage());
                   }
-                  return response;
+                  return null;
                });
       };
 
@@ -201,8 +201,8 @@ class TracingControllerIT extends AbstractBaseIT {
       Thread.sleep(100);
 
       // Generate traces by calling the REST endpoint
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      EntityExchangeResult<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.OK);
 
       // Wait for SSE events to be received
       Thread.sleep(500);


### PR DESCRIPTION
## Summary

Fixes #2116.

This PR migrates webapp integration tests from Spring Boot's `TestRestTemplate` to Spring Framework's `RestTestClient`.

Changes include:

- Replaced `TestRestTemplate` usage in webapp IT base/fuzz tests.
- Added shared `RestTestClient` helpers in `AbstractBaseIT`.
- Migrated regular GET/POST/PATCH/DELETE calls to `RestTestClient`.
- Kept SSE-streaming tests on `RestClient.exchange(...)` so they can still read the raw response stream.
- Added a no-redirect `RestTestClient` for redirect assertions.
- Removed the `spring-boot-resttestclient` test dependency.

## Verification

- `rg "org\.springframework\.boot\.resttestclient|TestRestTemplate|AutoConfigureTestRestTemplate" webapp/src/test webapp/pom.xml`
- `mvn -pl webapp '-Djava.version=21' spotless:check`
- Commit hook ran full `spotless:check` successfully.

I could not run the full IT suite locally because this machine has JDK 21 while the project is configured for Java 25.