### PR TITLE
fix: handle keyed AsyncAPI 3 examples

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
@@ -479,7 +479,7 @@ public class ProducerManager {
 
    /** Get the event messages that are not contextualized with request or response part. */
    private List<EventMessage> getPureEventMessages(AsyncMockDefinition definition) {
-      return definition.getEventMessages().stream()
+      return definition.getEventMessages().stream().filter(eventMessage -> eventMessage.getContent() != null)
             .filter(eventMessage -> !eventMessage.getContent().contains("request.")
                   && !eventMessage.getContent().contains("response."))
             .toList();
@@ -487,7 +487,7 @@ public class ProducerManager {
 
    /** Get the event messages that are contextualized with request or response part. */
    private List<EventMessage> getContextualizedMessages(AsyncMockDefinition definition) {
-      return definition.getEventMessages().stream()
+      return definition.getEventMessages().stream().filter(eventMessage -> eventMessage.getContent() != null)
             .filter(eventMessage -> eventMessage.getContent().contains("request.")
                   || eventMessage.getContent().contains("response."))
             .toList();
@@ -496,7 +496,7 @@ public class ProducerManager {
    /** Render event message content from definition applying template rendering if required. */
    private String renderEventMessageContent(EventMessage eventMessage) {
       String content = eventMessage.getContent();
-      if (content.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
+      if (content != null && content.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
          logger.debug("EventMessage contains dynamic EL expression, rendering it...");
          TemplateEngine engine = TemplateEngineFactory.getTemplateEngine();
 
@@ -512,7 +512,7 @@ public class ProducerManager {
    private String renderEventMessageContent(EventMessage eventMessage, RequestSnapshot request,
          ResponseSnapshot response) {
       String content = eventMessage.getContent();
-      if (content.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
+      if (content != null && content.contains(TemplateEngine.DEFAULT_EXPRESSION_PREFIX)) {
          logger.debug("EventMessage contains dynamic EL expression, rendering it...");
          TemplateEngine engine = TemplateEngineFactory.getTemplateEngine();
 

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/ProducerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/ProducerManagerTest.java
@@ -368,6 +368,29 @@ class ProducerManagerTest {
       verifyNoInteractions(natsProducerManager);
    }
 
+   @Test
+   void testProduceAsyncMockMessagesAt_ignoresNullContentMessages() {
+      Service service = new Service();
+      service.setId("svc-null");
+      service.setName("TestService");
+      service.setVersion("1.0.0");
+
+      Operation operation = new Operation();
+      operation.setName("event-op");
+      operation.setBindings(Map.of("KAFKA", new Binding(BindingType.KAFKA)));
+      service.addOperation(operation);
+
+      EventMessage nullContentMessage = new EventMessage();
+      nullContentMessage.setName("NullContent");
+      nullContentMessage.setMediaType("application/json");
+
+      AsyncMockDefinition definition = new AsyncMockDefinition(service, operation, List.of(nullContentMessage));
+      when(mockRepository.getMockDefinitionsByFrequency(10L)).thenReturn(Set.of(definition));
+
+      assertDoesNotThrow(() -> producerManager.produceAsyncMockMessagesAt(10L));
+      verifyNoInteractions(kafkaProducerManager);
+   }
+
    // -----------------------------------------------------------------------
    // Tests for template rendering (renderEventMessageContent)
    // -----------------------------------------------------------------------

--- a/webapp/src/main/java/io/github/microcks/util/asyncapi/AsyncAPI3Importer.java
+++ b/webapp/src/main/java/io/github/microcks/util/asyncapi/AsyncAPI3Importer.java
@@ -452,20 +452,24 @@ public class AsyncAPI3Importer extends AbstractJsonRepositoryImporter implements
       Iterator<JsonNode> examples = examplesNode.elements();
       while (examples.hasNext()) {
          JsonNode exampleNode = examples.next();
+         String keyedExampleName = getKeyedExampleName(exampleNode);
+         JsonNode example = getExampleNode(exampleNode);
 
          EventMessage eventMessage = new EventMessage();
          // Use name attribute if present, otherwise generate from message name.
-         if (exampleNode.has("name")) {
-            eventMessage.setName(exampleNode.get("name").asText());
+         if (example.has("name")) {
+            eventMessage.setName(example.get("name").asText());
+         } else if (keyedExampleName != null) {
+            eventMessage.setName(keyedExampleName);
          } else {
             eventMessage.setName(messageName + "-" + (exchanges.size() + 1));
          }
 
          eventMessage.setMediaType(contentType);
-         eventMessage.setContent(getExamplePayload(exampleNode));
+         eventMessage.setContent(getExamplePayload(example));
 
          // Now complete with specified headers.
-         List<Header> headers = AsyncAPICommons.getExampleHeaders(exampleNode);
+         List<Header> headers = AsyncAPICommons.getExampleHeaders(example);
          for (Header header : headers) {
             eventMessage.addHeader(header);
          }
@@ -473,6 +477,28 @@ public class AsyncAPI3Importer extends AbstractJsonRepositoryImporter implements
          exchanges.add(eventMessage);
       }
       return exchanges;
+   }
+
+   /** Get the example key when using the map-style examples notation. */
+   private String getKeyedExampleName(JsonNode example) {
+      if (!isKeyedExample(example)) {
+         return null;
+      }
+      return example.fieldNames().next();
+   }
+
+   /** Get the actual example node, unwrapping the map-style examples notation if necessary. */
+   private JsonNode getExampleNode(JsonNode example) {
+      if (!isKeyedExample(example)) {
+         return example;
+      }
+      return example.fields().next().getValue();
+   }
+
+   /** Check if an example uses the map-style notation: {@code - exampleName: { payload: ... }}. */
+   private boolean isKeyedExample(JsonNode example) {
+      return example.isObject() && example.size() == 1 && !example.has("name") && !example.has(EXAMPLE_PAYLOAD_NODE)
+            && !example.has("$payloadRef");
    }
 
    /**

--- a/webapp/src/test/java/io/github/microcks/util/asyncapi/AsyncAPI3ImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/asyncapi/AsyncAPI3ImporterTest.java
@@ -81,6 +81,33 @@ class AsyncAPI3ImporterTest {
    }
 
    @Test
+   void testKeyedExamplesAsyncAPI3ImportYAML() {
+      AsyncAPI3Importer importer = null;
+      try {
+         importer = new AsyncAPI3Importer(
+               "target/test-classes/io/github/microcks/util/asyncapi/user-signedup-asyncapi-3.0-keyed-examples.yaml",
+               null);
+      } catch (IOException ioe) {
+         Assertions.fail("Exception should not be thrown");
+      }
+
+      List<Service> services = null;
+      try {
+         services = importer.getServiceDefinitions();
+      } catch (MockRepositoryImportException e) {
+         Assertions.fail("Exception should not be thrown");
+      }
+
+      Assertions.assertEquals(1, services.size());
+      Service service = services.get(0);
+      Assertions.assertEquals("User signed-up API", service.getName());
+      Assertions.assertEquals(ServiceType.EVENT, service.getType());
+      Assertions.assertEquals("0.3.0", service.getVersion());
+
+      importAndAssertOnSimpleAsyncAPI(service, importer, "application/json");
+   }
+
+   @Test
    void testSimpleNamelessAsyncAPI3ImportYAML() {
       AsyncAPI3Importer importer = null;
       try {

--- a/webapp/src/test/resources/io/github/microcks/util/asyncapi/user-signedup-asyncapi-3.0-keyed-examples.yaml
+++ b/webapp/src/test/resources/io/github/microcks/util/asyncapi/user-signedup-asyncapi-3.0-keyed-examples.yaml
@@ -1,0 +1,55 @@
+asyncapi: 3.0.0
+id: 'urn:io.microcks.example.user-signedup'
+info:
+  title: User signed-up API
+  version: 0.3.0
+  description: Sample AsyncAPI for user signedup events
+defaultContentType: application/json
+channels:
+  user-signedup:
+    description: The topic on which user signed up events may be consumed
+    messages:
+      userSignedUp:
+        $ref: '#/components/messages/userSignedUp'
+operations:
+  publishUserSignedUps:
+    action: 'send'
+    channel:
+      $ref: '#/channels/user-signedup'
+    messages:
+      - $ref: '#/channels/user-signedup/messages/userSignedUp'
+components:
+  messages:
+    userSignedUp:
+      description: An event describing that a user just signed up
+      payload:
+        type: object
+        additionalProperties: false
+        properties:
+          fullName:
+            type: string
+          email:
+            type: string
+            format: email
+          age:
+            type: integer
+            minimum: 18
+      examples:
+        - laurent:
+            summary: Example for Laurent user
+            headers:
+              my-app-header: 23
+              sentAt: "2020-03-11T08:03:28Z"
+            payload:
+              fullName: Laurent Broudoux
+              email: "laurent@microcks.io"
+              age: 41
+        - john:
+            summary: Example for John Doe user
+            headers:
+              my-app-header: 24
+              sentAt: "2020-03-11T08:03:38Z"
+            payload:
+              fullName: John Doe
+              email: john@microcks.io
+              age: 36


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Added support for keyed/map-style AsyncAPI 3 examples, such as `- myExample: { payload: ... }`, when importing event messages.
- Reused the keyed example name as the imported `EventMessage` name and unwrapped the nested example before reading payload and headers.
- Hardened async producer message filtering/rendering to avoid NPEs when an `EventMessage` has null content.
- Added regression tests for keyed AsyncAPI 3 examples and null-content event messages.

### Related issue(s)

Fixes #2045