### PR TITLE
fix: replace break with continue in getNoContentRequestResponsePair()

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java
@@ -737,7 +737,7 @@ public class OpenAPIImporter extends AbstractJsonRepositoryImporter implements M
                      || DispatchStyles.URI_ELEMENTS.equals(operation.getDispatcher())) {
                   // We must have at least one path parameters but none!
                   // Do not register this request / response pair.
-                  break;
+                  continue;
                }
 
                // We should have everything at hand to build response here.


### PR DESCRIPTION
Description:

Fixes #2188

In `getNoContentRequestResponsePair()`, when an example from `x-microcks-refs` 
is missing path parameters for a `URI_PARTS` or `URI_ELEMENTS` dispatcher, the 
previous `break` exited the entire `requestRefsIterator` loop  silently dropping 
all remaining valid examples after the incomplete one.

The intent is clearly to skip only the current example (the comment says 
*"Do not register **this** request / response pair"*). `continue` is the correct 
statement.

Note: the equivalent block in the sibling method already uses `continue` correctly 
(line 647)  this brings `getNoContentRequestResponsePair()` into the same pattern.

Change

`webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIImporter.java` line 740:  
`break` - `continue`