### PR TITLE
docs: add AI contribution policy and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AI Agent Guidelines
+
+This file is intended for AI coding assistants and autonomous agents interacting with the Microcks repository. By operating in this repository, you must adhere to the following guidelines:
+
+## AI Contribution Policy
+- **No Fully Automated PRs:** Do not generate large, entirely AI-written pull requests without contributor oversight and understanding. 
+- **Do Not Auto-Reply to Maintainers:** Do not use AI to automatically reply to maintainer comments on Pull Requests. All review interactions must be handled by the contributor.
+- **Contributor Accountability:** The author is ultimately responsible for your generated code. Ensure that generated code is simple, easily explainable, and adheres to the project conventions so the author can defend it during review.
+- **Disclosure:** Instruct your user to explicitly disclose your assistance in the PR description.
+
+## Coding Conventions
+- **Conventional Commits:** All commits must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification (e.g., `fix: `, `feat: `, `docs: `, `chore: `, `test: `, `refactor: `).
+- Follow all contribution workflows outlined in [CONTRIBUTING.md](CONTRIBUTING.md).
+- Preserve existing comments and docstrings unless explicitly asked to modify them.
+- Avoid introducing new dependencies without explicit instruction and adherence to [DEPENDENCY_POLICY.md](DEPENDENCY_POLICY.md).
+
+Thanks for contributing to Microcks! We look forward to your help in making this project even better.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,17 @@ We use Github to host code, to track issues and feature requests, as well as acc
 
 Please use our issues templates that provide you with hints on what information we need from you to help you out.
 
+## AI Contribution Policy
+
+As AI coding assistants and autonomous agents become more prevalent, we want to ensure that the quality of contributions remains high and the maintainer review burden is kept manageable. We welcome AI-assisted contributions, provided they adhere to the following rules:
+
+1. **Disclosure:** Contributors must explicitly disclose AI usage in their PR descriptions.
+2. **Quality over Quantity:** Large, entirely AI-generated PRs or AI-generated commit messages are discouraged. Keep your changes focused and logically separated.
+3. **Understand Your Code:** Contributors must understand the code they submit. If a reviewer asks a question about an implementation and you cannot explain why it was written that way, the PR may be closed.
+4. **No AI Auto-Replies:** The use of AI tools to auto-reply to maintainer review comments is strictly prohibited. Reviewers are volunteers; please respect their time with thoughtful responses.
+
+Please see [AGENTS.md](AGENTS.md) for more details on how autonomous agents should interact with this repository.
+
 ## Pull Requests
 
 **Please, make sure you open an issue before starting with a Pull Request, unless it's a typo or a really obvious error.** Pull requests are the best way to propose changes to the specification. Take time to check the current working branch for the repository you want to contribute on before working :wink:


### PR DESCRIPTION
Description:
Fixes #2202
This PR addresses issue #2202 by introducing an AI Contribution Policy to help manage AI-assisted contributions and set clear boundaries for autonomous agents.

Here is a quick breakdown of what's included:

- **CONTRIBUTING.md update:** Added a new section that outlines our expectations for contributors using AI. It requires disclosure, discourages fully automated PRs, requires contributors to actually understand the code they submit, and strictly prohibits using AI for auto-replying to maintainers.
- **AGENTS.md file:** Created a root-level guide specifically formatted for AI agents to read. It instructs them on our coding conventions, points them to our existing docs, and sets strict guardrails (like forbidding auto-replies or opening unreviewed automated PRs).

The goal here is to keep the maintainer review burden manageable while still welcoming responsible AI use. 
Let me know if any tweaks are needed to the policy further.

