### PR TITLE
fix(web): make test runner connect timeout configurable

### DIFF
--- a/install/kubernetes/microcks/templates/configmap.yaml
+++ b/install/kubernetes/microcks/templates/configmap.yaml
@@ -54,6 +54,7 @@ data:
   application.properties: |-
     # Application configuration properties
     tests-callback.url=${TEST_CALLBACK_URL}
+    tests-runner.connect-timeout=${TESTS_RUNNER_CONNECT_TIMEOUT:5000}
     postman-runner.url=${POSTMAN_RUNNER_URL}
     async-minion.url=${ASYNC_MINION_URL|http://localhost:8081}
 

--- a/webapp/src/main/java/io/github/microcks/service/TestRunnerService.java
+++ b/webapp/src/main/java/io/github/microcks/service/TestRunnerService.java
@@ -102,6 +102,9 @@ public class TestRunnerService {
    @Value("${tests-callback.url}")
    private String testsCallbackUrl = null;
 
+   @Value("${tests-runner.connect-timeout:5000}")
+   private long runnerConnectTimeout;
+
    @Value("${postman-runner.url}")
    private String postmanRunnerUrl = null;
 
@@ -385,8 +388,9 @@ public class TestRunnerService {
             .setSSLSocketFactory(sslsf).build();
 
       CloseableHttpClient httpClient = HttpClients.custom().setConnectionManager(connectionManager)
-            .setDefaultRequestConfig(RequestConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(200))
-                  .setResponseTimeout(Timeout.ofMilliseconds(runnerTimeout)).build())
+            .setDefaultRequestConfig(
+                  RequestConfig.custom().setConnectTimeout(Timeout.ofMilliseconds(runnerConnectTimeout))
+                        .setResponseTimeout(Timeout.ofMilliseconds(runnerTimeout)).build())
             .build();
 
       HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient);

--- a/webapp/src/main/resources/config/application.properties
+++ b/webapp/src/main/resources/config/application.properties
@@ -21,6 +21,7 @@ management.metrics.distribution.percentiles-histogram.http.server.requests=true
 management.metrics.distribution.slo."http.server.requests"=1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1000ms, 2500ms, 5000ms, 10000ms
 
 tests-callback.url=${TEST_CALLBACK_URL:http://localhost:8080}
+tests-runner.connect-timeout=${TESTS_RUNNER_CONNECT_TIMEOUT:5000}
 postman-runner.url=${POSTMAN_RUNNER_URL:http://localhost:3000}
 async-minion.url=${ASYNC_MINION_URL:http://localhost:8081}
 default-artifacts-repository.url=${DEFAULT_ARTIFACTS_REPOSITORY_URL:#{null}}


### PR DESCRIPTION
### Description

- Introduce a configurable `tests-runner.connect-timeout` property with a default value of `5000` ms.
- Replace the previously hardcoded HTTP client connect timeout (`200` ms) with the configured value when creating the test runner HTTP client.
- Expose the property in both the default application configuration and the Kubernetes ConfigMap so it can be overridden through `TESTS_RUNNER_CONNECT_TIMEOUT`.

### Related issue(s)

Fixes #2223