### PR TITLE
fix: run Keycloak token refresh outside Angular zone to avoid unnecessary change detection

### DIFF
--- a/webapp/src/main/webapp/src/app/services/auth-keycloak.service.ts
+++ b/webapp/src/main/webapp/src/app/services/auth-keycloak.service.ts
@@ -18,6 +18,7 @@ import { Observable, BehaviorSubject } from 'rxjs';
 import { User } from '../models/user.model';
 import { ConfigService } from './config.service';
 import { HttpClient } from '@angular/common/http';
+import { NgZone } from '@angular/core';
 
 /**
  * A version of the authentication service that uses keycloak.js to provide
@@ -36,7 +37,7 @@ export class KeycloakAuthenticationService extends IAuthenticationService {
   /**
    * Constructor.
    */
-  constructor(private http: HttpClient, private config: ConfigService) {
+  constructor(private http: HttpClient, private config: ConfigService, private ngZone: NgZone) {
     super();
     const w: any = window;
     this.keycloak = w.keycloak;
@@ -53,11 +54,12 @@ export class KeycloakAuthenticationService extends IAuthenticationService {
     this.authenticated.next(true);
     this.authenticatedUser.next(user);
 
-    // Periodically refresh
-    // TODO run this outsize NgZone using zone.runOutsideAngular() : https://angular.io/api/core/NgZone
-    setInterval(() => {
-      this.keycloak.updateToken(30);
-    }, 30000);
+    // Periodically refresh outside Angular zone to avoid unnecessary change detection cycles
+    this.ngZone.runOutsideAngular(() => {
+      setInterval(() => {
+        this.keycloak.updateToken(30);
+      }, 30000);
+    });
   }
 
   /**

--- a/webapp/src/main/webapp/src/app/services/auth.service.provider.ts
+++ b/webapp/src/main/webapp/src/app/services/auth.service.provider.ts
@@ -18,13 +18,14 @@ import { ConfigService } from './config.service';
 import { KeycloakAuthenticationService } from './auth-keycloak.service';
 import { AnonymousAuthenticationService } from './auth-anonymous.service';
 import { HttpClient } from '@angular/common/http';
+import { NgZone } from '@angular/core';
 
 
-export function AuthenticationServiceFactory(http: HttpClient, config: ConfigService): IAuthenticationService {
+export function AuthenticationServiceFactory(http: HttpClient, config: ConfigService, ngZone: NgZone): IAuthenticationService {
   console.info('[AuthenticationServiceFactory] Creating AuthenticationService...');
   if (config.authType() === 'keycloakjs') {
     console.info('[AuthenticationServiceFactory] Creating keycloak.js auth service.');
-    return new KeycloakAuthenticationService(http, config);
+    return new KeycloakAuthenticationService(http, config, ngZone);
   } else if (config.authType() === 'anonymous') {
     console.info('[AuthenticationServiceFactory] Creating Anonymous auth service.');
     return new AnonymousAuthenticationService(http, config);
@@ -39,5 +40,5 @@ export function AuthenticationServiceFactory(http: HttpClient, config: ConfigSer
 export let AuthenticationServiceProvider = {
   provide: IAuthenticationService,
   useFactory: AuthenticationServiceFactory,
-  deps: [HttpClient, ConfigService]
+  deps: [HttpClient, ConfigService, NgZone]
 };


### PR DESCRIPTION
Summary
- Wrapped the periodic `setInterval` token refresh in `NgZone.runOutsideAngular()`
- Prevents Angular from triggering change detection every 30 seconds when no UI state has changed
- Added `NgZone` as a constructor dependency in `KeycloakAuthenticationService`

Changes
`webapp/src/main/webapp/src/app/services/auth-keycloak.service.ts`

Test plan
- [ ] Login to Microcks with Keycloak auth enabled
- [ ] Verify token still refreshes correctly after 30 seconds
- [ ] Verify no unnecessary Angular change detection cycles triggered during idle time

Fixes #2124