### PR TITLE
fix: return 404 for missing import jobs

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/JobController.java
+++ b/webapp/src/main/java/io/github/microcks/web/JobController.java
@@ -155,8 +155,13 @@ public class JobController {
    public ResponseEntity<ImportJob> activateJob(@PathVariable("id") String jobId, UserInfo userInfo) {
       log.debug("Activating job with id {}", jobId);
       ImportJob job = jobRepository.findById(jobId).orElse(null);
-      if (job != null && (authorizationChecker.hasRole(userInfo, AuthorizationChecker.ROLE_ADMIN)
-            || authorizationChecker.hasRoleForImportJob(userInfo, AuthorizationChecker.ROLE_MANAGER, job))) {
+
+      if (job == null) {
+         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+      }
+
+      if (authorizationChecker.hasRole(userInfo, AuthorizationChecker.ROLE_ADMIN)
+            || authorizationChecker.hasRoleForImportJob(userInfo, AuthorizationChecker.ROLE_MANAGER, job)) {
          job.setActive(true);
          initMetadataIfMissing(job);
          job.getMetadata().objectUpdated();
@@ -208,6 +213,11 @@ public class JobController {
    public ResponseEntity<String> deleteJob(@PathVariable("id") String jobId, UserInfo userInfo) {
       log.debug("Removing job with id {}", jobId);
       ImportJob job = jobRepository.findById(jobId).orElse(null);
+
+      if (job == null) {
+         return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+      }
+
       if (authorizationChecker.hasRole(userInfo, AuthorizationChecker.ROLE_ADMIN)
             || authorizationChecker.hasRoleForImportJob(userInfo, AuthorizationChecker.ROLE_MANAGER, job)) {
          jobRepository.deleteById(jobId);

--- a/webapp/src/test/java/io/github/microcks/web/JobControllerTest.java
+++ b/webapp/src/test/java/io/github/microcks/web/JobControllerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.web;
+
+import io.github.microcks.repository.ImportJobRepository;
+import io.github.microcks.security.AuthorizationChecker;
+import io.github.microcks.security.UserInfo;
+import io.github.microcks.service.JobService;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class JobControllerTest {
+
+   private static final String UNKNOWN_JOB_ID = "unknown-job";
+
+   @Mock
+   private ImportJobRepository jobRepository;
+
+   @Mock
+   private JobService jobService;
+
+   @Mock
+   private AuthorizationChecker authorizationChecker;
+
+   @InjectMocks
+   private JobController sut;
+
+   @Test
+   void shouldReturnNotFoundWhenActivatingUnknownJob() {
+      UserInfo userInfo = managerUserInfo();
+      Mockito.when(jobRepository.findById(UNKNOWN_JOB_ID)).thenReturn(Optional.empty());
+
+      ResponseEntity<?> response = sut.activateJob(UNKNOWN_JOB_ID, userInfo);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+      Mockito.verifyNoInteractions(authorizationChecker);
+      Mockito.verify(jobRepository, Mockito.never()).save(Mockito.any());
+   }
+
+   @Test
+   void shouldReturnNotFoundWhenDeletingUnknownJob() {
+      UserInfo userInfo = managerUserInfo();
+      Mockito.when(jobRepository.findById(UNKNOWN_JOB_ID)).thenReturn(Optional.empty());
+
+      ResponseEntity<?> response = sut.deleteJob(UNKNOWN_JOB_ID, userInfo);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+      Mockito.verifyNoInteractions(authorizationChecker);
+      Mockito.verify(jobRepository, Mockito.never()).deleteById(Mockito.anyString());
+   }
+
+   private static UserInfo managerUserInfo() {
+      return new UserInfo("Test Manager", "test-manager", "Test", "Manager", "manager@example.com",
+            new String[] { AuthorizationChecker.ROLE_MANAGER }, new String[0]);
+   }
+}


### PR DESCRIPTION
## Summary

- return `404 Not Found` when `deleteJob` receives an unknown job ID
- return the same `404 Not Found` response from `activateJob`
- add regression tests for both endpoints

## Root cause

`deleteJob` passed the nullable repository result to `hasRoleForImportJob`. For manager users, that method dereferenced the missing job and caused a `NullPointerException`.

Both endpoints now check whether the job exists before performing authorization. This also makes their behavior consistent with `startJob` and `stopJob`.

## Validation

- `mvn -pl webapp -am -Dtest=JobControllerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Spotless checks run by the commit hook

Fixes #2155
