### PR TITLE
feat(helm): add IBM MQ AsyncAPI support setup

### DIFF
--- a/install/kubernetes/microcks/templates/configmap.yaml
+++ b/install/kubernetes/microcks/templates/configmap.yaml
@@ -49,6 +49,9 @@ data:
     {{- if .Values.features.async.sns.region }}
     features.feature.async-api.endpoint-SNS={{ .Values.features.async.sns.region }}{{ if .Values.features.async.sns.endpointOverride }} at {{ .Values.features.async.sns.endpointOverride }}{{ end }}
     {{- end }}
+    {{- if .Values.features.async.ibmmq.server }}
+    features.feature.async-api.endpoint-IBMMQ={{ .Values.features.async.ibmmq.server }}
+    {{- end }}
 
     features.feature.ai-copilot.enabled={{ .Values.features.aiCopilot.enabled }}
   application.properties: |-
@@ -643,9 +646,21 @@ data:
     %kube.amazonsns.endpoint-override={{ .Values.features.async.sns.endpointOverride }}
     {{- end }}
     {{- end }}
+    {{- if .Values.features.async.ibmmq.server }}
+    # Access to IBM MQ broker.
+    %kube.ibmmq.server={{ .Values.features.async.ibmmq.server }}
+    {{- if .Values.features.async.ibmmq.queueManager }}
+    %kube.ibmmq.queue-manager={{ .Values.features.async.ibmmq.queueManager }}
+    {{- end }}
+    {{- if .Values.features.async.ibmmq.channel }}
+    %kube.ibmmq.channel={{ .Values.features.async.ibmmq.channel }}
+    {{- end }}
+    %kube.ibmmq.username={{ .Values.features.async.ibmmq.username }}
+    %kube.ibmmq.password={{ .Values.features.async.ibmmq.password }}
+    {{- end }}
 
     # Configure the minion own behavioral properties.
-    %kube.minion.supported-bindings=KAFKA,WS{{ if .Values.features.async.mqtt.url }},MQTT{{ end }}{{ if .Values.features.async.amqp.url }},AMQP{{ end }}{{ if .Values.features.async.nats.url }},NATS{{ end }}{{ if .Values.features.async.googlepubsub.project }},GOOGLEPUBSUB{{ end }}{{ if .Values.features.async.sqs.region }},SQS{{ end }}{{ if .Values.features.async.sns.region }},SNS{{ end }}
+    %kube.minion.supported-bindings=KAFKA,WS{{ if .Values.features.async.mqtt.url }},MQTT{{ end }}{{ if .Values.features.async.amqp.url }},AMQP{{ end }}{{ if .Values.features.async.nats.url }},NATS{{ end }}{{ if .Values.features.async.googlepubsub.project }},GOOGLEPUBSUB{{ end }}{{ if .Values.features.async.sqs.region }},SQS{{ end }}{{ if .Values.features.async.sns.region }},SNS{{ end }}{{ if .Values.features.async.ibmmq.server }},IBMMQ{{ end }}
     %kube.minion.restricted-frequencies=3,10,30
     %kube.minion.default-avro-encoding={{ .Values.features.async.defaultAvroEncoding }}
 {{- end -}}

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -402,6 +402,14 @@ features:
         #secret: aws-credentials
         #fileKey: aws.profile
 
+    # Uncomment the ibmmq.server and put a valid endpoint address below to enable IBM MQ support.
+    ibmmq:
+      #server: localhost:1414
+      #queueManager: QM1
+      #channel: DEV.APP.SVRCONN
+      username: microcks
+      password: microcks
+
     ws:
       #ingressSecretRef: my-secret-for-microcks-ws-ingress
       #ingressClassName: nginx


### PR DESCRIPTION
Fixes #1344

## Description
This PR introduces the connection setup for IBM MQ AsyncAPI binding within the Kubernetes Helm chart deployment, as requested in issue #1344.

### Changes included:

1. Added IBM MQ configuration block in values.yaml under features.async, providing options for server, queueManager, channel, username, and password.
2. Updated configmap.yaml to dynamically inject these IBM MQ connection variables into the microcks-async-minion component when ibmmq.server is provided.
3. Appended IBMMQ to the %kube.minion.supported-bindings property if IBM MQ configuration is present.
 This setup paves the way for testing and mocking IBM MQ interactions seamlessly in a Helm-managed environment.

## Testing and Validation
I have validated these Helm changes locally using helm lint and helm template:

**helm lint:**
```text

==> Linting install/kubernetes/microcks
1 chart(s) linted, 0 chart(s) failed
```
**helm template**: Rendered the chart with IBM MQ properties defined (--set features.async.ibmmq.server=...) and successfully verified that the IBM MQ environment variables are correctly injected into the microcks-async-minion-config ConfigMap:
```
properties

# Access to IBM MQ broker.
  %kube.ibmmq.server=localhost:1414
  %kube.ibmmq.queue-manager=QM1
  %kube.ibmmq.channel=DEV.APP.SVRCONN
  %kube.ibmmq.username=microcks
  %kube.ibmmq.password=microcks
  # Configure the minion own behavioral properties.
  %kube.minion.supported-bindings=KAFKA,WS,IBMMQ
  ```
Additionally, the microcks-config mapping correctly injects features.feature.async-api.endpoint-IBMMQ.