### PR TITLE
feat(test): report async test case phases to clients #2226

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/TestCasePhase.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/TestCasePhase.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.domain;
+
+/**
+ * Enumeration of the progress phases a TestCaseResult may go through while an asynchronous test is running. This allows
+ * clients to observe the readiness of the test machinery (for example, when the message consumer is connected and ready
+ * to receive) instead of relying on arbitrary delays. The field is optional: a {@code null} phase means no phase has
+ * been reported, in which case clients should fall back to the legacy behavior based on {@code elapsedTime}.
+ * @author sebastien
+ */
+public enum TestCasePhase {
+   /** The test machinery is connecting to the tested endpoint (for example, creating the broker consumer). */
+   CONNECTING,
+   /** The test machinery is connected and waiting for messages to be received on the tested endpoint. */
+   WAITING_FOR_MESSAGE,
+   /** The test case has completed (messages consumed and validated, or timed-out). */
+   DONE
+}

--- a/commons/model/src/main/java/io/github/microcks/domain/TestCaseResult.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/TestCaseResult.java
@@ -29,6 +29,7 @@ public class TestCaseResult {
    private boolean success = false;
    private long elapsedTime = -1;
    private String operationName;
+   private TestCasePhase phase;
 
    private List<TestStepResult> testStepResults = new ArrayList<>();
 
@@ -38,6 +39,14 @@ public class TestCaseResult {
 
    public void setSuccess(boolean success) {
       this.success = success;
+   }
+
+   public TestCasePhase getPhase() {
+      return phase;
+   }
+
+   public void setPhase(TestCasePhase phase) {
+      this.phase = phase;
    }
 
    public long getElapsedTime() {

--- a/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/AsyncAPITestManager.java
@@ -16,8 +16,10 @@
 package io.github.microcks.minion.async;
 
 import io.github.microcks.domain.EventMessage;
+import io.github.microcks.domain.TestCasePhase;
 import io.github.microcks.domain.TestReturn;
 import io.github.microcks.minion.async.client.MicrocksAPIConnector;
+import io.github.microcks.minion.async.client.dto.TestCasePhaseDTO;
 import io.github.microcks.minion.async.client.dto.TestCaseReturnDTO;
 import io.github.microcks.minion.async.consumer.AMQPMessageConsumptionTask;
 import io.github.microcks.minion.async.consumer.AmazonSNSMessageConsumptionTask;
@@ -115,6 +117,12 @@ public class AsyncAPITestManager {
          TestCaseReturnDTO testCaseReturn = new TestCaseReturnDTO(specification.getOperationName());
          MessageConsumptionTask messageConsumptionTask = buildMessageConsumptionTask(specification);
 
+         // Report that we are now connecting to the tested endpoint and forward later readiness phases (best-effort).
+         reportTestCasePhase(TestCasePhase.CONNECTING);
+         if (messageConsumptionTask != null) {
+            messageConsumptionTask.setPhaseListener(this::reportTestCasePhase);
+         }
+
          // Actually start test counter.
          startTime = System.currentTimeMillis();
          List<ConsumedMessage> outputs = null;
@@ -170,6 +178,20 @@ public class AsyncAPITestManager {
 
          // Finally, report the testCase results using Microcks API.
          microcksAPIConnector.reportTestCaseResult(specification.getTestResultId(), testCaseReturn);
+      }
+
+      /**
+       * Report a test case progress phase back to Microcks in a best-effort fashion. Any failure (for example an older
+       * Microcks server that does not expose the phase endpoint) is swallowed so it never impacts the running test.
+       * @param phase The progress phase to report for the current operation.
+       */
+      private void reportTestCasePhase(TestCasePhase phase) {
+         try {
+            microcksAPIConnector.reportTestCasePhase(specification.getTestResultId(),
+                  new TestCasePhaseDTO(specification.getOperationName(), phase));
+         } catch (Exception e) {
+            logger.debugf("Best-effort reporting of test case phase {%s} failed: {%s}", phase, e.getMessage());
+         }
       }
 
       /**

--- a/minions/async/src/main/java/io/github/microcks/minion/async/client/MicrocksAPIConnector.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/client/MicrocksAPIConnector.java
@@ -20,6 +20,7 @@ import io.github.microcks.domain.Service;
 import io.github.microcks.domain.ServiceView;
 import io.github.microcks.domain.TestCaseResult;
 
+import io.github.microcks.minion.async.client.dto.TestCasePhaseDTO;
 import io.github.microcks.minion.async.client.dto.TestCaseReturnDTO;
 import org.eclipse.microprofile.rest.client.annotation.RegisterClientHeaders;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
@@ -98,4 +99,16 @@ public interface MicrocksAPIConnector {
    @Path("/tests/{id}/testCaseResult")
    @Produces("application/json")
    TestCaseResult reportTestCaseResult(@PathParam("id") String testResultId, TestCaseReturnDTO testCaseReturn);
+
+   /**
+    * Report the current progress phase of a test case while an asynchronous test is still in progress. This is a
+    * best-effort, additive notification: callers should ignore failures (for example, a 404 from an older Microcks
+    * server that does not expose this endpoint).
+    * @param testResultId  The unique identifier of TestResult we want to report a phase for
+    * @param testCasePhase A Test Case phase data object for this TestResult
+    */
+   @POST
+   @Path("/tests/{id}/testCasePhase")
+   @Produces("application/json")
+   void reportTestCasePhase(@PathParam("id") String testResultId, TestCasePhaseDTO testCasePhase);
 }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/client/dto/TestCasePhaseDTO.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/client/dto/TestCasePhaseDTO.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.client.dto;
+
+import io.github.microcks.domain.TestCasePhase;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Data Transfer object for reporting the progress phase of a test case run while an asynchronous test is in progress.
+ * @author sebastien
+ */
+@RegisterForReflection
+public class TestCasePhaseDTO {
+
+   private String operationName;
+   private TestCasePhase phase;
+
+   public TestCasePhaseDTO() {
+   }
+
+   /**
+    * Create a new TestCasePhaseDTO for an operation and a phase.
+    * @param operationName The name of the operation this phase relates to
+    * @param phase         The current progress phase of the test case
+    */
+   public TestCasePhaseDTO(String operationName, TestCasePhase phase) {
+      this.operationName = operationName;
+      this.phase = phase;
+   }
+
+   public String getOperationName() {
+      return operationName;
+   }
+
+   public void setOperationName(String operationName) {
+      this.operationName = operationName;
+   }
+
+   public TestCasePhase getPhase() {
+      return phase;
+   }
+
+   public void setPhase(TestCasePhase phase) {
+      this.phase = phase;
+   }
+}

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/AMQPMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/AMQPMessageConsumptionTask.java
@@ -48,7 +48,7 @@ import java.util.regex.Pattern;
  * <code>amqp://{brokerhost[:port]}[/{virtualHost}]/{type}/{destination}[?option1=value1&amp;option2=value2]</code>
  * @author laurent
  */
-public class AMQPMessageConsumptionTask implements MessageConsumptionTask {
+public class AMQPMessageConsumptionTask extends AbstractMessageConsumptionTask {
 
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
@@ -174,6 +174,9 @@ public class AMQPMessageConsumptionTask implements MessageConsumptionTask {
                channel.basicAck(envelope.getDeliveryTag(), false);
             }
          });
+
+         // Consumer is now bound and ready to receive messages.
+         notifyWaitingForMessage();
 
          Thread.sleep(specification.getTimeoutMS());
 

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/AbstractMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/AbstractMessageConsumptionTask.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.consumer;
+
+import io.github.microcks.domain.TestCasePhase;
+
+import java.util.function.Consumer;
+
+/**
+ * Base class for {@link MessageConsumptionTask} implementations that factorizes the optional progress phase reporting.
+ * Subclasses just have to call {@link #notifyWaitingForMessage()} once their broker consumer is connected and ready to
+ * receive messages, so that clients can observe readiness instead of relying on arbitrary delays.
+ * @author sebastien
+ */
+public abstract class AbstractMessageConsumptionTask implements MessageConsumptionTask {
+
+   private Consumer<TestCasePhase> phaseListener;
+
+   @Override
+   public void setPhaseListener(Consumer<TestCasePhase> phaseListener) {
+      this.phaseListener = phaseListener;
+   }
+
+   /**
+    * Notify the registered phase listener (if any) that the consumer is now connected and waiting for messages. Safe to
+    * call when no listener has been registered.
+    */
+   protected void notifyWaitingForMessage() {
+      if (phaseListener != null) {
+         phaseListener.accept(TestCasePhase.WAITING_FOR_MESSAGE);
+      }
+   }
+}

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/AmazonSNSMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/AmazonSNSMessageConsumptionTask.java
@@ -61,7 +61,7 @@ import java.util.regex.Pattern;
  * <code>sns://{region}/{topic}[?option1=value1&amp;option2=value2]</code>
  * @author laurent
  */
-public class AmazonSNSMessageConsumptionTask implements MessageConsumptionTask {
+public class AmazonSNSMessageConsumptionTask extends AbstractMessageConsumptionTask {
 
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
@@ -119,6 +119,9 @@ public class AmazonSNSMessageConsumptionTask implements MessageConsumptionTask {
          initializeSubscription();
       }
       List<ConsumedMessage> messages = new ArrayList<>();
+
+      // Subscription is established: the consumer is connected and ready to receive messages.
+      notifyWaitingForMessage();
 
       long timeoutTime = startTime + specification.getTimeoutMS();
       while (System.currentTimeMillis() - startTime < specification.getTimeoutMS()) {

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/AmazonSQSMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/AmazonSQSMessageConsumptionTask.java
@@ -49,7 +49,7 @@ import java.util.regex.Pattern;
  * <code>sqs://{region}/{queue}[?option1=value1&amp;option2=value2]</code>
  * @author laurent
  */
-public class AmazonSQSMessageConsumptionTask implements MessageConsumptionTask {
+public class AmazonSQSMessageConsumptionTask extends AbstractMessageConsumptionTask {
 
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
@@ -104,6 +104,9 @@ public class AmazonSQSMessageConsumptionTask implements MessageConsumptionTask {
          logger.errorf("Unable to find the SQS queue URL for queue named '%s'", queue);
          throw new IOException("Unable to find the SQS queue URL for queue " + queue);
       }
+
+      // Queue is resolved: the consumer is connected and ready to receive messages.
+      notifyWaitingForMessage();
 
       long timeoutTime = startTime + specification.getTimeoutMS();
       while (System.currentTimeMillis() - startTime < specification.getTimeoutMS()) {

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/GooglePubSubMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/GooglePubSubMessageConsumptionTask.java
@@ -55,7 +55,7 @@ import java.util.regex.Pattern;
  * <code>googlepubsub://{projectId}/{topic}[?option1=value1&amp;option2=value2]</code>
  * @author laurent
  */
-public class GooglePubSubMessageConsumptionTask implements MessageConsumptionTask {
+public class GooglePubSubMessageConsumptionTask extends AbstractMessageConsumptionTask {
 
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
@@ -135,6 +135,9 @@ public class GooglePubSubMessageConsumptionTask implements MessageConsumptionTas
       // Create a new subscriber for subscription.
       subscriber = subBuilder.build();
       subscriber.startAsync().awaitRunning();
+
+      // Subscriber is running: the consumer is connected and ready to receive messages.
+      notifyWaitingForMessage();
 
       // Wait and stop async receiver.
       Thread.sleep(specification.getTimeoutMS() - (System.currentTimeMillis() - start));

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/KafkaMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/KafkaMessageConsumptionTask.java
@@ -19,7 +19,6 @@ import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 
 import io.github.microcks.domain.Header;
-import io.github.microcks.domain.TestCasePhase;
 import io.github.microcks.minion.async.AsyncTestSpecification;
 
 import org.apache.avro.generic.GenericRecord;
@@ -39,7 +38,6 @@ import java.io.*;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.*;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,7 +47,7 @@ import java.util.regex.Pattern;
  * <code>kafka://{brokerhost[:port]}/{topic}[?option1=value1&amp;option2=value2]</code>
  * @author laurent
  */
-public class KafkaMessageConsumptionTask implements MessageConsumptionTask {
+public class KafkaMessageConsumptionTask extends AbstractMessageConsumptionTask {
 
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
@@ -84,8 +82,6 @@ public class KafkaMessageConsumptionTask implements MessageConsumptionTask {
    protected Long startOffset;
    protected Long endOffset;
 
-   private Consumer<TestCasePhase> phaseListener;
-
 
    /**
     * Create a new consumption task from an Async test specification.
@@ -93,11 +89,6 @@ public class KafkaMessageConsumptionTask implements MessageConsumptionTask {
     */
    public KafkaMessageConsumptionTask(AsyncTestSpecification testSpecification) {
       this.specification = testSpecification;
-   }
-
-   @Override
-   public void setPhaseListener(Consumer<TestCasePhase> phaseListener) {
-      this.phaseListener = phaseListener;
    }
 
    /**
@@ -340,8 +331,8 @@ public class KafkaMessageConsumptionTask implements MessageConsumptionTask {
             });
          }
          // Partitions are now assigned: the consumer is connected and ready to receive messages.
-         if (phaseListener != null && !partitions.isEmpty()) {
-            phaseListener.accept(TestCasePhase.WAITING_FOR_MESSAGE);
+         if (!partitions.isEmpty()) {
+            notifyWaitingForMessage();
          }
       }
    }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/KafkaMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/KafkaMessageConsumptionTask.java
@@ -19,6 +19,7 @@ import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 
 import io.github.microcks.domain.Header;
+import io.github.microcks.domain.TestCasePhase;
 import io.github.microcks.minion.async.AsyncTestSpecification;
 
 import org.apache.avro.generic.GenericRecord;
@@ -38,6 +39,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -82,6 +84,8 @@ public class KafkaMessageConsumptionTask implements MessageConsumptionTask {
    protected Long startOffset;
    protected Long endOffset;
 
+   private Consumer<TestCasePhase> phaseListener;
+
 
    /**
     * Create a new consumption task from an Async test specification.
@@ -89,6 +93,11 @@ public class KafkaMessageConsumptionTask implements MessageConsumptionTask {
     */
    public KafkaMessageConsumptionTask(AsyncTestSpecification testSpecification) {
       this.specification = testSpecification;
+   }
+
+   @Override
+   public void setPhaseListener(Consumer<TestCasePhase> phaseListener) {
+      this.phaseListener = phaseListener;
    }
 
    /**
@@ -329,6 +338,10 @@ public class KafkaMessageConsumptionTask implements MessageConsumptionTask {
                   avroConsumer.seek(p, startOffset);
                }
             });
+         }
+         // Partitions are now assigned: the consumer is connected and ready to receive messages.
+         if (phaseListener != null && !partitions.isEmpty()) {
+            phaseListener.accept(TestCasePhase.WAITING_FOR_MESSAGE);
          }
       }
    }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/MQTTMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/MQTTMessageConsumptionTask.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  * <code>mqtt://{brokerhost[:port]}/{topic}[?option1=value1&amp;option2=value2]</code>
  * @author laurent
  */
-public class MQTTMessageConsumptionTask implements MessageConsumptionTask {
+public class MQTTMessageConsumptionTask extends AbstractMessageConsumptionTask {
 
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
@@ -90,6 +90,9 @@ public class MQTTMessageConsumptionTask implements MessageConsumptionTask {
          message.setPayload(mqttMessage.getPayload());
          messages.add(message);
       });
+
+      // Subscription is active: the consumer is connected and ready to receive messages.
+      notifyWaitingForMessage();
 
       Thread.sleep(specification.getTimeoutMS());
 

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/MessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/MessageConsumptionTask.java
@@ -15,14 +15,27 @@
  */
 package io.github.microcks.minion.async.consumer;
 
+import io.github.microcks.domain.TestCasePhase;
+
 import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 /**
  * Interface definition for Task consuming messages on a remote broker.
  * @author laurent
  */
 public interface MessageConsumptionTask extends Callable<List<ConsumedMessage>>, Closeable {
+
+   /**
+    * Register a listener that will be notified of the progress phases reached by this consumption task (for example
+    * {@link TestCasePhase#WAITING_FOR_MESSAGE} once the broker consumer is connected and ready to receive). This is an
+    * optional capability: implementations that cannot detect readiness may keep the default no-op behavior.
+    * @param phaseListener The listener to notify of phase changes.
+    */
+   default void setPhaseListener(Consumer<TestCasePhase> phaseListener) {
+      // Optional capability: no-op by default.
+   }
 
 }

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/NATSMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/NATSMessageConsumptionTask.java
@@ -40,7 +40,7 @@ import java.util.regex.Pattern;
  * specified using the following form: <code>nats://{brokerhost[:port]}</code>
  * @author laurent
  */
-public class NATSMessageConsumptionTask implements MessageConsumptionTask {
+public class NATSMessageConsumptionTask extends AbstractMessageConsumptionTask {
 
    /**
     * Get a JBoss logging logger.
@@ -102,6 +102,9 @@ public class NATSMessageConsumptionTask implements MessageConsumptionTask {
       });
 
       d.subscribe(endpointTopic);
+
+      // Subscription is active: the consumer is connected and ready to receive messages.
+      notifyWaitingForMessage();
 
       Thread.sleep(specification.getTimeoutMS());
 

--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTask.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  * Channel may be empty if connecting to the root context of the WebSocket server.
  * @author laurent
  */
-public class WebSocketMessageConsumptionTask implements MessageConsumptionTask {
+public class WebSocketMessageConsumptionTask extends AbstractMessageConsumptionTask {
 
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
@@ -98,6 +98,9 @@ public class WebSocketMessageConsumptionTask implements MessageConsumptionTask {
          logger.errorf("Connection error while try to reach {%s}", specification.getEndpointUrl());
          throw e;
       }
+
+      // Session is established: the consumer is connected and ready to receive messages.
+      notifyWaitingForMessage();
 
       Thread.sleep(specification.getTimeoutMS());
       if (session != null) {

--- a/minions/async/src/test/java/io/github/microcks/minion/async/AsyncAPITestManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/AsyncAPITestManagerIT.java
@@ -19,11 +19,13 @@ import io.github.microcks.domain.Resource;
 import io.github.microcks.domain.ResourceType;
 import io.github.microcks.domain.Service;
 import io.github.microcks.domain.ServiceView;
+import io.github.microcks.domain.TestCasePhase;
 import io.github.microcks.domain.TestCaseResult;
 import io.github.microcks.domain.TestReturn;
 import io.github.microcks.domain.TestRunnerType;
 import io.github.microcks.minion.async.client.KeycloakConfig;
 import io.github.microcks.minion.async.client.MicrocksAPIConnector;
+import io.github.microcks.minion.async.client.dto.TestCasePhaseDTO;
 import io.github.microcks.minion.async.client.dto.TestCaseReturnDTO;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -86,6 +88,7 @@ class AsyncAPITestManagerIT {
       String asyncAPIContent = Files
             .readString(Paths.get("target/test-classes/io/github/microcks/minion/async", config.specificationFile));
       Map<String, TestCaseReturnDTO> reportedTestCases = new HashMap<>();
+      List<TestCasePhase> reportedPhases = new java.util.ArrayList<>();
       MicrocksAPIConnector microcksAPIConnector = new MicrocksAPIConnector() {
          @Override
          public KeycloakConfig getKeycloakConfig() {
@@ -118,6 +121,11 @@ class AsyncAPITestManagerIT {
          public TestCaseResult reportTestCaseResult(String testResultId, TestCaseReturnDTO testCaseReturn) {
             reportedTestCases.put(testResultId, testCaseReturn);
             return null;
+         }
+
+         @Override
+         public void reportTestCasePhase(String testResultId, TestCasePhaseDTO testCasePhase) {
+            reportedPhases.add(testCasePhase.getPhase());
          }
       };
       SchemaRegistry schemaRegistry = new SchemaRegistry(microcksAPIConnector);
@@ -156,6 +164,9 @@ class AsyncAPITestManagerIT {
       for (TestReturn testReturn : testCaseReturn.getTestReturns()) {
          Assertions.assertEquals(TestReturn.SUCCESS_CODE, testReturn.getCode());
       }
+      // The minion should have reported the progress phases while the consumer was connecting and then ready.
+      Assertions.assertTrue(reportedPhases.contains(TestCasePhase.CONNECTING));
+      Assertions.assertTrue(reportedPhases.contains(TestCasePhase.WAITING_FOR_MESSAGE));
    }
 
    private static void sendTextMessagesOnTopic(int number, String message) {

--- a/minions/async/src/test/java/io/github/microcks/minion/async/consumer/AMQPMessageConsumptionTaskIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/consumer/AMQPMessageConsumptionTaskIT.java
@@ -63,6 +63,8 @@ class AMQPMessageConsumptionTaskIT {
       asyncTestSpecification.setEndpointUrl("amqp://localhost:%s/q/%s".formatted(RABBIT_MQ_PORT, QUEUE_NAME));
 
       AMQPMessageConsumptionTask amqpMessageConsumptionTask = new AMQPMessageConsumptionTask(asyncTestSpecification);
+      List<io.github.microcks.domain.TestCasePhase> reportedPhases = new java.util.ArrayList<>();
+      amqpMessageConsumptionTask.setPhaseListener(reportedPhases::add);
 
       sendMessageIntoQueue();
 
@@ -71,6 +73,8 @@ class AMQPMessageConsumptionTaskIT {
 
       // assert
       Assertions.assertFalse(messages.isEmpty());
+      Assertions.assertTrue(reportedPhases.contains(io.github.microcks.domain.TestCasePhase.WAITING_FOR_MESSAGE),
+            "The consumer should have reported it was waiting for messages.");
    }
 
    @Test

--- a/minions/async/src/test/java/io/github/microcks/minion/async/consumer/AmazonSNSMessageConsumptionTaskIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/consumer/AmazonSNSMessageConsumptionTaskIT.java
@@ -36,6 +36,7 @@ import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -110,10 +111,12 @@ class AmazonSNSMessageConsumptionTaskIT {
       asyncTestSpecification.setEndpointUrl(endpointUrl);
 
       List<ConsumedMessage> messages = null;
+      List<io.github.microcks.domain.TestCasePhase> reportedPhases = Collections.synchronizedList(new ArrayList<>());
 
       // Act.
       try (AmazonSNSMessageConsumptionTask snsConsumptionTask = new AmazonSNSMessageConsumptionTask(
             asyncTestSpecification); ExecutorService executorService = Executors.newFixedThreadPool(2);) {
+         snsConsumptionTask.setPhaseListener(reportedPhases::add);
          List<Future<List<ConsumedMessage>>> outputs = executorService
                .invokeAll(List.of(new Callable<List<ConsumedMessage>>() {
                   @Override
@@ -134,6 +137,9 @@ class AmazonSNSMessageConsumptionTaskIT {
       ConsumedMessage message = messages.getFirst();
       Assertions.assertEquals(TEXT_MESSAGE_TEMPLATE.formatted(0),
             new String(message.getPayload(), StandardCharsets.UTF_8));
+      // The real consumer should have reported it was connected and waiting for messages.
+      Assertions.assertTrue(reportedPhases.contains(io.github.microcks.domain.TestCasePhase.WAITING_FOR_MESSAGE),
+            "The SNS consumer should have reported the WAITING_FOR_MESSAGE phase.");
    }
 
    private void sendTextMessagesOnTopic(int numberOfMessages, String topicName) {

--- a/minions/async/src/test/java/io/github/microcks/minion/async/consumer/AmazonSQSMessageConsumptionTaskIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/consumer/AmazonSQSMessageConsumptionTaskIT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.consumer;
+
+import io.github.microcks.domain.Secret;
+import io.github.microcks.domain.TestCasePhase;
+import io.github.microcks.minion.async.AsyncTestSpecification;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+/**
+ * This is an integration test using <a href="https://testcontainers.com/">Testcontainers</a> to test
+ * {@link AmazonSQSMessageConsumptionTask} class.
+ * @author sebastien
+ */
+@Testcontainers
+class AmazonSQSMessageConsumptionTaskIT {
+
+   private static final Network NETWORK = Network.newNetwork();
+   private static final String QUEUE_NAME = "test-queue";
+   private static final String TEXT_MESSAGE_TEMPLATE = "{\"greeting\": \"Hello World!\", \"number\": %s}";
+
+   @Container
+   private static final LocalStackContainer localStackContainer = new LocalStackContainer(
+         DockerImageName.parse("localstack/localstack:4.14")).withNetwork(NETWORK).withNetworkAliases("localstack")
+               .withServices(LocalStackContainer.Service.SQS);
+
+   private static SqsClient sqsClient;
+   private static String queueUrl;
+
+   @BeforeAll
+   static void beforeAll() {
+      // Create an SQS client connected to LocalStack.
+      sqsClient = SqsClient.builder().endpointOverride(localStackContainer.getEndpoint())
+            .region(Region.of(localStackContainer.getRegion()))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                  AwsBasicCredentials.create(localStackContainer.getAccessKey(), localStackContainer.getSecretKey())))
+            .build();
+
+      // Create the SQS queue.
+      queueUrl = sqsClient.createQueue(CreateQueueRequest.builder().queueName(QUEUE_NAME).build()).queueUrl();
+   }
+
+   @AfterAll
+   static void afterAll() {
+      if (sqsClient != null) {
+         sqsClient.close();
+      }
+   }
+
+   @Test
+   void shouldReceiveMessageOnQueueCorrectly() throws Exception {
+      // Arrange.
+      AsyncTestSpecification asyncTestSpecification = new AsyncTestSpecification();
+      asyncTestSpecification.setTimeoutMS(3000L);
+      asyncTestSpecification.setTestResultId("sqs-test-result-id");
+
+      Secret secret = new Secret();
+      secret.setUsername(localStackContainer.getAccessKey());
+      secret.setPassword(localStackContainer.getSecretKey());
+      asyncTestSpecification.setSecret(secret);
+
+      String endpointUrl = "sqs://" + localStackContainer.getRegion() + "/" + QUEUE_NAME + "?overrideUrl="
+            + localStackContainer.getEndpoint();
+      asyncTestSpecification.setEndpointUrl(endpointUrl);
+
+      List<ConsumedMessage> messages = null;
+      List<TestCasePhase> reportedPhases = Collections.synchronizedList(new ArrayList<>());
+
+      // Act.
+      try (AmazonSQSMessageConsumptionTask sqsConsumptionTask = new AmazonSQSMessageConsumptionTask(
+            asyncTestSpecification); ExecutorService executorService = Executors.newFixedThreadPool(2);) {
+         sqsConsumptionTask.setPhaseListener(reportedPhases::add);
+         List<Future<List<ConsumedMessage>>> outputs = executorService
+               .invokeAll(List.of(new Callable<List<ConsumedMessage>>() {
+                  @Override
+                  public List<ConsumedMessage> call() throws Exception {
+                     // Wait a bit so that consumption task has actually started.
+                     await().during(1000, TimeUnit.MILLISECONDS).until(() -> true);
+                     sendTextMessagesOnQueue(1);
+                     return Collections.emptyList();
+                  }
+               }, sqsConsumptionTask), asyncTestSpecification.getTimeoutMS() + 1000L, TimeUnit.MILLISECONDS);
+
+         messages = outputs.get(1).get();
+      }
+
+      // Assert.
+      Assertions.assertFalse(messages.isEmpty());
+      Assertions.assertEquals(1, messages.size());
+      ConsumedMessage message = messages.getFirst();
+      Assertions.assertEquals(TEXT_MESSAGE_TEMPLATE.formatted(0),
+            new String(message.getPayload(), StandardCharsets.UTF_8));
+      // The real consumer should have reported it was connected and waiting for messages.
+      Assertions.assertTrue(reportedPhases.contains(TestCasePhase.WAITING_FOR_MESSAGE),
+            "The SQS consumer should have reported the WAITING_FOR_MESSAGE phase.");
+   }
+
+   private void sendTextMessagesOnQueue(int numberOfMessages) {
+      for (int i = 0; i < numberOfMessages; i++) {
+         sqsClient.sendMessage(
+               SendMessageRequest.builder().queueUrl(queueUrl).messageBody(TEXT_MESSAGE_TEMPLATE.formatted(i)).build());
+         await().pollDelay(250, TimeUnit.MILLISECONDS).untilAsserted(() -> assertTrue(true));
+      }
+   }
+}

--- a/minions/async/src/test/java/io/github/microcks/minion/async/consumer/GooglePubSubMessageConsumptionTaskIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/consumer/GooglePubSubMessageConsumptionTaskIT.java
@@ -40,6 +40,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -105,10 +106,12 @@ class GooglePubSubMessageConsumptionTaskIT {
             + emulatorContainer.getEmulatorEndpoint());
 
       List<ConsumedMessage> messages = null;
+      List<io.github.microcks.domain.TestCasePhase> reportedPhases = Collections.synchronizedList(new ArrayList<>());
 
       // Act.
       try (GooglePubSubMessageConsumptionTask pubsubConsumptionTask = new GooglePubSubMessageConsumptionTask(
             asyncTestSpecification); ExecutorService executorService = Executors.newFixedThreadPool(2);) {
+         pubsubConsumptionTask.setPhaseListener(reportedPhases::add);
          List<Future<List<ConsumedMessage>>> outputs = executorService
                .invokeAll(List.of(new Callable<List<ConsumedMessage>>() {
                   @Override
@@ -130,6 +133,9 @@ class GooglePubSubMessageConsumptionTaskIT {
       ConsumedMessage message = messages.get(0);
       Assertions.assertEquals(TEXT_MESSAGE_TEMPLATE.formatted(0),
             new String(message.getPayload(), StandardCharsets.UTF_8));
+      // The real consumer should have reported it was connected and waiting for messages.
+      Assertions.assertTrue(reportedPhases.contains(io.github.microcks.domain.TestCasePhase.WAITING_FOR_MESSAGE),
+            "The Google PubSub consumer should have reported the WAITING_FOR_MESSAGE phase.");
    }
 
    private void sendTextMessagesOnTopic(int numberOfMessages) {

--- a/minions/async/src/test/java/io/github/microcks/minion/async/consumer/KafkaMessageConsumptionTaskIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/consumer/KafkaMessageConsumptionTaskIT.java
@@ -39,6 +39,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -99,6 +100,8 @@ class KafkaMessageConsumptionTaskIT {
             "kafka://%s/%s".formatted(kafkaContainer.getBootstrapServers().replace("PLAINTEXT://", ""), TOPIC_NAME));
 
       KafkaMessageConsumptionTask kafkaMessageConsumptionTask = new KafkaMessageConsumptionTask(asyncTestSpecification);
+      List<io.github.microcks.domain.TestCasePhase> reportedPhases = Collections.synchronizedList(new ArrayList<>());
+      kafkaMessageConsumptionTask.setPhaseListener(reportedPhases::add);
 
       // Act.
       ExecutorService executorService = Executors.newFixedThreadPool(2);
@@ -121,6 +124,9 @@ class KafkaMessageConsumptionTaskIT {
       ConsumedMessage message = messages.get(0);
       Assertions.assertEquals(TEXT_MESSAGE_TEMPLATE.formatted(0),
             new String(message.getPayload(), StandardCharsets.UTF_8));
+      // The real consumer should have reported it was connected and waiting for messages once partitions got assigned.
+      Assertions.assertTrue(reportedPhases.contains(io.github.microcks.domain.TestCasePhase.WAITING_FOR_MESSAGE),
+            "The Kafka consumer should have reported the WAITING_FOR_MESSAGE phase.");
    }
 
    @Test

--- a/minions/async/src/test/java/io/github/microcks/minion/async/consumer/MQTTMessageConsumptionTaskIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/consumer/MQTTMessageConsumptionTaskIT.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.consumer;
+
+import io.github.microcks.domain.TestCasePhase;
+import io.github.microcks.minion.async.AsyncTestSpecification;
+
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+/**
+ * This is an integration test case using <a href="https://testcontainers.com/">Testcontainers</a> to test
+ * {@link MQTTMessageConsumptionTask} class.
+ * @author sebastien
+ */
+@Testcontainers
+class MQTTMessageConsumptionTaskIT {
+
+   private static final int MQTT_PORT = 1883;
+   private static final String TOPIC_NAME = "test-topic";
+   private static final String TEXT_MESSAGE_TEMPLATE = "{\"greeting\": \"Hello World!\", \"number\": %s}";
+
+   @Container
+   private static final GenericContainer<?> mosquittoContainer = new GenericContainer<>(
+         DockerImageName.parse("eclipse-mosquitto:1.6.15")).withExposedPorts(MQTT_PORT)
+               .waitingFor(Wait.forLogMessage(".*mosquitto version.*running.*\\n", 1));
+
+   @Test
+   void shouldReceiveMessageOnTopicCorrectly() throws Exception {
+      // Arrange.
+      String brokerUrl = "localhost:" + mosquittoContainer.getMappedPort(MQTT_PORT);
+      AsyncTestSpecification asyncTestSpecification = new AsyncTestSpecification();
+      asyncTestSpecification.setTimeoutMS(2000L);
+      asyncTestSpecification.setEndpointUrl("mqtt://" + brokerUrl + "/" + TOPIC_NAME);
+
+      MQTTMessageConsumptionTask mqttConsumptionTask = new MQTTMessageConsumptionTask(asyncTestSpecification);
+      List<TestCasePhase> reportedPhases = Collections.synchronizedList(new ArrayList<>());
+      mqttConsumptionTask.setPhaseListener(reportedPhases::add);
+
+      // Act.
+      ExecutorService executorService = Executors.newFixedThreadPool(2);
+      List<Future<List<ConsumedMessage>>> outputs = executorService
+            .invokeAll(List.of(new Callable<List<ConsumedMessage>>() {
+               @Override
+               public List<ConsumedMessage> call() throws Exception {
+                  // Wait a bit so that the consumer is actually subscribed before publishing.
+                  await().during(750, TimeUnit.MILLISECONDS).until(() -> true);
+                  sendTextMessageOnTopic(brokerUrl);
+                  return Collections.emptyList();
+               }
+            }, mqttConsumptionTask), asyncTestSpecification.getTimeoutMS() + 1000L, TimeUnit.MILLISECONDS);
+
+      List<ConsumedMessage> messages = outputs.get(1).get();
+
+      // Assert.
+      Assertions.assertFalse(messages.isEmpty());
+      Assertions.assertEquals(1, messages.size());
+      Assertions.assertEquals(TEXT_MESSAGE_TEMPLATE.formatted(0),
+            new String(messages.get(0).getPayload(), StandardCharsets.UTF_8));
+      // The real consumer should have reported it was connected and waiting for messages.
+      Assertions.assertTrue(reportedPhases.contains(TestCasePhase.WAITING_FOR_MESSAGE),
+            "The MQTT consumer should have reported the WAITING_FOR_MESSAGE phase.");
+   }
+
+   private void sendTextMessageOnTopic(String brokerUrl) throws Exception {
+      IMqttClient publisher = new MqttClient("tcp://" + brokerUrl, MqttClient.generateClientId(),
+            new MemoryPersistence());
+      try {
+         publisher.connect();
+         MqttMessage message = new MqttMessage(TEXT_MESSAGE_TEMPLATE.formatted(0).getBytes(StandardCharsets.UTF_8));
+         message.setQos(1);
+         publisher.publish(TOPIC_NAME, message);
+      } finally {
+         if (publisher.isConnected()) {
+            publisher.disconnect();
+         }
+         publisher.close();
+      }
+   }
+}

--- a/minions/async/src/test/java/io/github/microcks/minion/async/consumer/NATSMessageConsumptionTaskIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/consumer/NATSMessageConsumptionTaskIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.consumer;
+
+import io.github.microcks.domain.TestCasePhase;
+import io.github.microcks.minion.async.AsyncTestSpecification;
+
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+/**
+ * This is an integration test case using <a href="https://testcontainers.com/">Testcontainers</a> to test
+ * {@link NATSMessageConsumptionTask} class.
+ * @author sebastien
+ */
+@Testcontainers
+class NATSMessageConsumptionTaskIT {
+
+   private static final int NATS_PORT = 4222;
+   private static final String TOPIC_NAME = "test-topic";
+   private static final String TEXT_MESSAGE_TEMPLATE = "{\"greeting\": \"Hello World!\", \"number\": %s}";
+
+   @Container
+   private static final GenericContainer<?> natsContainer = new GenericContainer<>(
+         DockerImageName.parse("nats:2.14.0-alpine")).withExposedPorts(NATS_PORT)
+               .waitingFor(Wait.forLogMessage(".*Server is ready.*\\n", 1));
+
+   @Test
+   void shouldReceiveMessageOnTopicCorrectly() throws Exception {
+      // Arrange.
+      String brokerUrl = "localhost:" + natsContainer.getMappedPort(NATS_PORT);
+      AsyncTestSpecification asyncTestSpecification = new AsyncTestSpecification();
+      asyncTestSpecification.setTimeoutMS(2000L);
+      asyncTestSpecification.setEndpointUrl("nats://" + brokerUrl + "/" + TOPIC_NAME);
+
+      NATSMessageConsumptionTask natsConsumptionTask = new NATSMessageConsumptionTask(asyncTestSpecification);
+      List<TestCasePhase> reportedPhases = Collections.synchronizedList(new ArrayList<>());
+      natsConsumptionTask.setPhaseListener(reportedPhases::add);
+
+      // Act.
+      ExecutorService executorService = Executors.newFixedThreadPool(2);
+      List<Future<List<ConsumedMessage>>> outputs = executorService
+            .invokeAll(List.of(new Callable<List<ConsumedMessage>>() {
+               @Override
+               public List<ConsumedMessage> call() throws Exception {
+                  // Wait a bit so that the consumer is actually subscribed before publishing.
+                  await().during(750, TimeUnit.MILLISECONDS).until(() -> true);
+                  sendTextMessageOnTopic(brokerUrl);
+                  return Collections.emptyList();
+               }
+            }, natsConsumptionTask), asyncTestSpecification.getTimeoutMS() + 1000L, TimeUnit.MILLISECONDS);
+
+      List<ConsumedMessage> messages = outputs.get(1).get();
+
+      // Assert.
+      Assertions.assertFalse(messages.isEmpty());
+      Assertions.assertEquals(1, messages.size());
+      Assertions.assertEquals(TEXT_MESSAGE_TEMPLATE.formatted(0),
+            new String(messages.get(0).getPayload(), StandardCharsets.UTF_8));
+      // The real consumer should have reported it was connected and waiting for messages.
+      Assertions.assertTrue(reportedPhases.contains(TestCasePhase.WAITING_FOR_MESSAGE),
+            "The NATS consumer should have reported the WAITING_FOR_MESSAGE phase.");
+   }
+
+   private void sendTextMessageOnTopic(String brokerUrl) throws Exception {
+      try (Connection publisher = Nats.connect("nats://" + brokerUrl)) {
+         publisher.publish(TOPIC_NAME, TEXT_MESSAGE_TEMPLATE.formatted(0).getBytes(StandardCharsets.UTF_8));
+         publisher.flush(java.time.Duration.ofSeconds(1));
+      }
+   }
+}

--- a/minions/async/src/test/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTaskIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/consumer/WebSocketMessageConsumptionTaskIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.consumer;
+
+import io.github.microcks.domain.TestCasePhase;
+import io.github.microcks.minion.async.AsyncTestSpecification;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This is an integration test case for {@link WebSocketMessageConsumptionTask} class. It uses an embedded Vert.x
+ * WebSocket server (in-process, no Docker required) to exercise the real consumption task and assert it reports the
+ * {@link TestCasePhase#WAITING_FOR_MESSAGE} phase once its session is established.
+ * @author sebastien
+ */
+class WebSocketMessageConsumptionTaskIT {
+
+   private static final String CHANNEL = "websocket";
+   private static final String TEXT_MESSAGE = "{\"greeting\": \"Hello World!\", \"number\": 0}";
+
+   private static Vertx vertx;
+   private static HttpServer server;
+   private static int port;
+
+   @BeforeAll
+   static void beforeAll() throws Exception {
+      vertx = Vertx.vertx();
+      // On every client connection, push a text message after a short delay so that the consumer message handler is
+      // guaranteed to be registered before the message is sent.
+      server = vertx.createHttpServer()
+            .webSocketHandler(ws -> vertx.setTimer(250, id -> ws.writeTextMessage(TEXT_MESSAGE)));
+      server.listen(0, "localhost").toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      port = server.actualPort();
+   }
+
+   @AfterAll
+   static void afterAll() throws Exception {
+      if (server != null) {
+         server.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      }
+      if (vertx != null) {
+         vertx.close().toCompletionStage().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   void shouldReceiveMessageOnChannelCorrectly() throws Exception {
+      // Arrange.
+      AsyncTestSpecification asyncTestSpecification = new AsyncTestSpecification();
+      asyncTestSpecification.setTimeoutMS(1500L);
+      asyncTestSpecification.setEndpointUrl("ws://localhost:" + port + "/" + CHANNEL);
+
+      List<TestCasePhase> reportedPhases = Collections.synchronizedList(new ArrayList<>());
+      List<ConsumedMessage> messages;
+
+      // Act.
+      try (WebSocketMessageConsumptionTask wsConsumptionTask = new WebSocketMessageConsumptionTask(
+            asyncTestSpecification); ExecutorService executorService = Executors.newSingleThreadExecutor()) {
+         wsConsumptionTask.setPhaseListener(reportedPhases::add);
+         Future<List<ConsumedMessage>> output = executorService
+               .submit((Callable<List<ConsumedMessage>>) wsConsumptionTask);
+         messages = output.get(asyncTestSpecification.getTimeoutMS() + 2000L, TimeUnit.MILLISECONDS);
+      }
+
+      // Assert.
+      Assertions.assertFalse(messages.isEmpty());
+      Assertions.assertEquals(1, messages.size());
+      Assertions.assertEquals(TEXT_MESSAGE, new String(messages.get(0).getPayload(), StandardCharsets.UTF_8));
+      // The real consumer should have reported it was connected and waiting for messages.
+      Assertions.assertTrue(reportedPhases.contains(TestCasePhase.WAITING_FOR_MESSAGE),
+            "The WebSocket consumer should have reported the WAITING_FOR_MESSAGE phase.");
+   }
+}

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/FakeMicrocksAPIConnector.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/FakeMicrocksAPIConnector.java
@@ -22,6 +22,7 @@ import io.github.microcks.domain.ServiceView;
 import io.github.microcks.domain.TestCaseResult;
 import io.github.microcks.minion.async.client.KeycloakConfig;
 import io.github.microcks.minion.async.client.MicrocksAPIConnector;
+import io.github.microcks.minion.async.client.dto.TestCasePhaseDTO;
 import io.github.microcks.minion.async.client.dto.TestCaseReturnDTO;
 
 import java.util.Collections;
@@ -72,5 +73,10 @@ public class FakeMicrocksAPIConnector implements MicrocksAPIConnector {
    @Override
    public TestCaseResult reportTestCaseResult(String testResultId, TestCaseReturnDTO testCaseReturn) {
       return null;
+   }
+
+   @Override
+   public void reportTestCasePhase(String testResultId, TestCasePhaseDTO testCasePhase) {
+      // No-op for testing purposes.
    }
 }

--- a/webapp/src/main/java/io/github/microcks/service/TestService.java
+++ b/webapp/src/main/java/io/github/microcks/service/TestService.java
@@ -20,6 +20,7 @@ import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Request;
 import io.github.microcks.domain.Response;
 import io.github.microcks.domain.Service;
+import io.github.microcks.domain.TestCasePhase;
 import io.github.microcks.domain.TestCaseResult;
 import io.github.microcks.domain.TestOptionals;
 import io.github.microcks.domain.TestResult;
@@ -159,6 +160,7 @@ public class TestService {
                      updateTestCaseResultWithReturns(tcr, testReturns,
                            TestRunnerType.ASYNC_API_SCHEMA != finalTestResult1.getRunnerType(),
                            TestRunnerType.ASYNC_API_SCHEMA == finalTestResult1.getRunnerType());
+                     tcr.setPhase(TestCasePhase.DONE);
                   }
                });
 
@@ -177,6 +179,53 @@ public class TestService {
             saved = false;
             waitSomeRandomMS(5, 50);
             testResult = testResultRepository.findById(testResult.getId()).orElse(null);
+            times++;
+         }
+      }
+      return updatedTestCaseResult.get();
+   }
+
+   /**
+    * Endpoint for reporting the current progress phase of a test case while a test is still in progress. This only
+    * updates the {@code phase} of the matching TestCaseResult and never touches its elapsedTime, success or the global
+    * inProgress flag, so the legacy completion logic is left untouched.
+    * @param testResultId  Unique identifier of test results we report a phase for
+    * @param operationName Name of operation to report a phase for
+    * @param phase         The current progress phase of the test case
+    * @return The updated TestCaseResult object, or null if not found
+    */
+   public TestCaseResult reportTestCasePhase(String testResultId, String operationName, TestCasePhase phase) {
+      log.info("Reporting a TestCasePhase '{}' for testResult {} on operation '{}'", phase, testResultId,
+            operationName);
+      TestResult testResult = testResultRepository.findById(testResultId).orElse(null);
+      if (testResult == null) {
+         return null;
+      }
+      AtomicReference<TestCaseResult> updatedTestCaseResult = new AtomicReference<>();
+
+      // There may be a race condition while updating testResult concurrently with testCaseResult reports.
+      // So be prepared to catch a org.springframework.dao.OptimisticLockingFailureException and retry a few times.
+      int times = 0;
+      boolean saved = false;
+
+      while (!saved && times < 5) {
+         testResult.getTestCaseResults().stream().filter(tcr -> tcr.getOperationName().equals(operationName))
+               .findFirst().ifPresent(tcr -> {
+                  updatedTestCaseResult.set(tcr);
+                  tcr.setPhase(phase);
+               });
+
+         try {
+            testResultRepository.save(testResult);
+            saved = true;
+         } catch (org.springframework.dao.OptimisticLockingFailureException olfe) {
+            log.warn("Caught an OptimisticLockingFailureException, trying refreshing for {} times", times);
+            saved = false;
+            waitSomeRandomMS(5, 50);
+            testResult = testResultRepository.findById(testResult.getId()).orElse(null);
+            if (testResult == null) {
+               return null;
+            }
             times++;
          }
       }

--- a/webapp/src/main/java/io/github/microcks/web/TestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/TestController.java
@@ -33,6 +33,7 @@ import io.github.microcks.service.ServiceService;
 import io.github.microcks.service.TestService;
 import io.github.microcks.util.SafeLogger;
 import io.github.microcks.web.dto.HeaderDTO;
+import io.github.microcks.web.dto.TestCasePhaseDTO;
 import io.github.microcks.web.dto.TestCaseReturnDTO;
 import io.github.microcks.web.dto.TestRequestDTO;
 
@@ -173,6 +174,18 @@ public class TestController {
       log.debug("Reporting testCase results on test {}", testResultId);
       TestCaseResult testCaseResult = testService.reportTestCaseResult(testResultId, testCaseReturn.getOperationName(),
             testCaseReturn.getTestReturns());
+      if (testCaseResult != null) {
+         return new ResponseEntity<>(testCaseResult, HttpStatus.OK);
+      }
+      return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+   }
+
+   @PostMapping(value = "tests/{id}/testCasePhase")
+   public ResponseEntity<TestCaseResult> reportTestCasePhase(@PathVariable("id") String testResultId,
+         @RequestBody TestCasePhaseDTO testCasePhase) {
+      log.debug("Reporting testCase phase on test {}", testResultId);
+      TestCaseResult testCaseResult = testService.reportTestCasePhase(testResultId, testCasePhase.getOperationName(),
+            testCasePhase.getPhase());
       if (testCaseResult != null) {
          return new ResponseEntity<>(testCaseResult, HttpStatus.OK);
       }

--- a/webapp/src/main/java/io/github/microcks/web/dto/TestCasePhaseDTO.java
+++ b/webapp/src/main/java/io/github/microcks/web/dto/TestCasePhaseDTO.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.web.dto;
+
+import io.github.microcks.domain.TestCasePhase;
+
+/**
+ * Data Transfer object for reporting the progress phase of a test case run while an asynchronous test is in progress.
+ * @author sebastien
+ */
+public class TestCasePhaseDTO {
+
+   private String operationName;
+   private TestCasePhase phase;
+
+   public String getOperationName() {
+      return operationName;
+   }
+
+   public TestCasePhase getPhase() {
+      return phase;
+   }
+}

--- a/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
@@ -17,6 +17,8 @@
 package io.github.microcks.web;
 
 import io.github.microcks.domain.RequestResponsePair;
+import io.github.microcks.domain.TestCasePhase;
+import io.github.microcks.domain.TestCaseResult;
 import io.github.microcks.domain.TestResult;
 import io.github.microcks.domain.TestStepResult;
 import io.github.microcks.service.TestRunnerService;
@@ -123,6 +125,65 @@ class TestControllerIT extends AbstractBaseIT {
       List<RequestResponsePair> pairs = testController.getMessagesForTestCase(testResult.getId(), testCaseId);
       assertEquals(1, pairs.size());
       assertEquals("pastries_json", pairs.get(0).getRequest().getName());
+   }
+
+   @Test
+   void testReportTestCasePhase() {
+      // Upload PetStore reference artifact and launch a test to get a real TestResult with test case results.
+      uploadArtifactFile("target/test-classes/io/github/microcks/web/pastry-for-test-openapi.yaml", true);
+
+      String testEndpoint = String.format("http://localhost:%d", pastryImpl.getMappedPort(8282));
+
+      StringBuilder testRequest = new StringBuilder("{").append("\"serviceId\": \"pastry-for-test:2.0.0\", ")
+            .append("\"testEndpoint\": \"").append(testEndpoint).append("\", ")
+            .append("\"runnerType\": \"OPEN_API_SCHEMA\", ").append("\"timeout\": 2000").append("}");
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
+
+      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
+      assertEquals(201, response.getStatusCode().value());
+      TestResult testResult = response.getBody();
+      assertNotNull(testResult);
+
+      waitForTestCompletion(testResult, 3);
+
+      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      testResult = response.getBody();
+      assertNotNull(testResult);
+      assertFalse(testResult.getTestCaseResults().isEmpty());
+      String operationName = testResult.getTestCaseResults().get(0).getOperationName();
+
+      // Report a progress phase for an existing operation.
+      String phaseRequest = "{\"operationName\": \"" + operationName + "\", \"phase\": \"WAITING_FOR_MESSAGE\"}";
+      HttpEntity<String> phaseEntity = new HttpEntity<>(phaseRequest, headers);
+
+      ResponseEntity<TestCaseResult> phaseResponse = restTemplate
+            .postForEntity("/api/tests/" + testResult.getId() + "/testCasePhase", phaseEntity, TestCaseResult.class);
+      assertEquals(200, phaseResponse.getStatusCode().value());
+      assertNotNull(phaseResponse.getBody());
+      assertEquals(TestCasePhase.WAITING_FOR_MESSAGE, phaseResponse.getBody().getPhase());
+
+      // The phase must be persisted while completion indicators (inProgress, success) are left untouched.
+      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      TestResult refreshed = response.getBody();
+      assertNotNull(refreshed);
+      assertFalse(refreshed.isInProgress());
+      assertEquals(TestCasePhase.WAITING_FOR_MESSAGE, refreshed.getTestCaseResults().stream()
+            .filter(tcr -> tcr.getOperationName().equals(operationName)).findFirst().orElseThrow().getPhase());
+
+      // Reporting a phase for an unknown operation is rejected.
+      String unknownRequest = "{\"operationName\": \"UNKNOWN operation\", \"phase\": \"WAITING_FOR_MESSAGE\"}";
+      ResponseEntity<TestCaseResult> unknownResponse = restTemplate.postForEntity(
+            "/api/tests/" + testResult.getId() + "/testCasePhase", new HttpEntity<>(unknownRequest, headers),
+            TestCaseResult.class);
+      assertEquals(400, unknownResponse.getStatusCode().value());
+
+      // Reporting a phase for an unknown test result is rejected.
+      ResponseEntity<TestCaseResult> unknownTestResponse = restTemplate
+            .postForEntity("/api/tests/unknown-id/testCasePhase", phaseEntity, TestCaseResult.class);
+      assertEquals(400, unknownTestResponse.getStatusCode().value());
    }
 
    @Test


### PR DESCRIPTION
## Summary

Expose the progress phase of an asynchronous test case so clients (e.g. Testcontainers libraries) can know **when the broker consumer is ready to receive** messages, instead of relying on an arbitrary delay before publishing.

Today an async test runner POSTs the test to the minion, which subscribes to the broker asynchronously. A client that wants to publish a message *during* the test has no signal telling it the consumer is actually subscribed — hence the common `Thread.sleep(...)` / `Task.Delay(...)` workaround. This change surfaces that readiness as an observable phase.

## What changed

A new optional `TestCasePhase` enum ( `CONNECTING`, `WAITING_FOR_MESSAGE`, `DONE`)  is reported by the async minion and exposed on `TestCaseResult`.

- **commons/model**: add `TestCasePhase` enum and a nullable `phase` field on `TestCaseResult` (additive - `null` when not reported).
- **webapp**: add `POST /api/tests/{id}/testCasePhase` endpoint and `TestService.reportTestCasePhase(...)`, which updates only the phase without touching `elapsedTime` / `inProgress`.
- **minions/async**: `MessageConsumptionTask` gains an optional phase-listener hook; `AsyncAPITestThread` reports `CONNECTING` then, best-effort, the readiness phase. `KafkaMessageConsumptionTask` emits `WAITING_FOR_MESSAGE` from `onPartitionsAssigned` (consumer connected & assigned). `DONE` is set when the final result is reported.
- Tests: `AsyncAPITestManagerIT` asserts the phases are reported; `FakeMicrocksAPIConnector` implements the new connector method.

## How clients use it

A companion change in `microcks-testcontainers-dotnet` consumes this phase to publish exactly when the consumer is ready, removing the arbitrary delay.

Before — publish after an arbitrary delay and hope the consumer is subscribed:

```csharp
var testRequestTask = MicrocksContainer.TestEndpointAsync(kafkaTest, ct);
await Task.Delay(750, ct);                               // ⛔ guesswork
await orderUseCase.PlaceOrderAsync(info, ct);
var testResult = await testRequestTask;
```

After — the library invokes `onReady` as soon as the operation reaches `WAITING_FOR_MESSAGE`:

```csharp
var testResult = await MicrocksContainer.TestEndpointAsync(
    kafkaTest,
    onReady: async () =>
    {
        // called once the Kafka consumer is connected and ready to receive
        await orderUseCase.PlaceOrderAsync(info, ct);
    },
    ct);
```

The client polls `GET /api/tests/{id}`, reads `testCaseResults[].phase`, and fires its publish callback the moment the phase becomes `WAITING_FOR_MESSAGE`. When the server reports no phase (older server), it falls back to a short grace period so existing behavior still works.

## Backward compatibility

Fully additive / non-breaking:
- the new `phase` field is nullable and ignored by older clients;
- the phase callback from the minion is **best-effort** (failures, e.g. a 404 from an older server, are swallowed);
- existing `inProgress` / `elapsedTime` completion logic is untouched.

So any old/new combination of minion × server keeps working.