### PR TITLE
feat: Support External References in OpenAPI MCP Tool Converter

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIMcpToolConverter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIMcpToolConverter.java
@@ -66,7 +66,7 @@ public class OpenAPIMcpToolConverter extends McpToolConverter {
    private final ResourceRepository resourceRepository;
 
    private JsonNode schemaNode;
-   private final Map<Resource, JsonNode> externalResourcesContent = new HashMap<>();
+   private final Map<String, JsonNode> externalResourcesContent = new HashMap<>();
    private ObjectMapper yamlMapper;
 
    /**
@@ -273,59 +273,90 @@ public class OpenAPIMcpToolConverter extends McpToolConverter {
       return getNodeForExternalRef(reference);
    }
 
-   /** Get the JsonNode for reference that is localed in external resource. */
-   private JsonNode getNodeForExternalRef(String externalReference) {
-      String attachedResourceName = externalReference;
+   /** Hold the parts of an external reference after parsing. */
+   private record ExternalRefParts(String resourceName, String pointerInFile) {
+   }
 
-      // We may have a Json pointer to a specific place in external reference.
-      String pointerInFile = null;
-      if (externalReference.contains("#/")) {
-         attachedResourceName = externalReference.substring(0, externalReference.indexOf("#/"));
-         pointerInFile = externalReference.substring(externalReference.indexOf("#/"));
-      }
+   /** Get the JsonNode for reference that is located in external resource. */
+   private JsonNode getNodeForExternalRef(String externalReference) {
+      ExternalRefParts refParts = parseExternalReference(externalReference);
 
       if (resourceRepository != null) {
-         List<Resource> attachedResources = resourceRepository.findByServiceIdAndType(service.getId(),
-               ResourceType.OPEN_API_SPEC);
-         for (Resource attachedResource : attachedResources) {
-            // Skip the main resource
-            if (attachedResource.getId() != null && attachedResource.getId().equals(resource.getId())) {
-               continue;
-            }
-            // Path direct equality is for absolute ref ("http://raw.githubusercontent.com/...")
-            // Path equality with resource name if for relative refs that have been re-normalized ("Service name+Service version+...))
-            if (attachedResourceName.equals(attachedResource.getPath()) || attachedResourceName
-                  .equals(URLEncoder.encode(attachedResource.getName(), StandardCharsets.UTF_8))) {
-               JsonNode resourceNode = externalResourcesContent.computeIfAbsent(attachedResource, k -> {
-                  try {
-                     // We have to guess if content is JSON or YAML.
-                     if (attachedResource.getContent().startsWith("{")
-                           || attachedResource.getContent().startsWith("[")) {
-                        return mapper.readTree(attachedResource.getContent());
-                     } else {
-                        // yamlMapper is lazily initialized.
-                        if (yamlMapper == null) {
-                           yamlMapper = ObjectMapperFactory.getYamlObjectMapper();
-                        }
-                        return yamlMapper.readTree(attachedResource.getContent());
-                     }
-                  } catch (JsonProcessingException e) {
-                     log.error("Get a JSON processing exception on {}", externalReference, e);
-                     return null;
-                  }
-               });
-               if (resourceNode != null) {
-                  if (pointerInFile != null) {
-                     return resourceNode.at(pointerInFile.substring(1));
-                  }
-                  return resourceNode;
+         Resource attachedResource = findMatchingResource(refParts.resourceName());
+         if (attachedResource != null) {
+            JsonNode resourceNode = parseAndCacheResource(attachedResource, externalReference);
+            if (resourceNode != null) {
+               if (refParts.pointerInFile() != null) {
+                  return resourceNode.at(refParts.pointerInFile().substring(1));
                }
+               return resourceNode;
             }
          }
       }
 
       log.warn("Found no resource for reference '{}'", externalReference);
       return null;
+   }
+
+   /**
+    * Parse an external reference into the resource name and optional JSON pointer. For example,
+    * "models.yaml#/components/schemas/TestModel" becomes ExternalRefParts["models.yaml",
+    * "#/components/schemas/TestModel"].
+    */
+   private ExternalRefParts parseExternalReference(String externalReference) {
+      if (externalReference.contains("#/")) {
+         String resourceName = externalReference.substring(0, externalReference.indexOf("#/"));
+         String pointerInFile = externalReference.substring(externalReference.indexOf("#/"));
+         return new ExternalRefParts(resourceName, pointerInFile);
+      }
+      return new ExternalRefParts(externalReference, null);
+   }
+
+   /**
+    * Find a matching resource from the repository for the given resource name. Skips the main resource and matches by
+    * path or encoded name.
+    */
+   private Resource findMatchingResource(String resourceName) {
+      List<Resource> attachedResources = resourceRepository.findByServiceIdAndType(service.getId(),
+            ResourceType.OPEN_API_SPEC);
+      for (Resource attachedResource : attachedResources) {
+         // Skip the main resource.
+         if (attachedResource.getId() != null && attachedResource.getId().equals(resource.getId())) {
+            continue;
+         }
+         // Path direct equality is for absolute ref ("http://raw.githubusercontent.com/...").
+         // Path equality with resource name is for relative refs that have been re-normalized
+         // ("Service name+Service version+...").
+         if (resourceName.equals(attachedResource.getPath())
+               || resourceName.equals(URLEncoder.encode(attachedResource.getName(), StandardCharsets.UTF_8))) {
+            return attachedResource;
+         }
+      }
+      return null;
+   }
+
+   /**
+    * Parse and cache the content of a resource (JSON or YAML detection). Uses the resource ID as the cache key for
+    * stable lookup.
+    */
+   private JsonNode parseAndCacheResource(Resource resource, String externalReference) {
+      return externalResourcesContent.computeIfAbsent(resource.getId(), k -> {
+         try {
+            // We have to guess if content is JSON or YAML.
+            if (resource.getContent().startsWith("{") || resource.getContent().startsWith("[")) {
+               return mapper.readTree(resource.getContent());
+            } else {
+               // yamlMapper is lazily initialized.
+               if (yamlMapper == null) {
+                  yamlMapper = ObjectMapperFactory.getYamlObjectMapper();
+               }
+               return yamlMapper.readTree(resource.getContent());
+            }
+         } catch (JsonProcessingException e) {
+            log.error("Get a JSON processing exception on {}", externalReference, e);
+            return null;
+         }
+      });
    }
 
    /** Visit a node and extract its properties. */

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIMcpToolConverter.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPIMcpToolConverter.java
@@ -19,6 +19,9 @@ import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Resource;
 import io.github.microcks.domain.Response;
 import io.github.microcks.domain.Service;
+import io.github.microcks.domain.ResourceType;
+import io.github.microcks.repository.ResourceRepository;
+import io.github.microcks.util.ObjectMapperFactory;
 import io.github.microcks.util.URIBuilder;
 import io.github.microcks.util.ai.McpSchema;
 import io.github.microcks.util.ai.McpToolConverter;
@@ -28,6 +31,7 @@ import io.github.microcks.web.MockInvocationContext;
 import io.github.microcks.web.ResponseResult;
 import io.github.microcks.web.RestInvocationProcessor;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -35,6 +39,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -57,8 +63,11 @@ public class OpenAPIMcpToolConverter extends McpToolConverter {
 
    private final RestInvocationProcessor invocationProcessor;
    private final ObjectMapper mapper;
+   private final ResourceRepository resourceRepository;
 
    private JsonNode schemaNode;
+   private final Map<Resource, JsonNode> externalResourcesContent = new HashMap<>();
+   private ObjectMapper yamlMapper;
 
    /**
     * Build a new instance of OpenAPIMcpToolConverter.
@@ -67,9 +76,10 @@ public class OpenAPIMcpToolConverter extends McpToolConverter {
     * @param invocationProcessor The invocation processor to use for processing the call
     * @param mapper              The ObjectMapper to use for JSON serialization
     */
-   public OpenAPIMcpToolConverter(Service service, Resource resource, RestInvocationProcessor invocationProcessor,
-         ObjectMapper mapper) {
+   public OpenAPIMcpToolConverter(Service service, Resource resource, ResourceRepository resourceRepository,
+         RestInvocationProcessor invocationProcessor, ObjectMapper mapper) {
       super(service, resource);
+      this.resourceRepository = resourceRepository;
       this.invocationProcessor = invocationProcessor;
       this.mapper = mapper;
    }
@@ -260,7 +270,61 @@ public class OpenAPIMcpToolConverter extends McpToolConverter {
       if (reference.startsWith("#/")) {
          return schemaNode.at(reference.substring(1));
       }
-      // TODO: handle external references reusing imported resources?
+      return getNodeForExternalRef(reference);
+   }
+
+   /** Get the JsonNode for reference that is localed in external resource. */
+   private JsonNode getNodeForExternalRef(String externalReference) {
+      String attachedResourceName = externalReference;
+
+      // We may have a Json pointer to a specific place in external reference.
+      String pointerInFile = null;
+      if (externalReference.contains("#/")) {
+         attachedResourceName = externalReference.substring(0, externalReference.indexOf("#/"));
+         pointerInFile = externalReference.substring(externalReference.indexOf("#/"));
+      }
+
+      if (resourceRepository != null) {
+         List<Resource> attachedResources = resourceRepository.findByServiceIdAndType(service.getId(),
+               ResourceType.OPEN_API_SPEC);
+         for (Resource attachedResource : attachedResources) {
+            // Skip the main resource
+            if (attachedResource.getId() != null && attachedResource.getId().equals(resource.getId())) {
+               continue;
+            }
+            // Path direct equality is for absolute ref ("http://raw.githubusercontent.com/...")
+            // Path equality with resource name if for relative refs that have been re-normalized ("Service name+Service version+...))
+            if (attachedResourceName.equals(attachedResource.getPath()) || attachedResourceName
+                  .equals(URLEncoder.encode(attachedResource.getName(), StandardCharsets.UTF_8))) {
+               JsonNode resourceNode = externalResourcesContent.computeIfAbsent(attachedResource, k -> {
+                  try {
+                     // We have to guess if content is JSON or YAML.
+                     if (attachedResource.getContent().startsWith("{")
+                           || attachedResource.getContent().startsWith("[")) {
+                        return mapper.readTree(attachedResource.getContent());
+                     } else {
+                        // yamlMapper is lazily initialized.
+                        if (yamlMapper == null) {
+                           yamlMapper = ObjectMapperFactory.getYamlObjectMapper();
+                        }
+                        return yamlMapper.readTree(attachedResource.getContent());
+                     }
+                  } catch (JsonProcessingException e) {
+                     log.error("Get a JSON processing exception on {}", externalReference, e);
+                     return null;
+                  }
+               });
+               if (resourceNode != null) {
+                  if (pointerInFile != null) {
+                     return resourceNode.at(pointerInFile.substring(1));
+                  }
+                  return resourceNode;
+               }
+            }
+         }
+      }
+
+      log.warn("Found no resource for reference '{}'", externalReference);
       return null;
    }
 

--- a/webapp/src/main/java/io/github/microcks/web/McpController.java
+++ b/webapp/src/main/java/io/github/microcks/web/McpController.java
@@ -334,7 +334,8 @@ public class McpController {
       switch (service.getType()) {
          case GRPC -> converter = new GrpcMcpToolConverter(service, resource, grpcInvocationProcessor, mapper);
          case GRAPHQL -> converter = new GraphQLMcpToolConverter(service, resource, graphQLInvocationProcessor, mapper);
-         default -> converter = new OpenAPIMcpToolConverter(service, resource, restInvocationProcessor, mapper);
+         default -> converter = new OpenAPIMcpToolConverter(service, resource, resourceRepository,
+               restInvocationProcessor, mapper);
       }
       return converter;
    }

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIMcpToolConverterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPIMcpToolConverterTest.java
@@ -79,15 +79,15 @@ class OpenAPIMcpToolConverterTest {
       servicev1 = services.getFirst();
       List<Resource> resources = resourceRepository.findByServiceIdAndType(servicev1.getId(),
             ResourceType.OPEN_API_SPEC);
-      toolConverterv1 = new OpenAPIMcpToolConverter(servicev1, resources.getFirst(), restInvocationProcessor,
-            new ObjectMapper());
+      toolConverterv1 = new OpenAPIMcpToolConverter(servicev1, resources.getFirst(), resourceRepository,
+            restInvocationProcessor, new ObjectMapper());
       // For v2.
       services = serviceService.importServiceDefinition(artifactFilev2, null,
             new ArtifactInfo("petstore-2.0.0-openapi.yaml", true));
       servicev2 = services.getFirst();
       resources = resourceRepository.findByServiceIdAndType(servicev2.getId(), ResourceType.OPEN_API_SPEC);
-      toolConverterv2 = new OpenAPIMcpToolConverter(servicev2, resources.getFirst(), restInvocationProcessor,
-            new ObjectMapper());
+      toolConverterv2 = new OpenAPIMcpToolConverter(servicev2, resources.getFirst(), resourceRepository,
+            restInvocationProcessor, new ObjectMapper());
    }
 
    @Test
@@ -190,6 +190,76 @@ class OpenAPIMcpToolConverterTest {
             }
          }
       }
+   }
+
+   @Test
+   void testExternalReferenceResolution() {
+      // 1. Create a dummy Service
+      Service externalRefService = new Service();
+      externalRefService.setId("test-ext-ref");
+      externalRefService.setName("External Ref API");
+      externalRefService.setVersion("1.0.0");
+      externalRefService.setType(io.github.microcks.domain.ServiceType.REST);
+
+      // 2. Create the main Resource
+      Resource mainResource = new Resource();
+      mainResource.setId("main-res-id");
+      mainResource.setServiceId(externalRefService.getId());
+      mainResource.setType(ResourceType.OPEN_API_SPEC);
+      mainResource.setName("main.yaml");
+      mainResource.setContent("""
+            openapi: 3.0.0
+            info:
+              title: External Ref API
+              version: 1.0.0
+            paths:
+              /test:
+                post:
+                  operationId: postTest
+                  requestBody:
+                    content:
+                      application/json:
+                        schema:
+                          $ref: 'models.yaml#/components/schemas/TestModel'
+            """);
+      resourceRepository.save(mainResource);
+
+      // 3. Create the external Resource
+      Resource extResource = new Resource();
+      extResource.setId("ext-res-id");
+      extResource.setServiceId(externalRefService.getId());
+      extResource.setType(ResourceType.OPEN_API_SPEC);
+      extResource.setName("models.yaml");
+      extResource.setPath("models.yaml");
+      extResource.setContent("""
+            components:
+              schemas:
+                TestModel:
+                  type: object
+                  properties:
+                    testField:
+                      type: string
+                  required:
+                    - testField
+            """);
+      resourceRepository.save(extResource);
+
+      // 4. Create the Operation
+      Operation operation = new Operation();
+      operation.setName("POST /test");
+      operation.setMethod("POST");
+
+      // 5. Instantiate converter
+      OpenAPIMcpToolConverter converter = new OpenAPIMcpToolConverter(externalRefService, mainResource,
+            resourceRepository, restInvocationProcessor, new ObjectMapper());
+
+      // 6. Assert input schema
+      McpSchema.JsonSchema inputSchema = converter.getInputSchema(operation);
+      assertNotNull(inputSchema, "Input schema should not be null");
+      assertEquals("object", inputSchema.type());
+      assertFalse(inputSchema.properties().isEmpty(), "Properties should not be empty");
+      assertTrue(inputSchema.properties().containsKey("testField"),
+            "Properties should contain 'testField' from external ref");
    }
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

This PR implements the missing capability for the Microcks MCP Server to resolve and extract schemas from external `$ref` definitions (such as separate JSON or YAML schema files) when converting OpenAPI specifications into MCP tools.

- **Injected `ResourceRepository`:** Updated the `McpController` and `OpenAPIMcpToolConverter` constructors to inject the `ResourceRepository`, allowing the converter to fetch externally attached `Resource` files linked to the `Service`.
- **Implemented External Reference Resolution:** Ported the `getNodeForExternalRef` logic from the `reshaprio/reshapr` project. The algorithm correctly parses external file paths and JSON pointers (e.g., `models.yaml#/components/schemas/UserModel`), locates the corresponding resource in the repository, and extracts the exact schema slice required.
- **Added Caching:** Implemented lazy parsing and caching of JSON/YAML ASTs via `externalResourcesContent` (`Map<Resource, JsonNode>`) to ensure high-performance schema resolution without redundant parsing on subsequent tool calls.
- **Added Integration Test:** Added the `testExternalReferenceResolution` test case to `OpenAPIMcpToolConverterTest` which successfully mimics a multipart OpenAPI specification with external `$ref`s and asserts that the final `McpSchema.JsonSchema` contains the correctly mapped properties.

### Related issue(s)
Resolves #2210
