### PR TITLE
fix: gRPC server shutdown hang

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/grpc/GrpcServerStarter.java
+++ b/webapp/src/main/java/io/github/microcks/util/grpc/GrpcServerStarter.java
@@ -145,6 +145,8 @@ public class GrpcServerStarter {
                } catch (InterruptedException e) {
                   log.error("GRPC Server shutdown interrupted", e);
                   Thread.currentThread().interrupt();
+               } finally {
+                  latch.countDown();
                }
             }
          });


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Added a finally block in the JVM shutdown hook to count down the CountDownLatch (latch), ensuring the grpc-server-awaiter thread is unblocked and completes.


<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->