### PR TITLE
feat: Support Workload Identity (ADC) for Google Pub/Sub authentication

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/consumer/GooglePubSubMessageConsumptionTask.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/consumer/GooglePubSubMessageConsumptionTask.java
@@ -178,7 +178,15 @@ public class GooglePubSubMessageConsumptionTask implements MessageConsumptionTas
          credentialsProvider = FixedCredentialsProvider
                .create(GoogleCredentials.fromStream(is).createScoped(CLOUD_OAUTH_SCOPE));
       } else {
-         credentialsProvider = NoCredentialsProvider.create();
+         // No explicit JSON key provided: try Application Default Credentials so that
+         // GKE Workload Identity (or any other ADC source) can be used transparently.
+         try {
+            credentialsProvider = FixedCredentialsProvider
+                  .create(GoogleCredentials.getApplicationDefault().createScoped(CLOUD_OAUTH_SCOPE));
+         } catch (IOException ioe) {
+            logger.debug("No Application Default Credentials found, falling back to no credentials", ioe);
+            credentialsProvider = NoCredentialsProvider.create();
+         }
       }
 
       // Ensure connection is possible and subscription exists.

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/GooglePubSubProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/GooglePubSubProducerManager.java
@@ -112,7 +112,15 @@ public class GooglePubSubProducerManager {
             credentialsProvider = FixedCredentialsProvider
                   .create(GoogleCredentials.fromStream(is).createScoped(CLOUD_OAUTH_SCOPE));
          } else {
-            credentialsProvider = NoCredentialsProvider.create();
+            // No explicit JSON key provided: try Application Default Credentials so that
+            // GKE Workload Identity (or any other ADC source) can be used transparently.
+            try {
+               credentialsProvider = FixedCredentialsProvider
+                     .create(GoogleCredentials.getApplicationDefault().createScoped(CLOUD_OAUTH_SCOPE));
+            } catch (IOException ioe) {
+               logger.debug("No Application Default Credentials found, falling back to no credentials", ioe);
+               credentialsProvider = NoCredentialsProvider.create();
+            }
          }
       } catch (Exception e) {
          logger.errorf("Cannot read Google Cloud credentials %s", serviceAccountLocation);


### PR DESCRIPTION
Closes #2120

Adds support for GKE Workload Identity / Application Default Credentials
(ADC) as an authentication option for Google Pub/Sub, in both the async
minion's producer (mocking) and consumer (test) paths.

Previously, if no service-account JSON key was configured, the code
fell back straight to NoCredentialsProvider, which only works against
the local emulator and fails against real GCP Pub/Sub.

Now it first attempts GoogleCredentials.getApplicationDefault(), which
transparently picks up Workload Identity credentials on GKE (or any
other ADC source), and only falls back to NoCredentialsProvider if
that also fails — preserving existing behavior for local/dev setups.

This is non-breaking: existing JSON-key-based configuration is
unaffected and still takes priority when present.