### PR TITLE
Feature/amqps support 2233

### DIFF
--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
@@ -75,7 +75,7 @@ public class AMQPProducerManager {
       } catch (Exception e) {
          logger.errorf("Cannot connect to AMQP broker %s", amqpServer);
          logger.errorf("Connection exception: %s", e.getMessage());
-         throw e;
+         amqpConnection = null;
       }
    }
 

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
@@ -69,27 +69,26 @@ public class AMQPProducerManager {
     * @throws Exception If connection to AMQP Broker cannot be done.
     */
    @PostConstruct
-   public void create() throws Exception {
+   public void create() {
       try {
          amqpConnection = createConnection();
       } catch (Exception e) {
-         logger.errorf("Cannot connect to AMQP broker %s", amqpServer);
-         logger.errorf("Connection exception: %s", e.getMessage());
+         logger.errorf(e, "Cannot connect to AMQP broker %s", amqpServer);
          amqpConnection = null;
       }
    }
 
-  private String buildAmqpUri() {
-    if (amqpServer.contains("://")) {
-      return amqpServer;
-    }
+   static String buildAmqpUri() {
+      if (amqpServer.startsWith("amqp://") || amqpServer.startsWith("amqps://")) {
+         return amqpServer;
+      }
 
-    if (amqpServer.endsWith(":5671")) {
-      return "amqps://" + amqpServer;
-    }
+      if (amqpServer.endsWith(":5671")) {
+         return "amqps://" + amqpServer;
+      }
 
-    return "amqp://" + amqpServer;
-  }
+      return "amqp://" + amqpServer;
+   }
 
    /**
     * @return A newly created connection to configured broker
@@ -120,8 +119,8 @@ public class AMQPProducerManager {
    public void publishMessage(String destinationType, String destinationName, String routingKey, String value,
          Set<Header> headers) {
       if (amqpConnection == null) {
-        logger.warn("Skipping AMQP publish because broker is not connected");
-        return;
+         logger.warnf("Skipping AMQP publish to {%s}: broker is not connected", destinationName);
+         return;
       }
       logger.infof("Publishing on destination {%s}, message: %s ", destinationName, value);
       try (Channel channel = amqpConnection.createChannel()) {

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
@@ -119,6 +119,10 @@ public class AMQPProducerManager {
     */
    public void publishMessage(String destinationType, String destinationName, String routingKey, String value,
          Set<Header> headers) {
+      if (amqpConnection == null) {
+        logger.warn("Skipping AMQP publish because broker is not connected");
+        return;
+      }
       logger.infof("Publishing on destination {%s}, message: %s ", destinationName, value);
       try (Channel channel = amqpConnection.createChannel()) {
          channel.exchangeDeclare(destinationName, destinationType);

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
@@ -65,7 +65,7 @@ public class AMQPProducerManager {
 
    /**
     * Initialize the AMQP connection post construction.
-    * 
+    *
     * @throws Exception If connection to AMQP Broker cannot be done.
     */
    @PostConstruct
@@ -79,13 +79,25 @@ public class AMQPProducerManager {
       }
    }
 
+  private String buildAmqpUri() {
+    if (amqpServer.contains("://")) {
+      return amqpServer;
+    }
+
+    if (amqpServer.endsWith(":5671")) {
+      return "amqps://" + amqpServer;
+    }
+
+    return "amqp://" + amqpServer;
+  }
+
    /**
     * @return A newly created connection to configured broker
     * @throws Exception in case of connection failure
     */
    protected Connection createConnection() throws Exception {
       ConnectionFactory factory = new ConnectionFactory();
-      factory.setUri("amqp://" + amqpServer);
+      factory.setUri(buildAmqpUri());
 
       if (amqpUsername != null && !amqpUsername.isEmpty() && amqpPassword != null && !amqpPassword.isEmpty()) {
          logger.infof("Connecting to AMQP broker with user '%s'", amqpUsername);
@@ -98,7 +110,7 @@ public class AMQPProducerManager {
 
    /**
     * Publish a message on specified destination.
-    * 
+    *
     * @param destinationType The type of destination (queue, topic, fanout, ...)
     * @param destinationName The name of destination
     * @param routingKey      The routing key to use when publishing (may be null or empty)
@@ -144,7 +156,7 @@ public class AMQPProducerManager {
 
    /**
     * Render Microcks headers using the template engine.
-    * 
+    *
     * @param engine  The template engine to reuse (because we do not want to initialize and manage a context at the
     *                KafkaProducerManager level.)
     * @param headers The Microcks event message headers definition.

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
@@ -49,7 +49,7 @@ public class AMQPProducerManager {
    /** Get a JBoss logging logger. */
    private final Logger logger = Logger.getLogger(getClass());
 
-   private Connection amqpConnection;
+   private volatile Connection amqpConnection;
 
    @ConfigProperty(name = "amqp.server")
    String amqpServer;
@@ -63,22 +63,31 @@ public class AMQPProducerManager {
    @ConfigProperty(name = "amqp.password")
    String amqpPassword;
 
+
    /**
     * Initialize the AMQP connection post construction.
-    *
-    * @throws Exception If connection to AMQP Broker cannot be done.
     */
    @PostConstruct
    public void create() {
+      ensureConnection();
+   }
+
+   private synchronized boolean ensureConnection() {
+      if (amqpConnection != null && amqpConnection.isOpen()) {
+         return true;
+      }
+
       try {
          amqpConnection = createConnection();
+         return true;
       } catch (Exception e) {
-         logger.errorf(e, "Cannot connect to AMQP broker %s", amqpServer);
+         logger.warnf(e, "Cannot connect to AMQP broker %s", amqpServer);
          amqpConnection = null;
+         return false;
       }
    }
 
-   static String buildAmqpUri() {
+   String buildAmqpUri() {
       if (amqpServer.startsWith("amqp://") || amqpServer.startsWith("amqps://")) {
          return amqpServer;
       }
@@ -118,7 +127,7 @@ public class AMQPProducerManager {
     */
    public void publishMessage(String destinationType, String destinationName, String routingKey, String value,
          Set<Header> headers) {
-      if (amqpConnection == null) {
+      if (!ensureConnection()) {
          logger.warnf("Skipping AMQP publish to {%s}: broker is not connected", destinationName);
          return;
       }
@@ -138,7 +147,8 @@ public class AMQPProducerManager {
          String effectiveRoutingKey = (routingKey != null) ? routingKey : "";
          channel.basicPublish(destinationName, effectiveRoutingKey, properties, value.getBytes(StandardCharsets.UTF_8));
       } catch (IOException | TimeoutException ioe) {
-         logger.warnf("Message %s sending has thrown an exception", ioe);
+         logger.warnf(ioe, "Message %s sending has thrown an exception", value);
+         amqpConnection = null;
       }
    }
 

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/AMQPProducerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/AMQPProducerManagerTest.java
@@ -1,0 +1,51 @@
+package io.github.microcks.minion.async.producer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link AMQPProducerManager}.
+ */
+class AMQPProducerManagerTest {
+
+   @Test
+   void shouldBuildDefaultAmqpUri() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "rabbitmq";
+
+      assertEquals("amqp://rabbitmq", manager.buildAmqpUri());
+   }
+
+   @Test
+   void shouldBuildAmqpUriForStandardPort() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "rabbitmq:5672";
+
+      assertEquals("amqp://rabbitmq:5672", manager.buildAmqpUri());
+   }
+
+   @Test
+   void shouldBuildAmqpsUriForTlsPort() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "rabbitmq:5671";
+
+      assertEquals("amqps://rabbitmq:5671", manager.buildAmqpUri());
+   }
+
+   @Test
+   void shouldKeepExplicitAmqpUri() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "amqp://rabbitmq:5672";
+
+      assertEquals("amqp://rabbitmq:5672", manager.buildAmqpUri());
+   }
+
+   @Test
+   void shouldKeepExplicitAmqpsUri() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "amqps://rabbitmq:5671";
+
+      assertEquals("amqps://rabbitmq:5671", manager.buildAmqpUri());
+   }
+}


### PR DESCRIPTION
## Summary

This PR improves the AMQP producer used by the async minion by:

- Supporting explicit `amqp://` and `amqps://` URIs.
- Automatically using `amqps://` when the configured broker uses port `5671`.
- Allowing the async minion to start even when the AMQP broker is temporarily unavailable.
- Skipping message publication when no AMQP connection is available instead of failing.
- Adding unit tests covering AMQP URI construction.

## Changes

- Added `buildAmqpUri()` to centralize AMQP URI creation.
- Updated `createConnection()` to use the generated URI.
- Made AMQP connection failures during startup non-fatal by logging the error and continuing startup.
- Added a null guard in `publishMessage()` to safely skip publishing when no broker connection exists.
- Added unit tests for:
  - Default `amqp://` URI generation
  - Standard port (`5672`)
  - TLS port (`5671`)
  - Explicit `amqp://` URIs
  - Explicit `amqps://` URIs

## Testing

- Ran `mvn spotless:apply`
- Verified Spotless checks pass
- Added unit tests for URI construction

Fixes #2233