### PR TITLE
feat: show error feedback in UI on early test failure

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/TestResult.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/TestResult.java
@@ -47,6 +47,7 @@ public class TestResult {
    private TestRunnerType runnerType;
    private OperationsHeaders operationsHeaders;
    private OAuth2AuthorizedClient authorizedClient;
+   private String runnerMessage;
 
    private List<TestCaseResult> testCaseResults = new ArrayList<>();
 
@@ -168,5 +169,13 @@ public class TestResult {
 
    public void setAuthorizedClient(OAuth2AuthorizedClient authorizedClient) {
       this.authorizedClient = authorizedClient;
+   }
+
+   public String getRunnerMessage() {
+      return runnerMessage;
+   }
+
+   public void setRunnerMessage(String runnerMessage) {
+      this.runnerMessage = runnerMessage;
    }
 }

--- a/webapp/src/main/java/io/github/microcks/service/TestRunnerService.java
+++ b/webapp/src/main/java/io/github/microcks/service/TestRunnerService.java
@@ -179,6 +179,7 @@ public class TestRunnerService {
             testResult.setSuccess(false);
             testResult.setInProgress(false);
             testResult.setElapsedTime(0);
+            testResult.setRunnerMessage("OAuth2 token flow failed: " + authorizationException.getMessage());
             testResultRepository.save(testResult);
             return CompletableFuture.completedFuture(testResult);
          }
@@ -192,6 +193,7 @@ public class TestRunnerService {
          testResult.setSuccess(false);
          testResult.setInProgress(false);
          testResult.setElapsedTime(0);
+         testResult.setRunnerMessage("Could not retrieve runner for " + runnerType);
          testResultRepository.save(testResult);
          return CompletableFuture.completedFuture(testResult);
       }
@@ -222,6 +224,7 @@ public class TestRunnerService {
             // Set flags and add to results before exiting loop.
             testCaseResult.setSuccess(false);
             testCaseResult.setElapsedTime(0);
+            testResult.setRunnerMessage("URISyntaxException on endpoint: " + testResult.getTestedEndpoint());
             testResultRepository.save(testResult);
             break;
          } catch (Throwable t) {

--- a/webapp/src/main/webapp/src/app/models/test.model.ts
+++ b/webapp/src/main/webapp/src/app/models/test.model.ts
@@ -63,6 +63,7 @@ export type TestResult = {
   testCaseResults: TestCaseResult[];
   secretRef: SecretRef;
   authorizedClient: OAuth2AuthorizedClient;
+  runnerMessage?: string;
 }
 
 export type TestCaseResult = {

--- a/webapp/src/main/webapp/src/app/pages/tests/runner/test-runner.page.html
+++ b/webapp/src/main/webapp/src/app/pages/tests/runner/test-runner.page.html
@@ -19,6 +19,15 @@
     <h1>Test {{ test.id }}</h1>
     <small>Created {{ test.testDate.toString() | timeAgo }}</small>
 
+    <div class="row" *ngIf="test.runnerMessage" style="margin-top: 20px;">
+      <div class="col-md-12">
+        <div class="alert alert-danger">
+          <span class="pficon pficon-error-circle-o"></span>
+          <strong>Test failed:</strong> {{ test.runnerMessage }}
+        </div>
+      </div>
+    </div>
+
     <h3 class="section-label">Properties</h3>
 
     <div class="row">

--- a/webapp/src/main/webapp/src/app/pages/tests/{testId}/test-detail.page.html
+++ b/webapp/src/main/webapp/src/app/pages/tests/{testId}/test-detail.page.html
@@ -20,6 +20,15 @@
     </h1>
     <small>Created {{ test.testDate.toString() | timeAgo }}, ran on {{ test.testDate | date:'medium' }}</small>
 
+    <div class="row" *ngIf="test.runnerMessage" style="margin-top: 20px;">
+      <div class="col-md-12">
+        <div class="alert alert-danger">
+          <span class="pficon pficon-error-circle-o"></span>
+          <strong>Test failed:</strong> {{ test.runnerMessage }}
+        </div>
+      </div>
+    </div>
+
     <h3 class="section-label">Properties</h3>
 
     <div class="row">


### PR DESCRIPTION
## What does this PR do?
This PR provides clear UI feedback to the user whenever a test fails during its early setup phase (e.g., due to OAuth negotiation failures, malformed URIs, or runner setup errors).

Previously, if a test failed for known reasons like an AuthorizationException during the OAuth2 token flow, the failure was silently logged in the backend and the UI provided no immediate feedback. With these changes, the backend now explicitly captures these early failures and passes a runnerMessage to the frontend, which is then rendered as a prominent error alert directly in the UI.

Fixes #1056

## How was this tested?

- Backend: Verified that TestRunnerService properly populates the runnerMessage inside TestResult during AuthorizationException, URISyntaxException, and runner retrieval failures. Ran the full backend test suite (mvn clean test) to ensure no regressions.
- Frontend / UI:

- - Spun up the Microcks instance locally using Docker Compose.
- - Imported a sample API (Petstore API).
- -  Attempted to launch a new test with intentionally invalid OAuth credentials (wrong token URI, client ID, etc.).
- - Verified that a red alert banner displaying Test failed: OAuth2 token flow failed: ... appears immediately at the top of both the Test Details and Test Runner pages.

<img width="3420" height="1962" alt="test_failure_message_1783345304967" src="https://github.com/user-attachments/assets/90aeaf9f-8f86-4209-ad61-d05999e30c9e" />
