### PR TITLE
fix: retain examples from all messages of an AsyncAPI 3 operation

### DIFF
--- a/webapp/src/main/java/io/github/microcks/util/asyncapi/AsyncAPI3Importer.java
+++ b/webapp/src/main/java/io/github/microcks/util/asyncapi/AsyncAPI3Importer.java
@@ -421,7 +421,7 @@ public class AsyncAPI3Importer extends AbstractJsonRepositoryImporter implements
 
    /** Build a list of EventMessages from a "messages" Json node. */
    private List<EventMessage> buildEventMessages(JsonNode messagesNode, String defaultContentType) {
-      List<EventMessage> eventMessages = null;
+      List<EventMessage> eventMessages = new ArrayList<>();
       for (JsonNode messageRefNode : messagesNode) {
          JsonNode messageInChannelNode = followRefIfAny(messageRefNode);
          JsonNode msgNode = followRefIfAny(messageInChannelNode);
@@ -438,7 +438,7 @@ public class AsyncAPI3Importer extends AbstractJsonRepositoryImporter implements
          if (messageName != null && msgNode.has(EXAMPLES_NODE)) {
             // Compute a short message name if examples have no name attribute.
             messageName = messageName.substring(messageName.lastIndexOf("/") + 1);
-            eventMessages = buildEventMessageFromExamples(messageName, contentType, msgNode.get(EXAMPLES_NODE));
+            eventMessages.addAll(buildEventMessageFromExamples(messageName, contentType, msgNode.get(EXAMPLES_NODE)));
          }
       }
       return eventMessages;

--- a/webapp/src/test/java/io/github/microcks/util/asyncapi/AsyncAPI3ImporterTest.java
+++ b/webapp/src/test/java/io/github/microcks/util/asyncapi/AsyncAPI3ImporterTest.java
@@ -553,6 +553,65 @@ class AsyncAPI3ImporterTest {
    }
 
    @Test
+   void testMultiMessagesAsyncAPI3ImportYAML() {
+      AsyncAPI3Importer importer = null;
+      try {
+         importer = new AsyncAPI3Importer(
+               "target/test-classes/io/github/microcks/util/asyncapi/user-lifecycle-asyncapi-3.0-multi-messages.yaml",
+               null);
+      } catch (IOException ioe) {
+         Assertions.fail("Exception should not be thrown");
+      }
+
+      // Check that basic service properties are there.
+      List<Service> services = null;
+      try {
+         services = importer.getServiceDefinitions();
+      } catch (MockRepositoryImportException e) {
+         Assertions.fail("Exception should not be thrown");
+      }
+
+      Assertions.assertEquals(1, services.size());
+      Service service = services.get(0);
+      Assertions.assertEquals("User lifecycle API", service.getName());
+      Assertions.assertEquals(ServiceType.EVENT, service.getType());
+
+      // Check that operations and input/output have been found.
+      assertEquals(1, service.getOperations().size());
+      Operation operation = service.getOperations().get(0);
+      assertEquals("SEND publishUserLifecycleEvents", operation.getName());
+
+      // Check that examples from all the operation messages have been found.
+      List<Exchange> exchanges = null;
+      try {
+         exchanges = importer.getMessageDefinitions(service, operation);
+      } catch (Exception e) {
+         fail("No exception should be thrown when importing message definitions.");
+      }
+      assertEquals(3, exchanges.size());
+
+      for (Exchange exchange : exchanges) {
+         if (exchange instanceof UnidirectionalEvent) {
+            UnidirectionalEvent event = (UnidirectionalEvent) exchange;
+            EventMessage eventMessage = event.getEventMessage();
+            assertNotNull(eventMessage);
+
+            if ("laurent".equals(eventMessage.getName())) {
+               assertTrue(eventMessage.getContent().contains("laurent@microcks.io"));
+            } else if ("john".equals(eventMessage.getName())) {
+               assertTrue(eventMessage.getContent().contains("John Doe"));
+            } else if ("laurentDeleted".equals(eventMessage.getName())) {
+               assertTrue(eventMessage.getContent().contains("Asked for account removal"));
+            } else {
+               fail("Unknown message name: " + eventMessage.getName());
+            }
+         } else {
+            fail("Exchange has the wrong type. Expecting UnidirectionalEvent");
+         }
+      }
+   }
+
+   @Test
    void testReplyInfoAsyncAPI3ImportYAML() {
       AsyncAPI3Importer importer = null;
       try {

--- a/webapp/src/test/resources/io/github/microcks/util/asyncapi/user-lifecycle-asyncapi-3.0-multi-messages.yaml
+++ b/webapp/src/test/resources/io/github/microcks/util/asyncapi/user-lifecycle-asyncapi-3.0-multi-messages.yaml
@@ -1,0 +1,71 @@
+asyncapi: 3.0.0
+id: 'urn:io.microcks.example.user-lifecycle'
+info:
+  title: User lifecycle API
+  version: 0.1.0
+  description: Sample AsyncAPI with one operation referencing multiple messages
+  contact:
+    name: Laurent Broudoux
+    url: https://github.com/lbroudoux
+    email: laurent@microcks.io
+  license:
+    name: MIT License
+    url: https://opensource.org/licenses/MIT
+defaultContentType: application/json
+channels:
+  user-lifecycle:
+    description: The topic on which user lifecycle events may be consumed
+    messages:
+      userSignedUp:
+        $ref: '#/components/messages/userSignedUp'
+      userDeleted:
+        $ref: '#/components/messages/userDeleted'
+operations:
+  publishUserLifecycleEvents:
+    action: 'send'
+    channel:
+      $ref: '#/channels/user-lifecycle'
+    summary: Receive information about user lifecycle
+    messages:
+      - $ref: '#/channels/user-lifecycle/messages/userSignedUp'
+      - $ref: '#/channels/user-lifecycle/messages/userDeleted'
+components:
+  messages:
+    userSignedUp:
+      description: An event describing that a user just signed up
+      payload:
+        type: object
+        additionalProperties: false
+        properties:
+          fullName:
+            type: string
+          email:
+            type: string
+            format: email
+      examples:
+        - name: laurent
+          summary: Example for Laurent user
+          payload:
+            fullName: Laurent Broudoux
+            email: laurent@microcks.io
+        - name: john
+          summary: Example for John Doe user
+          payload:
+            fullName: John Doe
+            email: john@microcks.io
+    userDeleted:
+      description: An event describing that a user was deleted
+      payload:
+        type: object
+        additionalProperties: false
+        properties:
+          fullName:
+            type: string
+          reason:
+            type: string
+      examples:
+        - name: laurentDeleted
+          summary: Example for Laurent user deletion
+          payload:
+            fullName: Laurent Broudoux
+            reason: Asked for account removal


### PR DESCRIPTION
## Description

Fixes #2273 — importing an AsyncAPI 3.x document where one operation references multiple messages retained only the last message's examples; all others were silently dropped, so async mocks published a single event type.

`AsyncAPI3Importer.buildEventMessages` reassigned its result list on each iteration of the message loop. This change initialises the list once and accumulates with `addAll`, matching the v2 importer's behaviour for `message.oneOf`.

## Changes

- `AsyncAPI3Importer.buildEventMessages`: accumulate examples across all operation messages (2 lines)
- New test `testMultiMessagesAsyncAPI3ImportYAML` + resource spec with one `send` operation referencing two messages (2 + 1 examples): fails with `expected: <3> but was: <1>` before the fix, passes after; all existing `AsyncAPI3ImporterTest` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)