### PR TITLE
feat: compare OpenAPI response examples

### DIFF
--- a/api/microcks-openapi-v1.15.yaml
+++ b/api/microcks-openapi-v1.15.yaml
@@ -1536,6 +1536,10 @@ components:
         operationsHeaders:
           $ref: '#/components/schemas/OperationHeaders'
           description: This test operations headers override
+        responseExampleComparison:
+          $ref: '#/components/schemas/ResponseExampleComparisonMode'
+          description: Optional JSON response example comparison for OPEN_API_SCHEMA
+            tests
     Resource:
       description: "Resource represents a Service or API artifacts such as specification,\
         \ contract"
@@ -1581,6 +1585,15 @@ components:
       - ASYNC_API_SCHEMA
       - GRPC_PROTOBUF
       - GRAPHQL_SCHEMA
+      type: string
+    ResponseExampleComparisonMode:
+      description: "JSON response example comparison mode. STRICT requires the same\
+        \ structure and values while ignoring array ordering. LENIENT requires the\
+        \ example structure and values while allowing additional object fields and\
+        \ array elements."
+      enum:
+      - STRICT
+      - LENIENT
       type: string
     ArtifactUpload:
       description: |-

--- a/commons/model/src/main/java/io/github/microcks/domain/ResponseExampleComparisonMode.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/ResponseExampleComparisonMode.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.domain;
+
+/**
+ * Comparison modes for checking an actual JSON response against its OpenAPI response example.
+ */
+public enum ResponseExampleComparisonMode {
+   /** Require the same JSON structure and values while ignoring array ordering. */
+   STRICT,
+   /** Require the example structure and values while allowing additional object fields and array elements. */
+   LENIENT
+}

--- a/commons/model/src/main/java/io/github/microcks/domain/TestOptionals.java
+++ b/commons/model/src/main/java/io/github/microcks/domain/TestOptionals.java
@@ -29,17 +29,25 @@ public class TestOptionals {
    private List<String> filteredOperations;
    private OperationsHeaders operationsHeaders;
    private OAuth2ClientContext oAuth2Context;
+   private ResponseExampleComparisonMode responseExampleComparison;
 
    public TestOptionals() {
    }
 
    public TestOptionals(SecretRef secretRef, Long timeout, List<String> filteredOperations,
          OperationsHeaders operationsHeaders, OAuth2ClientContext oAuth2Context) {
+      this(secretRef, timeout, filteredOperations, operationsHeaders, oAuth2Context, null);
+   }
+
+   public TestOptionals(SecretRef secretRef, Long timeout, List<String> filteredOperations,
+         OperationsHeaders operationsHeaders, OAuth2ClientContext oAuth2Context,
+         ResponseExampleComparisonMode responseExampleComparison) {
       this.secretRef = secretRef;
       this.timeout = timeout;
       this.filteredOperations = filteredOperations;
       this.operationsHeaders = operationsHeaders;
       this.oAuth2Context = oAuth2Context;
+      this.responseExampleComparison = responseExampleComparison;
    }
 
    public SecretRef getSecretRef() {
@@ -80,5 +88,13 @@ public class TestOptionals {
 
    public void setOAuth2Context(OAuth2ClientContext oAuth2Context) {
       this.oAuth2Context = oAuth2Context;
+   }
+
+   public ResponseExampleComparisonMode getResponseExampleComparison() {
+      return responseExampleComparison;
+   }
+
+   public void setResponseExampleComparison(ResponseExampleComparisonMode responseExampleComparison) {
+      this.responseExampleComparison = responseExampleComparison;
    }
 }

--- a/webapp/src/main/java/io/github/microcks/service/TestRunnerService.java
+++ b/webapp/src/main/java/io/github/microcks/service/TestRunnerService.java
@@ -20,6 +20,7 @@ import io.github.microcks.domain.OAuth2ClientContext;
 import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Request;
 import io.github.microcks.domain.Response;
+import io.github.microcks.domain.ResponseExampleComparisonMode;
 import io.github.microcks.domain.Secret;
 import io.github.microcks.domain.Service;
 import io.github.microcks.domain.TestCaseResult;
@@ -142,6 +143,22 @@ public class TestRunnerService {
    @Async
    public CompletableFuture<TestResult> launchTestsInternal(TestResult testResult, Service service,
          TestRunnerType runnerType, OAuth2ClientContext oAuth2Context) {
+      return launchTestsInternal(testResult, service, runnerType, oAuth2Context, null);
+   }
+
+   /**
+    * Launch tests using asynchronous/completable future pattern.
+    * @param testResult                TestResults to aggregate results within
+    * @param service                   Service to test
+    * @param runnerType                Type of runner for launching the tests
+    * @param oAuth2Context             An optional OAuth2ClientContext that may complement Secret information
+    * @param responseExampleComparison An optional comparison mode for OpenAPI response examples
+    * @return A Future wrapping test results
+    */
+   @Async
+   public CompletableFuture<TestResult> launchTestsInternal(TestResult testResult, Service service,
+         TestRunnerType runnerType, OAuth2ClientContext oAuth2Context,
+         ResponseExampleComparisonMode responseExampleComparison) {
       // Found next build number for this test.
       List<TestResult> older = testResultRepository.findByServiceId(service.getId(),
             PageRequest.of(0, 2, Sort.Direction.DESC, "testNumber"));
@@ -187,7 +204,7 @@ public class TestRunnerService {
 
       // Initialize runner once as it is shared for each test.
       AbstractTestRunner<HttpMethod> testRunner = retrieveRunner(runnerType, secret, testResult.getTimeout(),
-            service.getId());
+            service.getId(), responseExampleComparison);
       if (testRunner == null) {
          // Set failure and stopped flags and save before exiting.
          testResult.setSuccess(false);
@@ -358,7 +375,7 @@ public class TestRunnerService {
 
    /** Retrieve correct test runner according given type. */
    private AbstractTestRunner<HttpMethod> retrieveRunner(TestRunnerType runnerType, Secret secret, Long runnerTimeout,
-         String serviceId) {
+         String serviceId, ResponseExampleComparisonMode responseExampleComparison) {
       // TODO: remove this ugly initialization later.
       // Initialize new HttpComponentsClientHttpRequestFactory that supports https connections.
       SSLContext sslContext = null;
@@ -399,7 +416,8 @@ public class TestRunnerService {
             soapRunner.setSecret(secret);
             return soapRunner;
          case OPEN_API_SCHEMA:
-            OpenAPITestRunner openApiRunner = new OpenAPITestRunner(resourceRepository, responseRepository, true);
+            OpenAPITestRunner openApiRunner = new OpenAPITestRunner(resourceRepository, responseRepository, true,
+                  responseExampleComparison);
             openApiRunner.setClientHttpRequestFactory(factory);
             openApiRunner.setResourceUrl(validationResourceUrl);
             openApiRunner.setSecret(secret);

--- a/webapp/src/main/java/io/github/microcks/service/TestService.java
+++ b/webapp/src/main/java/io/github/microcks/service/TestService.java
@@ -106,7 +106,8 @@ public class TestService {
 
       // Launch test asynchronously before returning result.
       log.debug("Calling launchTestsInternal() marked as Async");
-      testRunnerService.launchTestsInternal(testResult, service, runnerType, testOptionals.getOAuth2Context());
+      testRunnerService.launchTestsInternal(testResult, service, runnerType, testOptionals.getOAuth2Context(),
+            testOptionals.getResponseExampleComparison());
       log.debug("Async launchTestsInternal() as now finished");
       return testResult;
    }

--- a/webapp/src/main/java/io/github/microcks/util/openapi/JsonExampleComparator.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/JsonExampleComparator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.util.openapi;
+
+import io.github.microcks.domain.ResponseExampleComparisonMode;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Arrays;
+import java.util.Map;
+
+/**
+ * Compares JSON examples with actual response bodies using unordered array semantics.
+ */
+final class JsonExampleComparator {
+
+   private JsonExampleComparator() {
+      // Hide implicit public constructor.
+   }
+
+   /**
+    * Check whether an actual JSON body matches an expected example in the requested mode.
+    * @param expected expected response example
+    * @param actual   actual response body
+    * @param mode     comparison mode
+    * @return {@code true} when the actual body matches the example
+    */
+   static boolean matches(JsonNode expected, JsonNode actual, ResponseExampleComparisonMode mode) {
+      if (expected == null || actual == null || expected.getNodeType() != actual.getNodeType()) {
+         // Jackson uses different node types for integral and decimal values although both are JSON numbers.
+         return expected != null && actual != null && expected.isNumber() && actual.isNumber()
+               && expected.decimalValue().compareTo(actual.decimalValue()) == 0;
+      }
+
+      if (expected.isObject()) {
+         return objectsMatch(expected, actual, mode);
+      }
+      if (expected.isArray()) {
+         return arraysMatch(expected, actual, mode);
+      }
+      if (expected.isNumber()) {
+         return expected.decimalValue().compareTo(actual.decimalValue()) == 0;
+      }
+      return expected.equals(actual);
+   }
+
+   private static boolean objectsMatch(JsonNode expected, JsonNode actual, ResponseExampleComparisonMode mode) {
+      if (ResponseExampleComparisonMode.STRICT.equals(mode) && expected.size() != actual.size()) {
+         return false;
+      }
+      for (Map.Entry<String, JsonNode> property : expected.properties()) {
+         if (!actual.has(property.getKey()) || !matches(property.getValue(), actual.get(property.getKey()), mode)) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   private static boolean arraysMatch(JsonNode expected, JsonNode actual, ResponseExampleComparisonMode mode) {
+      if (ResponseExampleComparisonMode.STRICT.equals(mode) && expected.size() != actual.size()) {
+         return false;
+      }
+      if (expected.size() > actual.size()) {
+         return false;
+      }
+
+      // Find a distinct actual element for every expected element. A maximum matching avoids false negatives when
+      // lenient object comparisons make more than one actual element a candidate for an expected element.
+      int[] actualMatches = new int[actual.size()];
+      Arrays.fill(actualMatches, -1);
+      for (int expectedIndex = 0; expectedIndex < expected.size(); expectedIndex++) {
+         boolean[] visitedActualElements = new boolean[actual.size()];
+         if (!findArrayElementMatch(expectedIndex, expected, actual, mode, actualMatches, visitedActualElements)) {
+            return false;
+         }
+      }
+      return true;
+   }
+
+   private static boolean findArrayElementMatch(int expectedIndex, JsonNode expected, JsonNode actual,
+         ResponseExampleComparisonMode mode, int[] actualMatches, boolean[] visitedActualElements) {
+      for (int actualIndex = 0; actualIndex < actual.size(); actualIndex++) {
+         if (!visitedActualElements[actualIndex]
+               && matches(expected.get(expectedIndex), actual.get(actualIndex), mode)) {
+            visitedActualElements[actualIndex] = true;
+            if (actualMatches[actualIndex] == -1 || findArrayElementMatch(actualMatches[actualIndex], expected, actual,
+                  mode, actualMatches, visitedActualElements)) {
+               actualMatches[actualIndex] = expectedIndex;
+               return true;
+            }
+         }
+      }
+      return false;
+   }
+}

--- a/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPITestRunner.java
+++ b/webapp/src/main/java/io/github/microcks/util/openapi/OpenAPITestRunner.java
@@ -20,6 +20,7 @@ import io.github.microcks.domain.Request;
 import io.github.microcks.domain.Resource;
 import io.github.microcks.domain.ResourceType;
 import io.github.microcks.domain.Response;
+import io.github.microcks.domain.ResponseExampleComparisonMode;
 import io.github.microcks.domain.Service;
 import io.github.microcks.domain.TestReturn;
 import io.github.microcks.repository.ResourceRepository;
@@ -53,6 +54,7 @@ public class OpenAPITestRunner extends HttpTestRunner {
    private final ResponseRepository responseRepository;
 
    private final boolean validateResponseCode;
+   private final ResponseExampleComparisonMode responseExampleComparison;
 
 
    /** The URL of resources used for validation. */
@@ -68,9 +70,22 @@ public class OpenAPITestRunner extends HttpTestRunner {
     */
    public OpenAPITestRunner(ResourceRepository resourceRepository, ResponseRepository responseRepository,
          boolean validateResponseCode) {
+      this(resourceRepository, responseRepository, validateResponseCode, null);
+   }
+
+   /**
+    * Build a new OpenAPITestRunner.
+    * @param resourceRepository        Access to resources repository
+    * @param responseRepository        Access to response repository
+    * @param validateResponseCode      whether to validate response code
+    * @param responseExampleComparison optional comparison mode for response examples
+    */
+   public OpenAPITestRunner(ResourceRepository resourceRepository, ResponseRepository responseRepository,
+         boolean validateResponseCode, ResponseExampleComparisonMode responseExampleComparison) {
       this.resourceRepository = resourceRepository;
       this.responseRepository = responseRepository;
       this.validateResponseCode = validateResponseCode;
+      this.responseExampleComparison = responseExampleComparison;
    }
 
    /**
@@ -118,9 +133,13 @@ public class OpenAPITestRunner extends HttpTestRunner {
          log.debug("Response media-type is {}", httpResponse.getHeaders().getContentType());
       }
 
+      Response expectedResponse = null;
+      if ((validateResponseCode || responseExampleComparison != null) && request.getResponseId() != null) {
+         expectedResponse = responseRepository.findById(request.getResponseId()).orElse(null);
+      }
+
       // If required, compare response code and content-type to expected ones.
       if (validateResponseCode) {
-         Response expectedResponse = responseRepository.findById(request.getResponseId()).orElse(null);
          if (expectedResponse != null) {
             log.debug("Response expected status code: {}", expectedResponse.getStatus());
             if (!String.valueOf(responseCode).equals(expectedResponse.getStatus())) {
@@ -200,6 +219,30 @@ public class OpenAPITestRunner extends HttpTestRunner {
             return TestReturn.FAILURE_CODE;
          }
          log.debug("OpenAPI schema validation of response is successful !");
+
+         if (responseExampleComparison != null) {
+            if (expectedResponse == null || expectedResponse.getContent() == null
+                  || expectedResponse.getContent().isBlank()) {
+               lastValidationErrors = List.of("No response example is available for JSON response body comparison");
+               return TestReturn.FAILURE_CODE;
+            }
+
+            JsonNode expectedContentNode;
+            try {
+               expectedContentNode = OpenAPISchemaValidator.getJsonNode(expectedResponse.getContent());
+            } catch (IOException ioe) {
+               log.debug("Response example cannot be transformed as Json, returning failure");
+               lastValidationErrors = List.of("Response example cannot be transformed as JSON");
+               return TestReturn.FAILURE_CODE;
+            }
+
+            if (!JsonExampleComparator.matches(expectedContentNode, contentNode, responseExampleComparison)) {
+               lastValidationErrors = List.of(String.format(
+                     "Response body does not match response example using %s comparison", responseExampleComparison));
+               return TestReturn.FAILURE_CODE;
+            }
+            log.debug("Response body matches response example using {} comparison", responseExampleComparison);
+         }
       }
       return code;
    }

--- a/webapp/src/main/java/io/github/microcks/web/TestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/TestController.java
@@ -134,7 +134,7 @@ public class TestController {
       }
 
       TestOptionals testOptionals = new TestOptionals(secretRef, test.getTimeout(), test.getFilteredOperations(),
-            operationsHeaders, test.getOAuth2Context());
+            operationsHeaders, test.getOAuth2Context(), test.getResponseExampleComparison());
       TestResult testResult = testService.launchTests(service, test.getTestEndpoint(), testRunner, testOptionals);
       return new ResponseEntity<>(testResult, HttpStatus.CREATED);
    }

--- a/webapp/src/main/java/io/github/microcks/web/dto/TestRequestDTO.java
+++ b/webapp/src/main/java/io/github/microcks/web/dto/TestRequestDTO.java
@@ -16,6 +16,7 @@
 package io.github.microcks.web.dto;
 
 import io.github.microcks.domain.OAuth2ClientContext;
+import io.github.microcks.domain.ResponseExampleComparisonMode;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -35,6 +36,7 @@ public class TestRequestDTO {
    private Long timeout;
    private List<String> filteredOperations;
    private Map<String, List<HeaderDTO>> operationsHeaders;
+   private ResponseExampleComparisonMode responseExampleComparison;
    @JsonProperty("oAuth2Context")
    private OAuth2ClientContext oAuth2Context;
 
@@ -64,6 +66,10 @@ public class TestRequestDTO {
 
    public Map<String, List<HeaderDTO>> getOperationsHeaders() {
       return operationsHeaders;
+   }
+
+   public ResponseExampleComparisonMode getResponseExampleComparison() {
+      return responseExampleComparison;
    }
 
    public OAuth2ClientContext getOAuth2Context() {

--- a/webapp/src/main/webapp/src/app/models/test.model.ts
+++ b/webapp/src/main/webapp/src/app/models/test.model.ts
@@ -45,6 +45,7 @@ export type TestRequest = {
   runnerType: TestRunnerType;
   operationsHeaders: any;
   oAuth2Context: OAuth2ClientContext | undefined;
+  responseExampleComparison?: ResponseExampleComparisonMode;
 }
 
 export type TestResult = {
@@ -90,4 +91,9 @@ export enum TestRunnerType {
   ASYNC_API_SCHEMA = 'ASYNC_API_SCHEMA',
   GRPC_PROTOBUF = 'GRPC_PROTOBUF',
   GRAPHQL_SCHEMA = 'GRAPHQL_SCHEMA'
+}
+
+export enum ResponseExampleComparisonMode {
+  STRICT = 'STRICT',
+  LENIENT = 'LENIENT'
 }

--- a/webapp/src/test/java/io/github/microcks/util/openapi/JsonExampleComparatorTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/JsonExampleComparatorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.util.openapi;
+
+import io.github.microcks.domain.ResponseExampleComparisonMode;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonExampleComparatorTest {
+
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   @Test
+   void shouldStrictlyMatchObjectsAndUnorderedArrays() throws JsonProcessingException {
+      JsonNode expected = json("""
+            {"items":[{"id":1,"name":"one"},{"id":2,"name":"two"}],"active":true}
+            """);
+      JsonNode actual = json("""
+            {"active":true,"items":[{"name":"two","id":2.0},{"name":"one","id":1.0}]}
+            """);
+
+      assertTrue(JsonExampleComparator.matches(expected, actual, ResponseExampleComparisonMode.STRICT));
+   }
+
+   @Test
+   void shouldRejectAdditionalContentInStrictMode() throws JsonProcessingException {
+      JsonNode expected = json("""
+            {"items":[{"id":1}]}
+            """);
+
+      assertFalse(JsonExampleComparator.matches(expected, json("""
+            {"items":[{"id":1}],"traceId":"123"}
+            """), ResponseExampleComparisonMode.STRICT));
+      assertFalse(JsonExampleComparator.matches(expected, json("""
+            {"items":[{"id":1},{"id":2}]}
+            """), ResponseExampleComparisonMode.STRICT));
+   }
+
+   @Test
+   void shouldAllowAdditionalNestedContentInLenientMode() throws JsonProcessingException {
+      JsonNode expected = json("""
+            {"items":[{"id":1},{"id":2}]}
+            """);
+      JsonNode actual = json("""
+            {
+              "traceId":"123",
+              "items":[
+                {"id":2,"name":"two"},
+                {"id":3,"name":"three"},
+                {"id":1,"name":"one"}
+              ]
+            }
+            """);
+
+      assertTrue(JsonExampleComparator.matches(expected, actual, ResponseExampleComparisonMode.LENIENT));
+   }
+
+   @Test
+   void shouldRequireEveryExpectedArrayElementInLenientMode() throws JsonProcessingException {
+      JsonNode expected = json("""
+            [{"id":1},{"id":1}]
+            """);
+      JsonNode actual = json("""
+            [{"id":1,"name":"one"},{"id":2,"name":"two"}]
+            """);
+
+      assertFalse(JsonExampleComparator.matches(expected, actual, ResponseExampleComparisonMode.LENIENT));
+   }
+
+   @Test
+   void shouldFindDistinctMatchesForOverlappingLenientCandidates() throws JsonProcessingException {
+      JsonNode expected = json("""
+            [{"id":1},{"id":1,"kind":"primary"}]
+            """);
+      JsonNode actual = json("""
+            [
+              {"id":1,"kind":"primary"},
+              {"id":1,"kind":"secondary"},
+              {"id":2,"kind":"other"}
+            ]
+            """);
+
+      assertTrue(JsonExampleComparator.matches(expected, actual, ResponseExampleComparisonMode.LENIENT));
+   }
+
+   private static JsonNode json(String content) throws JsonProcessingException {
+      return MAPPER.readTree(content);
+   }
+}

--- a/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPITestRunnerTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/openapi/OpenAPITestRunnerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.util.openapi;
+
+import io.github.microcks.domain.Operation;
+import io.github.microcks.domain.Request;
+import io.github.microcks.domain.Resource;
+import io.github.microcks.domain.ResourceType;
+import io.github.microcks.domain.Response;
+import io.github.microcks.domain.ResponseExampleComparisonMode;
+import io.github.microcks.domain.Service;
+import io.github.microcks.domain.TestReturn;
+import io.github.microcks.repository.ResourceRepository;
+import io.github.microcks.repository.ResponseRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAPITestRunnerTest {
+
+   private static final String OPEN_API_SPEC = """
+         {
+           "openapi": "3.0.3",
+           "paths": {
+             "/items": {
+               "get": {
+                 "responses": {
+                   "200": {
+                     "content": {
+                       "application/json": {
+                         "schema": {
+                           "type": "object",
+                           "properties": {
+                             "items": {
+                               "type": "array",
+                               "items": {
+                                 "type": "object",
+                                 "properties": {
+                                   "id": {"type": "number"},
+                                   "name": {"type": "string"}
+                                 }
+                               }
+                             }
+                           }
+                         }
+                       }
+                     }
+                   }
+                 }
+               }
+             }
+           },
+           "components": {
+             "schemas": {}
+           }
+         }
+         """;
+
+   @Mock
+   private ResourceRepository resourceRepository;
+   @Mock
+   private ResponseRepository responseRepository;
+   @Mock
+   private ClientHttpResponse httpResponse;
+
+   private Service service;
+   private Operation operation;
+   private Request request;
+   private Response expectedResponse;
+
+   @BeforeEach
+   void setUp() throws IOException {
+      service = new Service();
+      service.setId("items-service");
+      service.setName("Items service");
+
+      operation = new Operation();
+      operation.setName("GET /items");
+      operation.setMethod(HttpMethod.GET.name());
+
+      request = new Request();
+      request.setResponseId("response-1");
+
+      expectedResponse = new Response();
+      expectedResponse.setStatus("200");
+      expectedResponse.setMediaType(MediaType.APPLICATION_JSON_VALUE);
+
+      Resource resource = new Resource();
+      resource.setType(ResourceType.OPEN_API_SPEC);
+      resource.setContent(OPEN_API_SPEC);
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.setContentType(MediaType.APPLICATION_JSON);
+
+      when(resourceRepository.findMainByServiceId(service.getId())).thenReturn(List.of(resource));
+      when(responseRepository.findById(request.getResponseId())).thenReturn(Optional.of(expectedResponse));
+      when(httpResponse.getStatusCode()).thenReturn(HttpStatus.OK);
+      when(httpResponse.getHeaders()).thenReturn(headers);
+   }
+
+   @Test
+   void shouldFailStrictComparisonWhenActualResponseHasAdditionalContent() {
+      expectedResponse.setContent("""
+            {"items":[{"id":1}]}
+            """);
+      OpenAPITestRunner runner = new OpenAPITestRunner(resourceRepository, responseRepository, true,
+            ResponseExampleComparisonMode.STRICT);
+
+      int result = runner.extractTestReturnCode(service, operation, request, httpResponse, """
+            {"items":[{"id":1}],"traceId":"123"}
+            """);
+
+      assertEquals(TestReturn.FAILURE_CODE, result);
+      assertEquals("Response body does not match response example using STRICT comparison\n",
+            runner.extractTestReturnMessage(service, operation, request, httpResponse));
+   }
+
+   @Test
+   void shouldPassLenientComparisonWithAdditionalObjectFieldsAndArrayElements() {
+      expectedResponse.setContent("""
+            {"items":[{"id":1}]}
+            """);
+      OpenAPITestRunner runner = new OpenAPITestRunner(resourceRepository, responseRepository, true,
+            ResponseExampleComparisonMode.LENIENT);
+
+      int result = runner.extractTestReturnCode(service, operation, request, httpResponse, """
+            {"items":[{"id":2,"name":"two"},{"id":1,"name":"one"}],"traceId":"123"}
+            """);
+
+      assertEquals(TestReturn.SUCCESS_CODE, result);
+      assertEquals("", runner.extractTestReturnMessage(service, operation, request, httpResponse));
+   }
+
+   @Test
+   void shouldPassStrictComparisonForReorderedArrays() {
+      expectedResponse.setContent("""
+            {"items":[{"id":1,"name":"one"},{"id":2,"name":"two"}]}
+            """);
+      OpenAPITestRunner runner = new OpenAPITestRunner(resourceRepository, responseRepository, true,
+            ResponseExampleComparisonMode.STRICT);
+
+      int result = runner.extractTestReturnCode(service, operation, request, httpResponse, """
+            {"items":[{"name":"two","id":2},{"name":"one","id":1}]}
+            """);
+
+      assertEquals(TestReturn.SUCCESS_CODE, result);
+   }
+
+   @Test
+   void shouldPreserveExistingSchemaOnlyBehaviorWhenComparisonIsNotRequested() {
+      expectedResponse.setContent("""
+            {"items":[{"id":1}]}
+            """);
+      OpenAPITestRunner runner = new OpenAPITestRunner(resourceRepository, responseRepository, true);
+
+      int result = runner.extractTestReturnCode(service, operation, request, httpResponse, """
+            {"items":[{"id":2}],"traceId":"123"}
+            """);
+
+      assertEquals(TestReturn.SUCCESS_CODE, result);
+   }
+}

--- a/webapp/src/test/java/io/github/microcks/web/TestControllerTest.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.web;
+
+import io.github.microcks.domain.ResponseExampleComparisonMode;
+import io.github.microcks.domain.Service;
+import io.github.microcks.domain.TestOptionals;
+import io.github.microcks.domain.TestResult;
+import io.github.microcks.domain.TestRunnerType;
+import io.github.microcks.repository.SecretRepository;
+import io.github.microcks.repository.TestResultRepository;
+import io.github.microcks.service.MessageService;
+import io.github.microcks.service.ServiceService;
+import io.github.microcks.service.TestService;
+import io.github.microcks.web.dto.TestRequestDTO;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TestControllerTest {
+
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   @Mock
+   private TestResultRepository testResultRepository;
+   @Mock
+   private SecretRepository secretRepository;
+   @Mock
+   private TestService testService;
+   @Mock
+   private MessageService messageService;
+   @Mock
+   private ServiceService serviceService;
+   @Mock
+   private TestRequestDTO testRequest;
+
+   @InjectMocks
+   private TestController controller;
+
+   @Test
+   void shouldDeserializeResponseExampleComparison() throws JsonProcessingException {
+      TestRequestDTO request = MAPPER.readValue("""
+            {
+              "serviceId": "service-1",
+              "testEndpoint": "https://example.com",
+              "runnerType": "OPEN_API_SCHEMA",
+              "timeout": 2000,
+              "responseExampleComparison": "STRICT"
+            }
+            """, TestRequestDTO.class);
+
+      assertEquals(ResponseExampleComparisonMode.STRICT, request.getResponseExampleComparison());
+   }
+
+   @Test
+   void shouldForwardResponseExampleComparisonToTestService() {
+      Service service = new Service();
+      service.setId("service-1");
+      TestResult testResult = new TestResult();
+
+      when(testRequest.getServiceId()).thenReturn(service.getId());
+      when(testRequest.getTestEndpoint()).thenReturn("https://example.com");
+      when(testRequest.getRunnerType()).thenReturn(TestRunnerType.OPEN_API_SCHEMA.name());
+      when(testRequest.getTimeout()).thenReturn(2000L);
+      when(testRequest.getResponseExampleComparison()).thenReturn(ResponseExampleComparisonMode.LENIENT);
+      when(serviceService.getServiceById(service.getId())).thenReturn(service);
+      when(testService.launchTests(eq(service), eq("https://example.com"), eq(TestRunnerType.OPEN_API_SCHEMA),
+            any(TestOptionals.class))).thenReturn(testResult);
+
+      ResponseEntity<Object> response = controller.createTest(testRequest);
+
+      ArgumentCaptor<TestOptionals> optionals = ArgumentCaptor.forClass(TestOptionals.class);
+      verify(testService).launchTests(eq(service), eq("https://example.com"), eq(TestRunnerType.OPEN_API_SCHEMA),
+            optionals.capture());
+      assertEquals(ResponseExampleComparisonMode.LENIENT, optionals.getValue().getResponseExampleComparison());
+      assertEquals(HttpStatus.CREATED, response.getStatusCode());
+      assertEquals(testResult, response.getBody());
+   }
+}


### PR DESCRIPTION
## What does this PR do?

  Adds optional JSON response-example comparison to the `/tests` API for `OPEN_API_SCHEMA` tests.

  Two comparison modes are supported:

  - `STRICT`: requires the same JSON structure and values while ignoring array ordering.
  - `LENIENT`: requires all expected values while allowing additional object fields and array elements.

  The comparison runs after the existing status-code, content-type, and schema validation. When the option is omitted, existing behavior remains unchanged.

  The OpenAPI specification and frontend TypeScript model are also updated.

  Closes #2243

  ## How was this tested?

  - Added matcher tests covering strict matching, lenient matching, unordered arrays, duplicate elements, and ambiguous array matches.
  - Added OpenAPI runner tests covering both modes and backward compatibility.
  - Added controller tests covering JSON deserialization and option propagation.
  - Java 25 Maven reactor build completed successfully.
  - 11 focused tests passed with 0 failures.
  - Spotless formatting and checks passed.
  - OpenAPI YAML parsing passed.
  
  > FOSSA reports 5 License Compliance issues, but the same check also fails on the PR’s base commit. This PR does not modify any dependency manifests or introduce new dependencies, so the findings appear to be pre-existing baseline issues.