### PR TITLE
fix: escape single quotes in curl command payload #2224

### DIFF
--- a/webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.spec.ts
+++ b/webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ServiceType } from '../../../models/service.model';
+import { ServiceDetailPageComponent } from './service-detail.page';
+
+describe('ServiceDetailPageComponent formatCurlCmd', () => {
+  function createComponentForCurl(): ServiceDetailPageComponent {
+    const component = Object.create(ServiceDetailPageComponent.prototype) as ServiceDetailPageComponent;
+
+    (component as any).resolvedServiceView = {
+      service: {
+        type: ServiceType.REST,
+        name: 'OpenAI API Documentation',
+        version: '1.0.0'
+      }
+    };
+
+    (component as any).formatMockUrl = () =>
+      'http://localhost:9090/rest/OpenAI+API+Documentation/1.0.0/providers/openai/deployments/gpt-4o/chat/completions?api-version=2024-06-01';
+
+    return component;
+  }
+
+  function extractAndParseCurlBody(cmd: string): unknown {
+    const match = cmd.match(/ -d '([\s\S]*)'$/);
+    expect(match).withContext('curl command should contain a single-quoted -d payload').not.toBeNull();
+
+    // The generated body escapes apostrophes using POSIX shell pattern: '\''
+    const payload = match![1].replace(/'\\''/g, "'");
+    return JSON.parse(payload);
+  }
+
+  it('should generate a curl body that remains valid JSON when content contains apostrophes', () => {
+    const component = createComponentForCurl();
+
+    const operation: any = { method: 'POST' };
+    const exchange: any = {
+      request: {
+        queryParameters: null,
+        headers: [{ name: 'Content-Type', values: ['application/json'] }],
+        content: '{"text":"Tu es un assistant d\'extraction de donnees"}'
+      },
+      response: { dispatchCriteria: null }
+    };
+
+    const cmd = component.formatCurlCmd(operation, exchange);
+
+    expect(cmd).toContain("-d '{\"text\":\"Tu es un assistant d'\\''extraction de donnees\"}'");
+    expect(extractAndParseCurlBody(cmd)).toEqual({
+      text: "Tu es un assistant d'extraction de donnees"
+    });
+  });
+});

--- a/webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.ts
+++ b/webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.ts
@@ -936,7 +936,8 @@ export class ServiceDetailPageComponent implements OnInit {
         && exchange.request.content != undefined
          && exchange.request.content != '') {
       const normalizedRequestContent = normalizeLineEndings(exchange.request.content);
-      cmd += ' -d \'' + normalizedRequestContent.replace(/\n/g, '') + '\'';
+      const escapedRequestContent = normalizedRequestContent.replace(/'/g, "'\\''").replace(/\n/g, '');
+      cmd += " -d '" + escapedRequestContent + "'";
     }
 
     if (this.resolvedServiceView.service.type === ServiceType.GRPC) {


### PR DESCRIPTION
This pull request improves the handling and testing of cURL command generation in the `ServiceDetailPageComponent`. The main focus is on correctly escaping apostrophes in JSON payloads to ensure the generated cURL commands remain valid and functional, especially when the payload contains single quotes.

**Bug Fixes and Improvements:**

* Properly escape apostrophes in request payloads when generating cURL commands, ensuring that payloads with single quotes produce valid shell commands. (`service-detail.page.ts`, [webapp/src/main/webapp/src/app/pages/services/{serviceId}/service-detail.page.tsL939-R940](diffhunk://#diff-b000fd75abf6789c0bc64a9641e829920aa2b8d8f8b7308efa0cc17df7f8e46aL939-R940))

**Testing Enhancements:**

* Add a new unit test suite (`service-detail.page.spec.ts`) that verifies cURL command generation, specifically testing that JSON payloads containing apostrophes are correctly escaped and can be parsed back to their original content.