### PR TITLE
fix: preserve null data in mock error responses

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
+++ b/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
@@ -249,17 +249,50 @@ public class GraphQLController {
       // ensures that aliasing applies consistently for both multi and single queries, matching actual
       // GraphQL behavior.
       ObjectNode aggregated = mapper.createObjectNode();
-      ObjectNode dataNode = aggregated.putObject("data");
-      for (GraphQLQueryResponse response : graphqlResponses) {
-         dataNode.set(StringUtils.defaultIfBlank(response.getAlias(), response.getOperationName()),
-               response.getJsonResponse().path("data").path(response.getOperationName()).deepCopy());
+
+      boolean hasDataKey = true;
+      boolean isDataNull = false;
+
+      if (graphqlResponses.size() == 1) {
+         JsonNode responseJson = graphqlResponses.get(0).getJsonResponse();
+         if (responseJson == null) {
+            hasDataKey = false;
+         } else if (!responseJson.has("data")) {
+            hasDataKey = false;
+         } else if (responseJson.get("data").isNull()) {
+            isDataNull = true;
+         }
+      }
+
+      if (hasDataKey) {
+         if (isDataNull) {
+            aggregated.set("data", mapper.nullNode());
+         } else {
+            ObjectNode dataNode = aggregated.putObject("data");
+            for (GraphQLQueryResponse response : graphqlResponses) {
+               JsonNode responseJson = response.getJsonResponse();
+               String key = StringUtils.defaultIfBlank(response.getAlias(), response.getOperationName());
+               if (responseJson == null) {
+                  dataNode.set(key, mapper.nullNode());
+               } else {
+                  JsonNode responseData = responseJson.path("data");
+                  if (responseData.isNull() || responseData.isMissingNode()) {
+                     dataNode.set(key, mapper.nullNode());
+                  } else {
+                     dataNode.set(key, responseData.path(response.getOperationName()).deepCopy());
+                  }
+               }
+            }
+         }
       }
       // Aggregate errors
       ArrayNode errorsNode = mapper.createArrayNode();
       for (GraphQLQueryResponse response : graphqlResponses) {
-         JsonNode errors = response.getJsonResponse().path("errors");
-         if (errors.isArray()) {
-            errors.forEach(errorsNode::add);
+         if (response.getJsonResponse() != null) {
+            JsonNode errors = response.getJsonResponse().path("errors");
+            if (errors.isArray()) {
+               errors.forEach(errorsNode::add);
+            }
          }
       }
       if (!errorsNode.isEmpty()) {
@@ -269,9 +302,11 @@ public class GraphQLController {
       // Aggregate extensions
       ObjectNode extensionsNode = mapper.createObjectNode();
       for (GraphQLQueryResponse response : graphqlResponses) {
-         JsonNode extensions = response.getJsonResponse().path("extensions");
-         if (extensions.isObject()) {
-            extensions.properties().forEach(e -> extensionsNode.set(e.getKey(), e.getValue().deepCopy()));
+         if (response.getJsonResponse() != null) {
+            JsonNode extensions = response.getJsonResponse().path("extensions");
+            if (extensions.isObject()) {
+               extensions.properties().forEach(e -> extensionsNode.set(e.getKey(), e.getValue().deepCopy()));
+            }
          }
       }
       if (!extensionsNode.isEmpty()) {
@@ -362,8 +397,11 @@ public class GraphQLController {
          if (responseResult.content() != null) {
             try {
                JsonNode responseJson = mapper.readTree(responseResult.content());
-               filterFieldSelection(graphqlField.getSelectionSet(), fragmentDefinitions,
-                     responseJson.get("data").get(operationName));
+               JsonNode dataNode = responseJson.get("data");
+               if (dataNode != null && !dataNode.isNull()) {
+                  filterFieldSelection(graphqlField.getSelectionSet(), fragmentDefinitions,
+                        dataNode.get(operationName));
+               }
                result.setJsonResponse(responseJson);
             } catch (Exception pe) {
                log.error("Exception while filtering response according GraphQL field selection", pe);
@@ -404,6 +442,9 @@ public class GraphQLController {
     */
    protected void filterFieldSelection(SelectionSet selectionSet, List<FragmentDefinition> fragmentDefinitions,
          JsonNode node) {
+      if (node == null || node.isNull() || node.isMissingNode()) {
+         return;
+      }
       // Stop condition: no more selection to apply.
       if (selectionSet == null || selectionSet.getSelections() == null || selectionSet.getSelections().isEmpty()) {
          return;

--- a/webapp/src/test/java/io/github/microcks/util/postman/PostmanCollectionImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/postman/PostmanCollectionImporterTest.java
@@ -651,7 +651,7 @@ class PostmanCollectionImporterTest {
             } catch (Exception e) {
                fail("No exception should be thrown when importing message definitions.");
             }
-            assertEquals(2, exchanges.size());
+            assertEquals(5, exchanges.size());
 
             for (Exchange exchange : exchanges) {
                assertTrue(exchange instanceof RequestResponsePair);
@@ -659,7 +659,10 @@ class PostmanCollectionImporterTest {
 
                assertNotNull(pair.getRequest().getContent());
                assertTrue(pair.getRequest().getContent().contains("\"id\": \"ZmlsbXM6MQ==\"")
-                     || pair.getRequest().getContent().contains("\"id\": \"ZmlsbXM6Mg==\""));
+                     || pair.getRequest().getContent().contains("\"id\": \"ZmlsbXM6Mg==\"")
+                     || pair.getRequest().getContent().contains("\"id\": \"ZmlsbXM6OTk=\"")
+                     || pair.getRequest().getContent().contains("\"id\": \"ZmlsbXM6OTg=\"")
+                     || pair.getRequest().getContent().contains("\"id\": \"ZmlsbXM6OTc=\""));
                assertNotNull(pair.getResponse().getContent());
                assertEquals("200", pair.getResponse().getStatus());
             }

--- a/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
@@ -18,6 +18,8 @@ package io.github.microcks.web;
 import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.Customization;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -249,5 +251,67 @@ class GraphQLControllerIT extends AbstractBaseIT {
             {"query": "query film($id: String) {film(id: \\"ZmlsbXM6MA==\\") {id title episodeID starCount comment}}"}""";
       response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertResponseIsOkAndContains(response, "\"comment\":\"Original!!!\"");
+   }
+
+   @Test
+   void testGraphQLErrorAPIMocking() {
+      // Upload the 2 required reference artifacts.
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/graphql/films.graphql", true);
+      uploadArtifactFile("target/test-classes/io/github/microcks/util/graphql/films-postman.json", false);
+
+      ObjectMapper mapper = new ObjectMapper();
+
+      // 1. Check mock response with "data": null and "errors" array
+      String query = "{\"query\": \"query film($id: String) {\\n  film(id: \\\"ZmlsbXM6OTk=\\\") {\\n    id\\n    title\\n  }\\n}\"}";
+      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatusCode().value());
+      try {
+         JsonNode responseJson = mapper.readTree(response.getBody());
+         assertTrue(responseJson.has("data"), "Response should contain 'data' key");
+         assertTrue(responseJson.get("data").isNull(), "Response 'data' should be null");
+         assertTrue(responseJson.has("errors"), "Response should contain 'errors' key");
+
+         JSONAssert.assertEquals("{\n" + "  \"data\": null,\n" + "  \"errors\": [\n" + "    {\n"
+               + "      \"message\": \"Film not found\",\n" + "      \"path\": [\"film\"]\n" + "    }\n" + "  ]\n"
+               + "}", response.getBody(), JSONCompareMode.STRICT);
+      } catch (Exception e) {
+         fail("No Exception should be thrown here");
+      }
+
+      // 2. Check mock response with absent "data" key and "errors" array
+      query = "{\"query\": \"query film($id: String) {\\n  film(id: \\\"ZmlsbXM6OTg=\\\") {\\n    id\\n    title\\n  }\\n}\"}";
+      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatusCode().value());
+      try {
+         JsonNode responseJson = mapper.readTree(response.getBody());
+         assertFalse(responseJson.has("data"), "Response should not contain 'data' key");
+         assertTrue(responseJson.has("errors"), "Response should contain 'errors' key");
+
+         JSONAssert.assertEquals(
+               "{\n" + "  \"errors\": [\n" + "    {\n" + "      \"message\": \"Access Denied\",\n"
+                     + "      \"path\": [\"film\"]\n" + "    }\n" + "  ]\n" + "}",
+               response.getBody(), JSONCompareMode.STRICT);
+      } catch (Exception e) {
+         fail("No Exception should be thrown here");
+      }
+
+      // 3. Check mock response with "data": {"film": null} and "errors" array
+      query = "{\"query\": \"query film($id: String) {\\n  film(id: \\\"ZmlsbXM6OTc=\\\") {\\n    id\\n    title\\n  }\\n}\"}";
+      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatusCode().value());
+      try {
+         JsonNode responseJson = mapper.readTree(response.getBody());
+         assertTrue(responseJson.has("data"), "Response should contain 'data' key");
+         assertFalse(responseJson.get("data").isNull(), "Response 'data' should not be null");
+         assertTrue(responseJson.get("data").has("film"), "Response 'data' should contain 'film' key");
+         assertTrue(responseJson.get("data").get("film").isNull(), "Response 'data.film' should be null");
+         assertTrue(responseJson.has("errors"), "Response should contain 'errors' key");
+
+         JSONAssert.assertEquals("{\n" + "  \"data\": {\n" + "    \"film\": null\n" + "  },\n" + "  \"errors\": [\n"
+               + "    {\n" + "      \"message\": \"Partial error\",\n" + "      \"path\": [\"film\"]\n" + "    }\n"
+               + "  ]\n" + "}", response.getBody(), JSONCompareMode.STRICT);
+      } catch (Exception e) {
+         fail("No Exception should be thrown here");
+      }
    }
 }

--- a/webapp/src/test/resources/io/github/microcks/util/graphql/films-postman.json
+++ b/webapp/src/test/resources/io/github/microcks/util/graphql/films-postman.json
@@ -129,7 +129,85 @@
 							"_postman_previewlanguage": "json",
 							"header": null,
 							"cookie": [],
-							"body": "{\n    \"data\": {\n        \"film\": {\n            \"id\": \"ZmlsbXM6Mg==\",\n            \"title\": \"The Empire Strikes Back\",\n            \"episodeID\": 5,\n            \"director\": \"Irvin Kershner\",\n            \"starCount\": 433,\n            \"rating\": 4.3\n        }\n    }\n}"
+							"body": "{\"data\": {\"film\": {\"id\": \"ZmlsbXM6Mg==\", \"title\": \"The Empire Strikes Back\", \"episodeID\": 5, \"director\": \"Irvin Kershner\", \"starCount\": 433, \"rating\": 4.3}}}"
+						},
+						{
+							"name": "film ZmlsbXM6OTk=",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "query film ($id: String) {\n    film (id: $id) {\n        id\n        title\n        episodeID\n        director\n        starCount\n        rating\n    }\n}",
+										"variables": "{\n  \"id\": \"ZmlsbXM6OTk=\"\n}"
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": null,
+							"cookie": [],
+							"body": "{\n    \"data\": null,\n    \"errors\": [\n        {\n            \"message\": \"Film not found\",\n            \"path\": [\n                \"film\"\n            ]\n        }\n    ]\n}"
+						},
+						{
+							"name": "film ZmlsbXM6OTg=",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "query film ($id: String) {\n    film (id: $id) {\n        id\n        title\n        episodeID\n        director\n        starCount\n        rating\n    }\n}",
+										"variables": "{\n  \"id\": \"ZmlsbXM6OTg=\"\n}"
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": null,
+							"cookie": [],
+							"body": "{\n    \"errors\": [\n        {\n            \"message\": \"Access Denied\",\n            \"path\": [\n                \"film\"\n            ]\n        }\n    ]\n}"
+						},
+						{
+							"name": "film ZmlsbXM6OTc=",
+							"originalRequest": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "graphql",
+									"graphql": {
+										"query": "query film ($id: String) {\n    film (id: $id) {\n        id\n        title\n        episodeID\n        director\n        starCount\n        rating\n    }\n}",
+										"variables": "{\n  \"id\": \"ZmlsbXM6OTc=\"\n}"
+									}
+								},
+								"url": {
+									"raw": "{{url}}",
+									"host": [
+										"{{url}}"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": null,
+							"cookie": [],
+							"body": "{\n    \"data\": {\n        \"film\": null\n    },\n    \"errors\": [\n        {\n            \"message\": \"Partial error\",\n            \"path\": [\n                \"film\"\n            ]\n        }\n    ]\n}"
 						}
 					]
 				}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Handle GraphQL mock responses with null or missing data fields without failing.
- Preserve GraphQL error payloads when aggregating mock responses.
- Add integration tests for GraphQL error response scenarios.

### Related issue

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->
Fixes #2176 