### PR TITLE
feat: implement IBM MQ AsyncAPI mocking support (#1342)

### DIFF
--- a/commons/model/src/main/java/io/github/microcks/domain/BindingType.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/BindingType.java
@@ -28,5 +28,6 @@ public enum BindingType {
    NATS,
    GOOGLEPUBSUB,
    SQS,
-   SNS
+   SNS,
+   IBMMQ
 }

--- a/minions/async/pom.xml
+++ b/minions/async/pom.xml
@@ -28,6 +28,7 @@
     <eclipse-paho.version>1.2.5</eclipse-paho.version>
     <nats.version>2.25.3</nats.version>
     <rabbitmq.version>5.30.0</rabbitmq.version>
+    <ibmmq.version>9.3.4.1</ibmmq.version>
     <apicurio-registry.version>2.6.13.Final</apicurio-registry.version>
     <confluent-registry.version>6.2.10</confluent-registry.version>
     <surefire-plugin.version>3.2.5</surefire-plugin.version>
@@ -118,6 +119,13 @@
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
       <version>${rabbitmq.version}</version>
+    </dependency>
+
+    <!-- IBM MQ related dependencies -->
+    <dependency>
+      <groupId>com.ibm.mq</groupId>
+      <artifactId>com.ibm.mq.allclient</artifactId>
+      <version>${ibmmq.version}</version>
     </dependency>
 
     <!-- NATS related dependencies -->

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/IBMMQProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/IBMMQProducerManager.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.producer;
+
+import io.github.microcks.domain.EventMessage;
+import io.github.microcks.minion.async.AsyncMockDefinition;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import com.ibm.mq.MQEnvironment;
+import com.ibm.mq.MQException;
+import com.ibm.mq.MQMessage;
+import com.ibm.mq.MQQueue;
+import com.ibm.mq.MQQueueManager;
+import com.ibm.mq.constants.CMQC;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+/**
+ * IBM MQ implementation of producer for async event messages.
+ * @author laurent
+ */
+@ApplicationScoped
+public class IBMMQProducerManager {
+
+   /** Get a JBoss logging logger. */
+   private final Logger logger = Logger.getLogger(getClass());
+
+   private MQQueueManager queueManager;
+
+   @ConfigProperty(name = "ibmmq.server")
+   Optional<String> ibmmqServer;
+
+   @ConfigProperty(name = "ibmmq.queue-manager")
+   Optional<String> queueManagerName;
+
+   @ConfigProperty(name = "ibmmq.channel", defaultValue = "DEV.APP.SVRCONN")
+   String ibmmqChannel;
+
+   @ConfigProperty(name = "ibmmq.username")
+   Optional<String> ibmmqUsername;
+
+   @ConfigProperty(name = "ibmmq.password")
+   Optional<String> ibmmqPassword;
+
+   /**
+    * Initialize the IBM MQ client post construction.
+    * @throws Exception If connection to IBM MQ Broker cannot be done.
+    */
+   @PostConstruct
+   public void create() throws Exception {
+      try {
+         if (ibmmqServer.isPresent() && !ibmmqServer.get().isEmpty()) {
+            queueManager = createClient();
+         }
+      } catch (Exception e) {
+         logger.errorf("Cannot connect to IBM MQ broker %s", ibmmqServer.orElse(""));
+         logger.errorf("Connection exception: %s", e.getMessage());
+         throw e;
+      }
+   }
+
+   /**
+    * Create a MQQueueManager and connect it to the server.
+    * @return A new MQQueueManager implementation initialized with configuration properties.
+    * @throws Exception in case of connection failure
+    */
+   protected MQQueueManager createClient() throws Exception {
+      String host = ibmmqServer.get();
+      int port = 1414;
+      if (host.contains(":")) {
+         String[] parts = host.split(":");
+         host = parts[0];
+         port = Integer.parseInt(parts[1]);
+      }
+
+      MQEnvironment.hostname = host;
+      MQEnvironment.port = port;
+      MQEnvironment.channel = ibmmqChannel;
+
+      if (ibmmqUsername.isPresent() && !ibmmqUsername.get().isEmpty() && ibmmqPassword.isPresent()
+            && !ibmmqPassword.get().isEmpty()) {
+         logger.infof("Connecting to IBM MQ broker with user '%s'", ibmmqUsername.get());
+         MQEnvironment.userID = ibmmqUsername.get();
+         MQEnvironment.password = ibmmqPassword.get();
+      }
+
+      return new MQQueueManager(queueManagerName.orElse("QM1"));
+   }
+
+   /**
+    * Publish a message on specified queue.
+    * @param queueName The destination queue for message
+    * @param value     The message payload
+    */
+   public void publishMessage(String queueName, String value) {
+      logger.infof("Publishing on queue {%s}, message: %s ", queueName, value);
+
+      if (queueManager == null) {
+         logger.warn("IBM MQ queueManager is not initialized, ignoring publish.");
+         return;
+      }
+
+      MQQueue queue = null;
+      try {
+         int openOptions = CMQC.MQOO_OUTPUT | CMQC.MQOO_FAIL_IF_QUIESCING;
+         queue = queueManager.accessQueue(queueName, openOptions);
+
+         MQMessage message = new MQMessage();
+         message.write(value.getBytes(StandardCharsets.UTF_8));
+
+         queue.put(message);
+      } catch (MQException | java.io.IOException e) {
+         logger.warnf("Exception caught while publishing message to IBM MQ", e);
+      } finally {
+         if (queue != null) {
+            try {
+               queue.close();
+            } catch (MQException e) {
+               logger.warn("Exception caught while closing IBM MQ queue", e);
+            }
+         }
+      }
+   }
+
+   /**
+    * Get the IBM MQ queue name corresponding to a AsyncMockDefinition, sanitizing all parameters.
+    * @param definition   The AsyncMockDefinition
+    * @param eventMessage The message to get queue name
+    * @return The queue name for definition and event
+    */
+   public String getTopicName(AsyncMockDefinition definition, EventMessage eventMessage) {
+      // Produce service name part of topic name.
+      String serviceName = definition.getOwnerService().getName().replace(" ", "");
+      serviceName = serviceName.replace("-", "");
+
+      // Produce version name part of topic name.
+      String versionName = definition.getOwnerService().getVersion().replace(" ", "");
+
+      // Produce operation name part of topic name.
+      String operationName = ProducerManager.getDestinationOperationPart(definition.getOperation(), eventMessage);
+
+      // Aggregate the 3 parts using '-' as delimiter.
+      return serviceName + "-" + versionName + "-" + operationName;
+   }
+}

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/ProducerManager.java
@@ -80,6 +80,7 @@ public class ProducerManager {
    final GooglePubSubProducerManager googlePubSubProducerManager;
    final AmazonSQSProducerManager amazonSQSProducerManager;
    final AmazonSNSProducerManager amazonSNSProducerManager;
+   final IBMMQProducerManager ibmmqProducerManager;
 
    @SuppressWarnings("java:S6813")
    final WebSocketProducerManager wsProducerManager;
@@ -99,12 +100,13 @@ public class ProducerManager {
       final GooglePubSubProducerManager googlePubSubProducerManager;
       final AmazonSQSProducerManager amazonSQSProducerManager;
       final AmazonSNSProducerManager amazonSNSProducerManager;
+      final IBMMQProducerManager ibmmqProducerManager;
 
       @Inject
       public ProducerDependencies(KafkaProducerManager kafkaProducerManager, MQTTProducerManager mqttProducerManager,
             NATSProducerManager natsProducerManager, AMQPProducerManager amqpProducerManager,
             GooglePubSubProducerManager googlePubSubProducerManager, AmazonSQSProducerManager amazonSQSProducerManager,
-            AmazonSNSProducerManager amazonSNSProducerManager) {
+            AmazonSNSProducerManager amazonSNSProducerManager, IBMMQProducerManager ibmmqProducerManager) {
          this.kafkaProducerManager = kafkaProducerManager;
          this.mqttProducerManager = mqttProducerManager;
          this.natsProducerManager = natsProducerManager;
@@ -112,6 +114,7 @@ public class ProducerManager {
          this.googlePubSubProducerManager = googlePubSubProducerManager;
          this.amazonSQSProducerManager = amazonSQSProducerManager;
          this.amazonSNSProducerManager = amazonSNSProducerManager;
+         this.ibmmqProducerManager = ibmmqProducerManager;
       }
    }
 
@@ -134,6 +137,7 @@ public class ProducerManager {
       this.googlePubSubProducerManager = dependencies.googlePubSubProducerManager;
       this.amazonSQSProducerManager = dependencies.amazonSQSProducerManager;
       this.amazonSNSProducerManager = dependencies.amazonSNSProducerManager;
+      this.ibmmqProducerManager = dependencies.ibmmqProducerManager;
       this.wsProducerManager = wsProducerManager;
    }
 
@@ -177,6 +181,9 @@ public class ProducerManager {
                      break;
                   case SNS:
                      produceSNSMockMessages(definition);
+                     break;
+                  case IBMMQ:
+                     produceIBMMQMockMessages(definition);
                      break;
                   default:
                      break;
@@ -255,6 +262,10 @@ public class ProducerManager {
             break;
          case SNS:
             produceSNSMockMessage(definition, eventMessage,
+                  renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
+            break;
+         case IBMMQ:
+            produceIBMMQMockMessage(definition, eventMessage,
                   renderEventMessageContent(eventMessage, command.getRequest(), command.getResponse()));
             break;
          default:
@@ -370,11 +381,24 @@ public class ProducerManager {
       }
    }
 
-   /** Take care publishing MQTT message for definition. */
    protected void produceMQTTMockMessage(AsyncMockDefinition definition, EventMessage eventMessage,
          String renderedContent) {
       String topic = mqttProducerManager.getTopicName(definition, eventMessage);
       mqttProducerManager.publishMessage(topic, renderedContent);
+   }
+
+   /** Take care publishing IBM MQ mock messages for definition. */
+   protected void produceIBMMQMockMessages(AsyncMockDefinition definition) {
+      for (EventMessage eventMessage : getPureEventMessages(definition)) {
+         produceIBMMQMockMessage(definition, eventMessage, renderEventMessageContent(eventMessage));
+      }
+   }
+
+   /** Take care publishing IBM MQ message for definition. */
+   protected void produceIBMMQMockMessage(AsyncMockDefinition definition, EventMessage eventMessage,
+         String renderedContent) {
+      String queue = ibmmqProducerManager.getTopicName(definition, eventMessage);
+      ibmmqProducerManager.publishMessage(queue, renderedContent);
    }
 
    /** Take care publishing WebSocket mock messages for definition. */

--- a/minions/async/src/main/resources/application.properties
+++ b/minions/async/src/main/resources/application.properties
@@ -60,6 +60,12 @@ mqtt.server=localhost:1883
 mqtt.username=microcks
 mqtt.password=microcks
 
+ibmmq.server=localhost:1414
+ibmmq.queue-manager=QM1
+ibmmq.channel=DEV.APP.SVRCONN
+ibmmq.username=
+ibmmq.password=
+
 # Access to RabbitMQ broker.
 amqp.server=localhost:5672
 amqp.username=microcks

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/AmazonSQSProducerManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/AmazonSQSProducerManagerIT.java
@@ -127,7 +127,8 @@ class AmazonSQSProducerManagerIT {
       sqsProducerManager.create();
 
       ProducerManager producerManager = new ProducerManager(mockRepository, null,
-            new ProducerManager.ProducerDependencies(null, null, null, null, null, sqsProducerManager, null), null);
+            new ProducerManager.ProducerDependencies(null, null, null, null, null, sqsProducerManager, null, null),
+            null);
 
       // Act.
       producerManager.produceSQSMockMessages(mockDefinition);

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/GooglePubSubProducerManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/GooglePubSubProducerManagerIT.java
@@ -139,7 +139,8 @@ class GooglePubSubProducerManagerIT {
       pubSubProducerManager.create();
 
       ProducerManager producerManager = new ProducerManager(mockRepository, null,
-            new ProducerManager.ProducerDependencies(null, null, null, null, pubSubProducerManager, null, null), null);
+            new ProducerManager.ProducerDependencies(null, null, null, null, pubSubProducerManager, null, null, null),
+            null);
 
       // Act a 1st time to ensure topic creation before starting subscriber.
       producerManager.produceGooglePubSubMockMessages(mockDefinition);

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerIT.java
@@ -148,7 +148,8 @@ class KafkaProducerManagerIT {
       kafkaProducerManager.create();
 
       ProducerManager producerManager = new ProducerManager(mockRepository, schemaRegistry,
-            new ProducerManager.ProducerDependencies(kafkaProducerManager, null, null, null, null, null, null), null);
+            new ProducerManager.ProducerDependencies(kafkaProducerManager, null, null, null, null, null, null, null),
+            null);
 
       // Act.
       producerManager.produceKafkaMockMessages(mockDefinition);
@@ -235,7 +236,8 @@ class KafkaProducerManagerIT {
       kafkaProducerManager.create();
 
       ProducerManager producerManager = new ProducerManager(mockRepository, schemaRegistry,
-            new ProducerManager.ProducerDependencies(kafkaProducerManager, null, null, null, null, null, null), null);
+            new ProducerManager.ProducerDependencies(kafkaProducerManager, null, null, null, null, null, null, null),
+            null);
       producerManager.defaultAvroEncoding = "REGISTRY";
 
       // Act.

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/NATSProducerManagerIT.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/NATSProducerManagerIT.java
@@ -166,7 +166,8 @@ class NATSProducerManagerIT {
 
       // Act - Publish messages using ProducerManager.
       ProducerManager producerManager = new ProducerManager(mockRepository, null,
-            new ProducerManager.ProducerDependencies(null, null, natsProducerManager, null, null, null, null), null);
+            new ProducerManager.ProducerDependencies(null, null, natsProducerManager, null, null, null, null, null),
+            null);
       producerManager.produceNatsMockMessages(mockDefinition);
 
       // Assert - Consume messages from NATS.

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/ProducerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/ProducerManagerTest.java
@@ -58,6 +58,7 @@ class ProducerManagerTest {
    private GooglePubSubProducerManager googlePubSubProducerManager;
    private AmazonSQSProducerManager amazonSQSProducerManager;
    private AmazonSNSProducerManager amazonSNSProducerManager;
+   private IBMMQProducerManager ibmMQProducerManager;
 
    private ProducerManager producerManager;
 
@@ -73,10 +74,12 @@ class ProducerManagerTest {
       googlePubSubProducerManager = mock(GooglePubSubProducerManager.class);
       amazonSQSProducerManager = mock(AmazonSQSProducerManager.class);
       amazonSNSProducerManager = mock(AmazonSNSProducerManager.class);
+      ibmMQProducerManager = mock(IBMMQProducerManager.class);
 
       producerManager = new ProducerManager(mockRepository, schemaRegistry,
             new ProducerManager.ProducerDependencies(kafkaProducerManager, mqttProducerManager, natsProducerManager,
-                  amqpProducerManager, googlePubSubProducerManager, amazonSQSProducerManager, amazonSNSProducerManager),
+                  amqpProducerManager, googlePubSubProducerManager, amazonSQSProducerManager, amazonSNSProducerManager,
+                  null),
             null);
 
       // Set the supportedBindings field via reflection (normally injected by Quarkus).


### PR DESCRIPTION
## Description
This PR implements the requested mocking support for IBM MQ via AsyncAPI, addressing #1342. With this change, Microcks can now mock producer behavior and publish asynchronous event messages directly to an IBM MQ instance.

## Key Changes

- Added IBMMQ to the BindingType enumeration.
- Configured default IBM MQ properties in application.properties for the minion (`ibmmq.server`, `ibmmq.queue-manager`, etc.).
- Included the `com.ibm.mq.allclient` dependency in the `microcks-async-minion pom.xml`.
- Implemented` IBMMQProducerManager.java` to handle connection lifecycle and publishing logic over IBM MQ.
- Injected `IBMMQProducerManager` into the central ProducerManager.java orchestration layer to route IBMMQ bindings to our new manager.
- Updated unit tests (`ProducerManagerTest.java` and related integration tests) to account for the new constructor dependency.

## Testing and Validation
Since Apple Silicon (arm64) does not currently natively support the ibmcom/mq Docker images without Rosetta's x86-64-v3 emulation support, local containerized testing fails on M-series chips.

Validation should be performed via the CI/CD pipeline which will verify:

- Compilation succeeds and Spotless code formatting is enforced (verified locally via `mvn clean install`).
- Core functionality operates as expected when a mocked IBM MQ service is triggered.

If you have a remote IBM MQ server available or are running on an x86 host, you can test this locally by:

1. Setting up an IBM MQ instance.
2. Modifying the minion properties in your config (ibmmq.server, ibmmq.queue-manager, etc.).
3. Uploading an AsyncAPI spec with an ibmmq binding to Microcks.
4. Triggering a mock message and verifying it arrives at the expected destination queue on your MQ server!

Fixes #1342