### PR TITLE
fix: prevent StringIndexOutOfBoundsException in HARImporter for URLs without file extension

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/har/HARImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/har/HARImporter.java
@@ -384,7 +384,11 @@ public class HARImporter implements MockRepositoryImporter {
    private List<JsonNode> filterValidEntries(Iterator<JsonNode> entries) {
       return Stream.generate(() -> null).takeWhile(x -> entries.hasNext()).map(next -> entries.next()).filter(entry -> {
          String url = entry.path(REQUEST_NODE).path("url").asText();
-         String extension = url.substring(url.lastIndexOf("."));
+         int dotIndex = url.lastIndexOf(".");
+         if (dotIndex == -1) {
+            return true;
+         }
+         String extension = url.substring(dotIndex);
          return !INVALID_ENTRY_EXTENSIONS.contains(extension);
       }).filter(entry -> {
          if (apiPrefix != null) {


### PR DESCRIPTION
 Summary
1) Fixed a crash in `HARImporter.filterValidEntries()` where URLs with no 
  file extension (e.g. `/api/users`) caused `lastIndexOf(".")` to return `-1`, 
  making `substring(-1)` throw `StringIndexOutOfBoundsException`
2)Added a guard so extension-less URLs are treated as valid API entries
3) HAR import no longer fails when any entry has a clean REST URL

Changes
`webapp/src/main/java/io/github/microcks/util/har/HARImporter.java` line 387

Test plan
[ ] Import a HAR file with a request to `/api/users` (no extension)   should succeed
[ ] Verify existing HAR files with extensions (.ico, .js) still get filtered out

Fixes #2157 