### PR TITLE
refactor: graphql test return message

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLTestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/graphql/GraphQLTestRunner.java
@@ -146,15 +146,16 @@ public class GraphQLTestRunner extends HttpTestRunner {
    @Override
    protected String extractTestReturnMessage(Service service, Operation operation, Request request,
          ClientHttpResponse httpResponse) {
-      StringBuilder builder = new StringBuilder();
-      if (lastValidationErrors != null && !lastValidationErrors.isEmpty()) {
-         for (String error : lastValidationErrors) {
-            builder.append(error).append("/n");
+      try {
+         if (lastValidationErrors == null || lastValidationErrors.isEmpty()) {
+            return "";
          }
+
+         return String.join(System.lineSeparator(), lastValidationErrors);
+      } finally {
+         // Reset after consumption to avoid side effects.
+         lastValidationErrors = null;
       }
-      // Reset just after consumption so avoid side-effects.
-      lastValidationErrors = null;
-      return builder.toString();
    }
 
    /**


### PR DESCRIPTION
### Description
Fixed incorrect newline formatting in GraphQL test validation error messages in `GraphQLTestRunner`.

- Previously, validation errors were concatenated using the literal string `"/n"` instead of a proper newline character, producing malformed output.
- Replaced manual `StringBuilder` concatenation with `String.join(System.lineSeparator(), ...)` for clearer, more idiomatic error message construction.
- Wrapped the logic in a `finally` block to guarantee `lastValidationErrors` is reset after consumption, avoiding potential state leakage between test runs.

### Testing
Verified locally via `mvn clean install` and `mvn spotless:check` — build passes with no formatting violations.

### Related issue(s)
No related issue — found while reviewing the codebase.