### PR TITLE
fix: #2199 GraphQL 500 when fragment definitions precede the operation

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
+++ b/webapp/src/main/java/io/github/microcks/web/GraphQLController.java
@@ -36,7 +36,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.language.Argument;
-import graphql.language.Definition;
 import graphql.language.Document;
 import graphql.language.Field;
 import graphql.language.FragmentDefinition;
@@ -149,17 +148,31 @@ public class GraphQLController {
          return new ResponseEntity<>("Error parsing GraphQL request: " + e.getMessage(), HttpStatus.BAD_REQUEST);
       }
 
-      Definition<?> graphqlDef = graphqlRequest.getDefinitions().get(0);
-      OperationDefinition graphqlOperation = (OperationDefinition) graphqlDef;
+      // GraphQL clients (Apollo, urql, Relay...) emit fragment definitions before the operation, so the
+      // operation cannot be assumed to be the first definition of the document. Select it explicitly -
+      // by name when the request carries an operationName, otherwise the first operation found.
+      List<OperationDefinition> operationDefinitions = graphqlRequest.getDefinitionsOfType(OperationDefinition.class);
+      String requestedOperationName = graphqlHttpReq.getOperationName();
+      OperationDefinition graphqlOperation = operationDefinitions.stream().filter(op -> requestedOperationName == null
+            || requestedOperationName.isEmpty() || requestedOperationName.equals(op.getName())).findFirst()
+            .orElse(null);
+
+      if (graphqlOperation == null) {
+         log.error("No matching operation definition found in GraphQL request");
+         return new ResponseEntity<>("No matching operation definition found in GraphQL request",
+               HttpStatus.BAD_REQUEST);
+      }
 
       log.debug("Got this graphqlOperation: {}", graphqlOperation);
 
       // Operation type is direct but name depends on syntax (it can be a composite one). Better to use the names of selections...
       String operationType = graphqlOperation.getOperation().toString();
 
-      // Check is it's an introspection query to handle first.
-      if ("QUERY".equals(operationType) && INTROSPECTION_SELECTION
-            .equals(((Field) graphqlOperation.getSelectionSet().getSelections().get(0)).getName())) {
+      // Check is it's an introspection query to handle first. The first selection may be a fragment spread
+      // rather than a Field, so guard the cast.
+      Selection<?> firstSelection = graphqlOperation.getSelectionSet().getSelections().get(0);
+      if ("QUERY".equals(operationType) && firstSelection instanceof Field firstField
+            && INTROSPECTION_SELECTION.equals(firstField.getName())) {
          log.info("Handling GraphQL schema introspection query...");
          Resource graphqlSchema = resourceRepository
                .findByServiceIdAndType(service.getId(), ResourceType.GRAPHQL_SCHEMA).get(0);
@@ -188,11 +201,13 @@ public class GraphQLController {
       Long maxDelay = specifiedDelay == null ? 0L : specifiedDelay.baseValue();
       String maxDelayStrategy = specifiedDelay == null ? null : specifiedDelay.strategyName();
 
-      for (Selection<?> selection : graphqlOperation.getSelectionSet().getSelections()) {
+      // A top-level selection may itself be a fragment spread, so flatten spreads into their fields before
+      // processing each queried field.
+      List<FragmentDefinition> fragmentDefinitions = graphqlRequest.getDefinitionsOfType(FragmentDefinition.class);
+      for (Field selection : collectFields(graphqlOperation.getSelectionSet(), fragmentDefinitions)) {
          try {
-            GraphQLQueryResponse graphqlResponse = processGraphQLQuery(service, operationType, (Field) selection,
-                  graphqlRequest.getDefinitionsOfType(FragmentDefinition.class), body, graphqlHttpReq, headers,
-                  request);
+            GraphQLQueryResponse graphqlResponse = processGraphQLQuery(service, operationType, selection,
+                  fragmentDefinitions, body, graphqlHttpReq, headers, request);
 
             //            if (graphqlResponse.getProxyUrl() != null) {
             //               // If we've got a proxyUrl, that's the moment!

--- a/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
@@ -206,6 +206,38 @@ class GraphQLControllerIT extends AbstractBaseIT {
          fail("No Exception should be thrown here");
       }
 
+      // Check query with fragment definitions declared before the operation (Apollo/urql/Relay ordering, #2199).
+      subQuery = """
+            fragment filmFields on Film {
+              id
+              title
+              episodeID
+              starCount
+            }
+            query film($id: String) {
+              film(id: "ZmlsbXM6MQ==") {
+                ...filmFields
+              }
+            }""";
+      query = mapper.createObjectNode().put("query", subQuery).toString();
+      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      assertEquals(200, response.getStatusCode().value());
+      try {
+         JSONAssert.assertEquals("""
+               {
+                 "data": {
+                   "film": {
+                     "id": "ZmlsbXM6MQ==",
+                     "title": "A New Hope",
+                     "episodeID": 4,
+                     "starCount": 432
+                   }
+                 }
+               }""", response.getBody(), JSONCompareMode.LENIENT);
+      } catch (Exception e) {
+         fail("No Exception should be thrown here");
+      }
+
       // Check query with multiple selection and aliases
       subQuery = """
             {


### PR DESCRIPTION
### Fixes #2199

## Problem

GraphQL clients (Apollo, urql, Relay) emit **fragment definitions before the operation** in the query document. `GraphQLController` assumed the operation is the first definition and blindly cast `getDefinitions().get(0)` to `OperationDefinition`, so any real client query using named fragment spreads throws:

```
java.lang.ClassCastException: class graphql.language.FragmentDefinition
cannot be cast to class graphql.language.OperationDefinition
    at io.github.microcks.web.GraphQLController.execute(...)
```

This is a different code path from the one fixed in #2201 (ab184ed) — that change hardened field *retention* in `filterFieldSelection`, but `execute()` throws before ever reaching it, so the 500 remains for real-world queries.

## Reproduction

Same query, only the definition order differs:

| Variant | Result |
|---|---|
| Named fragment spreads, **fragments defined first** (Apollo's native output) | **HTTP 500** |
| Same query, **operation moved before the fragments** | **HTTP 200** |
| Same query, fragments inlined (`... on Type {}`) | HTTP 200 |

Reordering the operation to the front makes the identical named-fragment query succeed, confirming the failure is the `get(0)` cast rather than the spreads themselves.

## Fix

- Select the operation via `getDefinitionsOfType(OperationDefinition.class)`, honoring the request `operationName` when present (mirrors the existing `getDefinitionsOfType(FragmentDefinition.class)` call just below).
- Harden two sibling casts that assumed a top-level selection is always a `Field`: guard the introspection check with `instanceof`, and flatten top-level fragment spreads via `collectFields()` before processing each queried field.

## Test

Adds a `GraphQLControllerIT` case asserting a query whose `fragment` definition precedes the operation returns 200 (verified failing before the change, passing after).
