### PR TITLE
fix(openapi): skip mock registration when examples are missing required path parameters

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/DispatchCriteriaHelper.java
+++ b/webapp/src/main/java/io/github/microcks/util/DispatchCriteriaHelper.java
@@ -389,7 +389,7 @@ public class DispatchCriteriaHelper {
                (m, e) -> m.put(e.getKey(), e.getValue()), Multimap::putAll);
          return buildFromPartsMap(partsRule, multimap);
       }
-      return "";
+      return buildFromPartsMap(partsRule, (Multimap<String, String>) null);
    }
 
    /**
@@ -400,8 +400,17 @@ public class DispatchCriteriaHelper {
     */
    public static String buildFromPartsMap(String partsRule, Multimap<String, String> partsMap) {
       // We may have a partsRule for URI_ELEMENT with params parts, ignore this part.
-      if (partsRule.contains("??")) {
+      if (partsRule != null && partsRule.contains("??")) {
          partsRule = partsRule.split("\\?\\?")[0];
+      }
+
+      if (partsRule != null && !partsRule.trim().isEmpty()) {
+         String[] ruleParts = partsRule.split("&&");
+         for (String rulePart : ruleParts) {
+            if (partsMap == null || !partsMap.containsKey(rulePart.trim())) {
+               return null;
+            }
+         }
       }
 
       if (partsMap != null && !partsMap.isEmpty()) {
@@ -417,7 +426,7 @@ public class DispatchCriteriaHelper {
              * the criteria we're looking for (see
              * https://stackoverflow.com/questions/32380375/hyphen-dash-to-be-included-in-regex-word-boundary-b)
              */
-            if (partsRule.matches(".*(^|[^-])\\b" + criteria.getKey() + "\\b([^-]|$).*")) {
+            if (partsRule != null && partsRule.matches(".*(^|[^-])\\b" + criteria.getKey() + "\\b([^-]|$).*")) {
                result.append("/").append(criteria.getKey()).append("=").append(criteria.getValue());
             }
          }
@@ -434,8 +443,9 @@ public class DispatchCriteriaHelper {
     */
    public static String buildFromParamsMap(String paramsRule, Multimap<String, String> paramsMap) {
       // We may have a paramsRule for URI_ELEMENT with path parts, ignore this part.
-      if (paramsRule.contains("??")) {
-         paramsRule = paramsRule.split("\\?\\?")[1];
+      if (paramsRule != null && paramsRule.contains("??")) {
+         String[] rules = paramsRule.split("\\?\\?");
+         paramsRule = rules.length > 1 ? rules[1] : "";
       }
 
       if (paramsMap != null && !paramsMap.isEmpty()) {
@@ -451,7 +461,7 @@ public class DispatchCriteriaHelper {
              * the criteria we're looking for (see
              * https://stackoverflow.com/questions/32380375/hyphen-dash-to-be-included-in-regex-word-boundary-b)
              */
-            if (paramsRule.matches(".*(^|[^-])\\b" + criteria.getKey() + "\\b([^-]|$).*")) {
+            if (paramsRule != null && paramsRule.matches(".*(^|[^-])\\b" + criteria.getKey() + "\\b([^-]|$).*")) {
                result.append("?").append(criteria.getKey()).append("=").append(criteria.getValue());
             }
          }

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -653,10 +653,10 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
          completeRequestWithHeaderParameters(request, headerParametersByExample.get(exampleName));
 
          // Finally, take care about dispatchCriteria and complete operation resourcePaths.
-         completeDispatchCriteriaAndResourcePaths(operation, rootDispatcher, rootDispatcherRules,
-               pathParametersByExample, queryParametersByExample, headerParametersByExample, exampleName, response);
-
-         results.put(request, response);
+         if (completeDispatchCriteriaAndResourcePaths(operation, rootDispatcher, rootDispatcherRules,
+               pathParametersByExample, queryParametersByExample, headerParametersByExample, exampleName, response)) {
+            results.put(request, response);
+         }
       }
 
       return results;
@@ -758,11 +758,11 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                completeRequestWithHeaderParameters(request, headerParametersByExample.get(exampleName));
 
                // Finally, take care about dispatchCriteria and complete operation resourcePaths.
-               completeDispatchCriteriaAndResourcePaths(operation, rootDispatcher, rootDispatcherRules,
+               if (completeDispatchCriteriaAndResourcePaths(operation, rootDispatcher, rootDispatcherRules,
                      pathParametersByExample, queryParametersByExample, headerParametersByExample, exampleName,
-                     response);
-
-               results.put(request, response);
+                     response)) {
+                  results.put(request, response);
+               }
             }
          }
       }
@@ -803,7 +803,7 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
       }
    }
 
-   private void completeDispatchCriteriaAndResourcePaths(Operation operation, String rootDispatcher,
+   private boolean completeDispatchCriteriaAndResourcePaths(Operation operation, String rootDispatcher,
          String rootDispatcherRules, Map<String, Multimap<String, String>> pathParametersByExample,
          Map<String, Multimap<String, String>> queryParametersByExample,
          Map<String, Multimap<String, String>> headerParametersByExample, String exampleName, Response response) {
@@ -813,11 +813,17 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
       if (DispatchStyles.URI_PARAMS.equals(rootDispatcher)) {
          Multimap<String, String> queryParams = queryParametersByExample.get(exampleName);
          dispatchCriteria = DispatchCriteriaHelper.buildFromParamsMap(rootDispatcherRules, queryParams);
+         if (dispatchCriteria == null) {
+            return false;
+         }
          // We only need the pattern here.
          operation.addResourcePath(resourcePathPattern);
       } else if (DispatchStyles.URI_PARTS.equals(rootDispatcher)) {
          Multimap<String, String> parts = pathParametersByExample.get(exampleName);
          dispatchCriteria = DispatchCriteriaHelper.buildFromPartsMap(rootDispatcherRules, parts);
+         if (dispatchCriteria == null) {
+            return false;
+         }
          // We should complete resourcePath here.
          String resourcePath = URIBuilder.buildURIFromPattern(resourcePathPattern, parts);
          operation.addResourcePath(resourcePath);
@@ -825,17 +831,25 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
          Multimap<String, String> parts = pathParametersByExample.get(exampleName);
          Multimap<String, String> queryParams = queryParametersByExample.get(exampleName);
          dispatchCriteria = DispatchCriteriaHelper.buildFromPartsMap(rootDispatcherRules, parts);
-         dispatchCriteria += DispatchCriteriaHelper.buildFromParamsMap(rootDispatcherRules, queryParams);
+         String paramsCriteria = DispatchCriteriaHelper.buildFromParamsMap(rootDispatcherRules, queryParams);
+         if (dispatchCriteria == null || paramsCriteria == null) {
+            return false;
+         }
+         dispatchCriteria += paramsCriteria;
          // We should complete resourcePath here.
          String resourcePath = URIBuilder.buildURIFromPattern(resourcePathPattern, parts);
          operation.addResourcePath(resourcePath);
       } else if (DispatchStyles.QUERY_HEADER.equals(rootDispatcher)) {
          Multimap<String, String> headerParams = headerParametersByExample.get(exampleName);
          dispatchCriteria = DispatchCriteriaHelper.buildFromParamsMap(rootDispatcherRules, headerParams);
+         if (dispatchCriteria == null) {
+            return false;
+         }
          // We only need the pattern here.
          operation.addResourcePath(resourcePathPattern);
       }
       response.setDispatchCriteria(dispatchCriteria);
+      return true;
    }
 
    /**

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
@@ -809,28 +809,7 @@ class OpenAPIImporterTest {
                fail("No exception should be thrown when importing message definitions.");
             }
 
-            // TODO: below should be a failure. We currently detect 1 message as we should have 0
-            // cause car path parameters is missing. We should add a test into URIBuilder.buildFromParamsMap()
-            // to check that we have at least the number of params what we have into uri pattern.
-            //assertEquals(0, messages.size());
-
-            for (Exchange exchange : exchanges) {
-               if (exchange instanceof RequestResponsePair) {
-                  RequestResponsePair entry = (RequestResponsePair) exchange;
-                  Request request = entry.getRequest();
-                  Response response = entry.getResponse();
-                  assertNotNull(request);
-                  assertNotNull(response);
-                  assertEquals("laurent_307_passengers", request.getName());
-                  assertEquals("laurent_307_passengers", response.getName());
-                  assertEquals("/owner=laurent", response.getDispatchCriteria());
-                  assertEquals("200", response.getStatus());
-                  assertEquals("application/json", response.getMediaType());
-                  assertNotNull(response.getContent());
-               } else {
-                  fail("Exchange has the wrong type. Expecting RequestResponsePair");
-               }
-            }
+            assertEquals(0, exchanges.size());
          } else {
             fail("Unknown operation name: " + operation.getName());
          }


### PR DESCRIPTION
## Description
Fixes: #2168
This PR addresses an issue where the OpenAPIImporter was successfully registering mocked endpoints even if the provided example data lacked required path parameters. Previously, the DispatchCriteriaHelper would silently build an incomplete dispatch criteria string when required path parameters were absent, leading to the creation of invalid RequestResponsePair entries.

## Changes Made

- DispatchCriteriaHelper.java: Updated buildFromPartsMap(...) to strictly validate if all variables required by the dispatcherRules are present in the provided parts map. If any required parameter is missing, it now correctly returns null instead of an incomplete string.
- OpenAPIImporter.java: Added a validation check inside completeDispatchCriteriaAndResourcePaths(...). If the helper returns null (indicating missing parameters), the method returns false, signaling the importer to safely skip adding that specific RequestResponsePair to the mocked endpoints.

## Testing & Validation

- Unit Tests Updated: Removed the commented-out workaround in OpenAPIImporterTest.java and enabled the strict assertion assertEquals(0, exchanges.size()); for testUncompleteParamsOpenAPIImportYAML().
- Validation Run: Verified the fix by running the full OpenAPIImporterTest test suite locally (mvn test -pl webapp -Dtest=OpenAPIImporterTest).
- Results: Endpoints missing required path parameters now correctly result in 0 exchanges being created, and no other OpenAPI import functionalities were broken by this strict validation.

