### PR TITLE
fix: add null check for GenericResource payload in ResourceController

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/ResourceController.java
+++ b/webapp/src/main/java/io/github/microcks/web/ResourceController.java
@@ -121,8 +121,12 @@ public class ResourceController {
          if (genericResources != null && !genericResources.isEmpty()) {
             try {
                Document reference = genericResources.get(0).getPayload();
-               reference.append(ID_FIELD, genericResources.get(0).getId());
-               referenceSchema = OpenAPISchemaBuilder.buildTypeSchemaFromJson(reference.toJson());
+               if (reference != null) {
+                  reference.append(ID_FIELD, genericResources.get(0).getId());
+                  referenceSchema = OpenAPISchemaBuilder.buildTypeSchemaFromJson(reference.toJson());
+               } else {
+                  log.warn("Reference payload is null for serviceId: {}", serviceId);
+               }
             } catch (Exception e) {
                log.warn("Exception while building reference schema", e);
             }


### PR DESCRIPTION
Summary
1) `getPayload()` can return `null` on a `GenericResource`, causing a silent 
  `NullPointerException` at `reference.append()` 
2) The exception was being swallowed by a generic `catch(Exception e)` block 
  with only a warn log, making it very hard to debug
3)Added an explicit `null` guard with a descriptive warning log

 Changes:
`webapp/src/main/java/io/github/microcks/web/ResourceController.java` lines 123–128

Test plan
1)[ ] Call `GET /api/resources/{serviceId}/resourceType` for a service 
  with a GenericResource that has a null payload
2)[ ] Verify no NullPointerException is thrown
3) [ ] Verify a clear warning log is emitted instead

Fixes #2162 