### PR TITLE
fix: skip OpenAPI examples with missing path parameters

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/DispatchCriteriaHelper.java
+++ b/webapp/src/main/java/io/github/microcks/util/DispatchCriteriaHelper.java
@@ -389,7 +389,7 @@ public class DispatchCriteriaHelper {
                (m, e) -> m.put(e.getKey(), e.getValue()), Multimap::putAll);
          return buildFromPartsMap(partsRule, multimap);
       }
-      return "";
+      return hasRequiredCriteria(partsRule, partsMap) ? "" : null;
    }
 
    /**
@@ -399,9 +399,17 @@ public class DispatchCriteriaHelper {
     * @return A string representing dispatch criteria for the corresponding incoming request.
     */
    public static String buildFromPartsMap(String partsRule, Multimap<String, String> partsMap) {
+      if (partsRule == null || partsRule.isBlank()) {
+         return "";
+      }
+
       // We may have a partsRule for URI_ELEMENT with params parts, ignore this part.
       if (partsRule.contains("??")) {
          partsRule = partsRule.split("\\?\\?")[0];
+      }
+
+      if (!hasRequiredCriteria(partsRule, partsMap)) {
+         return null;
       }
 
       if (partsMap != null && !partsMap.isEmpty()) {
@@ -433,9 +441,17 @@ public class DispatchCriteriaHelper {
     * @return A string representing a dispatch criteria for the corresponding incoming request.
     */
    public static String buildFromParamsMap(String paramsRule, Multimap<String, String> paramsMap) {
+      if (paramsRule == null || paramsRule.isBlank()) {
+         return "";
+      }
+
       // We may have a paramsRule for URI_ELEMENT with path parts, ignore this part.
       if (paramsRule.contains("??")) {
          paramsRule = paramsRule.split("\\?\\?")[1];
+      }
+
+      if (!hasRequiredCriteria(paramsRule, paramsMap)) {
+         return null;
       }
 
       if (paramsMap != null && !paramsMap.isEmpty()) {
@@ -458,6 +474,32 @@ public class DispatchCriteriaHelper {
          return result.toString();
       }
       return "";
+   }
+
+   private static boolean hasRequiredCriteria(String criteriaRule, Map<String, String> criteriaMap) {
+      if (criteriaMap != null && !criteriaMap.isEmpty()) {
+         return hasRequiredCriteria(criteriaRule, criteriaMap.keySet());
+      }
+      return extractRequiredCriteriaNames(criteriaRule).isEmpty();
+   }
+
+   private static boolean hasRequiredCriteria(String criteriaRule, Multimap<String, String> criteriaMap) {
+      if (criteriaMap != null && !criteriaMap.isEmpty()) {
+         return hasRequiredCriteria(criteriaRule, criteriaMap.keySet());
+      }
+      return extractRequiredCriteriaNames(criteriaRule).isEmpty();
+   }
+
+   private static boolean hasRequiredCriteria(String criteriaRule, Set<String> criteriaNames) {
+      return criteriaNames.containsAll(extractRequiredCriteriaNames(criteriaRule));
+   }
+
+   private static Set<String> extractRequiredCriteriaNames(String criteriaRule) {
+      if (criteriaRule == null || criteriaRule.isBlank()) {
+         return Set.of();
+      }
+      return Arrays.stream(criteriaRule.split("&&")).map(String::trim).filter(criteria -> !criteria.isEmpty())
+            .collect(Collectors.toSet());
    }
 
    /**

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -653,8 +653,10 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
          completeRequestWithHeaderParameters(request, headerParametersByExample.get(exampleName));
 
          // Finally, take care about dispatchCriteria and complete operation resourcePaths.
-         completeDispatchCriteriaAndResourcePaths(operation, rootDispatcher, rootDispatcherRules,
-               pathParametersByExample, queryParametersByExample, headerParametersByExample, exampleName, response);
+         if (!completeDispatchCriteriaAndResourcePaths(operation, rootDispatcher, rootDispatcherRules,
+               pathParametersByExample, queryParametersByExample, headerParametersByExample, exampleName, response)) {
+            continue;
+         }
 
          results.put(request, response);
       }
@@ -758,9 +760,11 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                completeRequestWithHeaderParameters(request, headerParametersByExample.get(exampleName));
 
                // Finally, take care about dispatchCriteria and complete operation resourcePaths.
-               completeDispatchCriteriaAndResourcePaths(operation, rootDispatcher, rootDispatcherRules,
+               if (!completeDispatchCriteriaAndResourcePaths(operation, rootDispatcher, rootDispatcherRules,
                      pathParametersByExample, queryParametersByExample, headerParametersByExample, exampleName,
-                     response);
+                     response)) {
+                  continue;
+               }
 
                results.put(request, response);
             }
@@ -803,7 +807,7 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
       }
    }
 
-   private void completeDispatchCriteriaAndResourcePaths(Operation operation, String rootDispatcher,
+   private boolean completeDispatchCriteriaAndResourcePaths(Operation operation, String rootDispatcher,
          String rootDispatcherRules, Map<String, Multimap<String, String>> pathParametersByExample,
          Map<String, Multimap<String, String>> queryParametersByExample,
          Map<String, Multimap<String, String>> headerParametersByExample, String exampleName, Response response) {
@@ -813,11 +817,17 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
       if (DispatchStyles.URI_PARAMS.equals(rootDispatcher)) {
          Multimap<String, String> queryParams = queryParametersByExample.get(exampleName);
          dispatchCriteria = DispatchCriteriaHelper.buildFromParamsMap(rootDispatcherRules, queryParams);
+         if (dispatchCriteria == null) {
+            return false;
+         }
          // We only need the pattern here.
          operation.addResourcePath(resourcePathPattern);
       } else if (DispatchStyles.URI_PARTS.equals(rootDispatcher)) {
          Multimap<String, String> parts = pathParametersByExample.get(exampleName);
          dispatchCriteria = DispatchCriteriaHelper.buildFromPartsMap(rootDispatcherRules, parts);
+         if (dispatchCriteria == null) {
+            return false;
+         }
          // We should complete resourcePath here.
          String resourcePath = URIBuilder.buildURIFromPattern(resourcePathPattern, parts);
          operation.addResourcePath(resourcePath);
@@ -825,17 +835,25 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
          Multimap<String, String> parts = pathParametersByExample.get(exampleName);
          Multimap<String, String> queryParams = queryParametersByExample.get(exampleName);
          dispatchCriteria = DispatchCriteriaHelper.buildFromPartsMap(rootDispatcherRules, parts);
-         dispatchCriteria += DispatchCriteriaHelper.buildFromParamsMap(rootDispatcherRules, queryParams);
+         String queryDispatchCriteria = DispatchCriteriaHelper.buildFromParamsMap(rootDispatcherRules, queryParams);
+         if (dispatchCriteria == null || queryDispatchCriteria == null) {
+            return false;
+         }
+         dispatchCriteria += queryDispatchCriteria;
          // We should complete resourcePath here.
          String resourcePath = URIBuilder.buildURIFromPattern(resourcePathPattern, parts);
          operation.addResourcePath(resourcePath);
       } else if (DispatchStyles.QUERY_HEADER.equals(rootDispatcher)) {
          Multimap<String, String> headerParams = headerParametersByExample.get(exampleName);
          dispatchCriteria = DispatchCriteriaHelper.buildFromParamsMap(rootDispatcherRules, headerParams);
+         if (dispatchCriteria == null) {
+            return false;
+         }
          // We only need the pattern here.
          operation.addResourcePath(resourcePathPattern);
       }
       response.setDispatchCriteria(dispatchCriteria);
+      return true;
    }
 
    /**

--- a/webapp/src/test/java/io/github/microcks/util/DispatchCriteriaHelperTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/DispatchCriteriaHelperTest.java
@@ -285,6 +285,10 @@ class DispatchCriteriaHelperTest {
          // 2 parameters should be taken into account according to rules with no inclusion of year.
          dispatchCriteria = DispatchCriteriaHelper.buildFromPartsMap("month && year-summary", partsMap);
          assertEquals("/month=05/year-summary=true", dispatchCriteria);
+
+         // Missing required parameters should invalidate the dispatch criteria.
+         dispatchCriteria = DispatchCriteriaHelper.buildFromPartsMap("month && year && day", partsMap);
+         assertNull(dispatchCriteria);
       }
    }
 
@@ -309,6 +313,10 @@ class DispatchCriteriaHelperTest {
          // 2 parameters should be considered and sorted according to rules with no inclusion of limit.
          dispatchCriteria = DispatchCriteriaHelper.buildFromParamsMap("page && limitation", paramsMap);
          assertEquals("?limitation=20?page=1", dispatchCriteria);
+
+         // Missing required parameters should invalidate the dispatch criteria.
+         dispatchCriteria = DispatchCriteriaHelper.buildFromParamsMap("page && size", paramsMap);
+         assertNull(dispatchCriteria);
       }
 
       @Test

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIImporterTest.java
@@ -808,29 +808,7 @@ class OpenAPIImporterTest {
             } catch (Exception e) {
                fail("No exception should be thrown when importing message definitions.");
             }
-
-            // TODO: below should be a failure. We currently detect 1 message as we should have 0
-            // cause car path parameters is missing. We should add a test into URIBuilder.buildFromParamsMap()
-            // to check that we have at least the number of params what we have into uri pattern.
-            //assertEquals(0, messages.size());
-
-            for (Exchange exchange : exchanges) {
-               if (exchange instanceof RequestResponsePair) {
-                  RequestResponsePair entry = (RequestResponsePair) exchange;
-                  Request request = entry.getRequest();
-                  Response response = entry.getResponse();
-                  assertNotNull(request);
-                  assertNotNull(response);
-                  assertEquals("laurent_307_passengers", request.getName());
-                  assertEquals("laurent_307_passengers", response.getName());
-                  assertEquals("/owner=laurent", response.getDispatchCriteria());
-                  assertEquals("200", response.getStatus());
-                  assertEquals("application/json", response.getMediaType());
-                  assertNotNull(response.getContent());
-               } else {
-                  fail("Exchange has the wrong type. Expecting RequestResponsePair");
-               }
-            }
+            assertEquals(0, exchanges.size());
          } else {
             fail("Unknown operation name: " + operation.getName());
          }


### PR DESCRIPTION
Fixes #2168 ## Summary - Validate that all dispatcher rule parameters are present before building a dispatch criteria string. - buildFromPartsMap and buildFromParamsMap now return null when required variables are missing. - OpenAPIImporter.completeDispatchCriteriaAndResourcePaths returns a boolean and skips registering examples whose dispatch criteria came back null. - Enable the existing regression test testUncompleteParamsOpenAPIImportYAML. - Add two assertNull assertions in DispatchCriteriaHelperTest covering the new null-return paths. ## Tests Tests not run locally — JDK 25 not available on my environment. CI on the PR will verify.