### PR TITLE
test: migrate webapp ITs to RestTestClient

### DIFF
--- a/webapp/src/test/java/io/github/microcks/MicrocksApplicationFuzz.java
+++ b/webapp/src/test/java/io/github/microcks/MicrocksApplicationFuzz.java
@@ -23,14 +23,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
+import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.MockMvcPrint;
 import org.springframework.core.io.FileSystemResource;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -57,7 +56,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
  * @author laurent
  */
 @AutoConfigureMockMvc(print = MockMvcPrint.NONE)
-@AutoConfigureTestRestTemplate
+@AutoConfigureRestTestClient
 @SpringBootTest(classes = MicrocksApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("fuzz")
 @TestPropertySource(locations = { "classpath:/config/fuzz.properties" })
@@ -88,7 +87,7 @@ public class MicrocksApplicationFuzz {
    protected MockMvc mockMvc;
 
    @Autowired
-   protected TestRestTemplate restTemplate;
+   protected RestTestClient restTestClient;
 
    private boolean beforeCalled = false;
 
@@ -142,13 +141,15 @@ public class MicrocksApplicationFuzz {
       MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
       body.add("file", new FileSystemResource(new File(artifactFilePath)));
 
-      HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
       ResponseEntity<String> response;
       if (isMainArtifact) {
-         response = restTemplate.postForEntity("/api/artifact/upload", requestEntity, String.class);
+         var result = restTestClient.post().uri("/api/artifact/upload").headers(h -> h.addAll(headers)).body(body)
+               .exchange().returnResult(String.class);
+         response = new ResponseEntity<>(result.getResponseBody(), result.getResponseHeaders(), result.getStatus());
       } else {
-         response = restTemplate.postForEntity("/api/artifact/upload?mainArtifact=false", requestEntity, String.class);
+         var result = restTestClient.post().uri("/api/artifact/upload?mainArtifact=false")
+               .headers(h -> h.addAll(headers)).body(body).exchange().returnResult(String.class);
+         response = new ResponseEntity<>(result.getResponseBody(), result.getResponseHeaders(), result.getStatus());
       }
 
       assertEquals(201, response.getStatusCode().value());

--- a/webapp/src/test/java/io/github/microcks/web/AbstractBaseIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/AbstractBaseIT.java
@@ -21,25 +21,33 @@ import io.github.microcks.repository.ServiceRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.TestRestTemplate;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
+import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
 import org.testcontainers.mongodb.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
+import java.io.InputStream;
+import java.net.http.HttpClient;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -48,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author laurent
  */
 @SpringBootTest(classes = MicrocksApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureTestRestTemplate
+@AutoConfigureRestTestClient
 @ActiveProfiles("it")
 @TestPropertySource(locations = { "classpath:/config/test.properties" })
 public abstract class AbstractBaseIT {
@@ -60,7 +68,7 @@ public abstract class AbstractBaseIT {
    private int port;
 
    @Autowired
-   protected TestRestTemplate restTemplate;
+   protected RestTestClient restTestClient;
 
    @Autowired
    protected ServiceRepository serviceRepository;
@@ -95,13 +103,15 @@ public abstract class AbstractBaseIT {
       MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
       body.add("file", new FileSystemResource(new File(artifactFilePath)));
 
-      HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
-
       ResponseEntity<String> response;
       if (isMainArtifact) {
-         response = restTemplate.postForEntity("/api/artifact/upload", requestEntity, String.class);
+         var result = restTestClient.post().uri("/api/artifact/upload").headers(h -> h.addAll(headers)).body(body)
+               .exchange().returnResult(String.class);
+         response = responseEntity(result);
       } else {
-         response = restTemplate.postForEntity("/api/artifact/upload?mainArtifact=false", requestEntity, String.class);
+         var result = restTestClient.post().uri("/api/artifact/upload?mainArtifact=false")
+               .headers(h -> h.addAll(headers)).body(body).exchange().returnResult(String.class);
+         response = responseEntity(result);
       }
 
       assertEquals(201, response.getStatusCode().value());
@@ -112,5 +122,63 @@ public abstract class AbstractBaseIT {
       assertEquals(200, response.getStatusCode().value());
       assertNotNull(response.getBody());
       assertTrue(response.getBody().contains(substring));
+   }
+
+   protected <T> ResponseEntity<T> getForEntity(String uri, Class<T> responseType) {
+      var result = restTestClient.get().uri(uri).exchange().returnResult(responseType);
+      return responseEntity(result);
+   }
+
+   protected <T> ResponseEntity<T> postForEntity(String uri, Object request, Class<T> responseType) {
+      var requestSpec = restTestClient.post().uri(uri);
+      configureRequest(requestSpec, request);
+      var result = requestSpec.exchange().returnResult(responseType);
+      return responseEntity(result);
+   }
+
+   protected <T> ResponseEntity<T> exchange(String uri, HttpMethod method, HttpEntity<?> request, Class<T> responseType) {
+      var requestSpec = restTestClient.method(method).uri(uri);
+      configureRequest(requestSpec, request);
+      var result = requestSpec.exchange().returnResult(responseType);
+      return responseEntity(result);
+   }
+
+   protected <T> ResponseEntity<T> exchange(String uri, HttpMethod method, HttpEntity<?> request,
+         ParameterizedTypeReference<T> responseType) {
+      var requestSpec = restTestClient.method(method).uri(uri);
+      configureRequest(requestSpec, request);
+      var result = requestSpec.exchange().returnResult(responseType);
+      return responseEntity(result);
+   }
+
+   protected void executeSse(String uri, Consumer<InputStream> responseConsumer) {
+      RestClient.builder().baseUrl(getServerUrl()).build().get().uri(uri)
+            .exchange((request, response) -> {
+               responseConsumer.accept(response.getBody());
+               return null;
+            });
+   }
+
+   protected <T> ResponseEntity<T> getForEntityWithoutRedirects(String uri, Class<T> responseType) {
+      var requestFactory = new JdkClientHttpRequestFactory(HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER).build());
+      var client = RestTestClient.bindToServer(requestFactory).baseUrl(getServerUrl()).build();
+      var result = client.get().uri(uri).exchange().returnResult(responseType);
+      return responseEntity(result);
+   }
+
+   private void configureRequest(RestTestClient.RequestBodySpec requestSpec, Object request) {
+      if (request instanceof HttpEntity<?> entity) {
+         requestSpec.headers(headers -> headers.addAll(entity.getHeaders()));
+         if (entity.getBody() != null) {
+            requestSpec.body(entity.getBody());
+         }
+      } else if (request != null) {
+         requestSpec.body(request);
+      }
+   }
+
+   private <T> ResponseEntity<T> responseEntity(EntityExchangeResult<T> result) {
+      return new ResponseEntity<>(result.getResponseBody(), result.getResponseHeaders(), result.getStatus());
    }
 }

--- a/webapp/src/test/java/io/github/microcks/web/AbstractBaseIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/AbstractBaseIT.java
@@ -136,7 +136,8 @@ public abstract class AbstractBaseIT {
       return responseEntity(result);
    }
 
-   protected <T> ResponseEntity<T> exchange(String uri, HttpMethod method, HttpEntity<?> request, Class<T> responseType) {
+   protected <T> ResponseEntity<T> exchange(String uri, HttpMethod method, HttpEntity<?> request,
+         Class<T> responseType) {
       var requestSpec = restTestClient.method(method).uri(uri);
       configureRequest(requestSpec, request);
       var result = requestSpec.exchange().returnResult(responseType);
@@ -152,16 +153,15 @@ public abstract class AbstractBaseIT {
    }
 
    protected void executeSse(String uri, Consumer<InputStream> responseConsumer) {
-      RestClient.builder().baseUrl(getServerUrl()).build().get().uri(uri)
-            .exchange((request, response) -> {
-               responseConsumer.accept(response.getBody());
-               return null;
-            });
+      RestClient.builder().baseUrl(getServerUrl()).build().get().uri(uri).exchange((request, response) -> {
+         responseConsumer.accept(response.getBody());
+         return null;
+      });
    }
 
    protected <T> ResponseEntity<T> getForEntityWithoutRedirects(String uri, Class<T> responseType) {
-      var requestFactory = new JdkClientHttpRequestFactory(HttpClient.newBuilder()
-            .followRedirects(HttpClient.Redirect.NEVER).build());
+      var requestFactory = new JdkClientHttpRequestFactory(
+            HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NEVER).build());
       var client = RestTestClient.bindToServer(requestFactory).baseUrl(getServerUrl()).build();
       var result = client.get().uri(uri).exchange().returnResult(responseType);
       return responseEntity(result);

--- a/webapp/src/test/java/io/github/microcks/web/DynamicMockRestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/DynamicMockRestControllerIT.java
@@ -57,7 +57,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
          headers.setContentType(MediaType.APPLICATION_JSON);
 
          HttpEntity<GenericResourceServiceDTO> request = new HttpEntity<>(dto, headers);
-         ResponseEntity<String> response = restTemplate.postForEntity("/api/services/generic", request, String.class);
+         ResponseEntity<String> response = postForEntity("/api/services/generic", request, String.class);
          assertEquals(201, response.getStatusCode().value(), "Generic REST service should be created");
       }
    }
@@ -66,7 +66,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testCreateResource() throws Exception {
       String body = "{\"productId\": \"ABC123\", \"quantity\": 2, \"price\": 19.99}";
 
-      ResponseEntity<String> response = restTemplate.postForEntity(
+      ResponseEntity<String> response = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
 
       assertEquals(201, response.getStatusCode().value());
@@ -82,7 +82,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testCreateResourceWithInvalidJson() {
       String invalidBody = "this is not json";
 
-      ResponseEntity<String> response = restTemplate.postForEntity(
+      ResponseEntity<String> response = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, invalidBody, String.class);
 
       assertEquals(422, response.getStatusCode().value());
@@ -103,9 +103,9 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       // First, create two resources.
       String body1 = "{\"productId\": \"FIND1\", \"quantity\": 1}";
       String body2 = "{\"productId\": \"FIND2\", \"quantity\": 5}";
-      restTemplate.postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body1,
+      postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body1,
             String.class);
-      restTemplate.postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body2,
+      postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body2,
             String.class);
 
       // Now list resources.
@@ -125,12 +125,12 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       // Create a few resources for pagination.
       for (int i = 0; i < 3; i++) {
          String body = "{\"productId\": \"PAGE" + i + "\"}";
-         restTemplate.postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body,
+         postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body,
                String.class);
       }
 
       // Request with small page size.
-      ResponseEntity<String> response = restTemplate.getForEntity(
+      ResponseEntity<String> response = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "?page=0&size=2",
             String.class);
 
@@ -146,7 +146,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testGetResourceById() throws Exception {
       // Create a resource first.
       String body = "{\"productId\": \"GET1\", \"quantity\": 10}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      ResponseEntity<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
       assertEquals(201, createResponse.getStatusCode().value());
 
@@ -154,7 +154,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       String resourceId = created.get("id").asText();
 
       // Now get the resource by id.
-      ResponseEntity<String> response = restTemplate.getForEntity(
+      ResponseEntity<String> response = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
 
@@ -169,7 +169,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
 
    @Test
    void testGetResourceByIdNotFound() {
-      ResponseEntity<String> response = restTemplate.getForEntity(
+      ResponseEntity<String> response = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/nonexistent-id-12345",
             String.class);
 
@@ -180,7 +180,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testUpdateResource() throws Exception {
       // Create a resource.
       String body = "{\"productId\": \"UPD1\", \"quantity\": 3}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      ResponseEntity<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
       assertEquals(201, createResponse.getStatusCode().value());
 
@@ -193,7 +193,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> requestEntity = new HttpEntity<>(updatedBody, headers);
 
-      ResponseEntity<String> response = restTemplate.exchange(
+      ResponseEntity<String> response = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.PUT, requestEntity, String.class);
 
@@ -204,7 +204,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       assertEquals(42, node.get("quantity").asInt());
 
       // Verify the update by retrieving the resource.
-      ResponseEntity<String> getResponse = restTemplate.getForEntity(
+      ResponseEntity<String> getResponse = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
       assertEquals(200, getResponse.getStatusCode().value());
@@ -216,7 +216,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testUpdateResourceWithInvalidJson() throws Exception {
       // Create a resource first.
       String body = "{\"productId\": \"UPD_INV\", \"quantity\": 1}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      ResponseEntity<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
       assertEquals(201, createResponse.getStatusCode().value());
 
@@ -228,7 +228,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> requestEntity = new HttpEntity<>("this is not json", headers);
 
-      ResponseEntity<String> response = restTemplate.exchange(
+      ResponseEntity<String> response = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.PUT, requestEntity, String.class);
 
@@ -242,7 +242,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> requestEntity = new HttpEntity<>(updatedBody, headers);
 
-      ResponseEntity<String> response = restTemplate.exchange(
+      ResponseEntity<String> response = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/nonexistent-id-12345",
             HttpMethod.PUT, requestEntity, String.class);
 
@@ -253,7 +253,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testDeleteResource() throws Exception {
       // Create a resource.
       String body = "{\"productId\": \"DEL1\", \"quantity\": 7}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      ResponseEntity<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
       assertEquals(201, createResponse.getStatusCode().value());
 
@@ -261,14 +261,14 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       String resourceId = created.get("id").asText();
 
       // Delete the resource.
-      ResponseEntity<String> response = restTemplate.exchange(
+      ResponseEntity<String> response = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.DELETE, null, String.class);
 
       assertEquals(204, response.getStatusCode().value());
 
       // Verify it's deleted.
-      ResponseEntity<String> getResponse = restTemplate.getForEntity(
+      ResponseEntity<String> getResponse = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
       assertEquals(404, getResponse.getStatusCode().value());
@@ -276,7 +276,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
 
    @Test
    void testDeleteResourceForUnknownService() {
-      ResponseEntity<String> response = restTemplate.exchange(
+      ResponseEntity<String> response = exchange(
             "/dynarest/UnknownService/" + SERVICE_VERSION + "/" + RESOURCE + "/some-id", HttpMethod.DELETE, null,
             String.class);
 
@@ -287,7 +287,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
    void testFullCrudLifecycle() throws Exception {
       // CREATE
       String body = "{\"name\": \"Widget\", \"status\": \"new\"}";
-      ResponseEntity<String> createResponse = restTemplate.postForEntity(
+      ResponseEntity<String> createResponse = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body, String.class);
       assertEquals(201, createResponse.getStatusCode().value());
       JsonNode created = mapper.readTree(createResponse.getBody());
@@ -295,7 +295,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       assertNotNull(resourceId);
 
       // READ
-      ResponseEntity<String> getResponse = restTemplate.getForEntity(
+      ResponseEntity<String> getResponse = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
       assertEquals(200, getResponse.getStatusCode().value());
@@ -309,7 +309,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> updateEntity = new HttpEntity<>(updatedBody, headers);
 
-      ResponseEntity<String> updateResponse = restTemplate.exchange(
+      ResponseEntity<String> updateResponse = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.PUT, updateEntity, String.class);
       assertEquals(200, updateResponse.getStatusCode().value());
@@ -325,13 +325,13 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       assertFalse(list.isEmpty());
 
       // DELETE
-      ResponseEntity<String> deleteResponse = restTemplate.exchange(
+      ResponseEntity<String> deleteResponse = exchange(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             HttpMethod.DELETE, null, String.class);
       assertEquals(204, deleteResponse.getStatusCode().value());
 
       // VERIFY DELETED
-      ResponseEntity<String> deletedGetResponse = restTemplate.getForEntity(
+      ResponseEntity<String> deletedGetResponse = getForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "/" + resourceId,
             String.class);
       assertEquals(404, deletedGetResponse.getStatusCode().value());
@@ -343,7 +343,7 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       long delay = 200L;
 
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate.postForEntity(
+      ResponseEntity<String> response = postForEntity(
             "/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE + "?delay=" + delay, body,
             String.class);
       long elapsed = System.currentTimeMillis() - startTime;

--- a/webapp/src/test/java/io/github/microcks/web/DynamicMockRestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/DynamicMockRestControllerIT.java
@@ -103,10 +103,8 @@ class DynamicMockRestControllerIT extends AbstractBaseIT {
       // First, create two resources.
       String body1 = "{\"productId\": \"FIND1\", \"quantity\": 1}";
       String body2 = "{\"productId\": \"FIND2\", \"quantity\": 5}";
-      postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body1,
-            String.class);
-      postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body2,
-            String.class);
+      postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body1, String.class);
+      postForEntity("/dynarest/" + encodedServiceName() + "/" + SERVICE_VERSION + "/" + RESOURCE, body2, String.class);
 
       // Now list resources.
       ResponseEntity<String> response = restTemplate

--- a/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/GraphQLControllerIT.java
@@ -57,7 +57,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       String query = mapper.createObjectNode().put("query", subQuery).toString();
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      ResponseEntity<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -90,7 +90,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -121,7 +121,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
       var requestBody = mapper.createObjectNode().put("query", subQuery);
       requestBody.putObject("variables").put("id", "ZmlsbXM6MQ==");
       query = requestBody.toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -153,7 +153,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               starCount
             }""";
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -188,7 +188,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
             }
             """;
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -220,7 +220,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -256,7 +256,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -298,7 +298,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -338,7 +338,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("""
@@ -379,9 +379,9 @@ class GraphQLControllerIT extends AbstractBaseIT {
       requestBody.putObject("variables").put("filmId", "notavailable");
       String query = requestBody.toString();
 
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      ResponseEntity<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertNotNull(response.getBody(), "Response body should not be null");
       assertTrue(response.getBody().contains("\"errors\""));
       assertTrue(response.getBody().contains("\"extensions\""));
@@ -432,7 +432,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
       // Execute and assert that it was proxy.
       String query = """
             {"query": "query film($id: String) {film(id: \\"ZmlsbXM6Mg==\\") {id title episodeID starCount comment}}"}""";
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      ResponseEntity<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertResponseIsOkAndContains(response, "\"comment\":\"Original!!!\"");
    }
 
@@ -459,7 +459,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
       // Execute and assert that it wasn't proxy.
       String query = """
             {"query": "query film($id: String) {film(id: \\"ZmlsbXM6Mg==\\") {id title episodeID starCount comment}}"}""";
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      ResponseEntity<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       assertNotNull(response.getBody());
       assertFalse(response.getBody().contains("\"comment\":\"Original!!!\""));
@@ -467,7 +467,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
       // Execute and assert that it was proxy.
       query = """
             {"query": "query film($id: String) {film(id: \\"ZmlsbXM6MA==\\") {id title episodeID starCount comment}}"}""";
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertResponseIsOkAndContains(response, "\"comment\":\"Original!!!\"");
    }
 
@@ -488,7 +488,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       String query = mapper.createObjectNode().put("query", subQuery).toString();
-      ResponseEntity<String> response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      ResponseEntity<String> response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JsonNode responseJson = mapper.readTree(response.getBody());
@@ -519,7 +519,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JsonNode responseJson = mapper.readTree(response.getBody());
@@ -548,7 +548,7 @@ class GraphQLControllerIT extends AbstractBaseIT {
               }
             }""";
       query = mapper.createObjectNode().put("query", subQuery).toString();
-      response = restTemplate.postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
+      response = postForEntity("/graphql/Movie+Graph+API/1.0", query, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JsonNode responseJson = mapper.readTree(response.getBody());

--- a/webapp/src/test/java/io/github/microcks/web/McpControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/McpControllerIT.java
@@ -70,16 +70,16 @@ class McpControllerIT extends AbstractBaseIT {
       // Define the runnable for the SSE client.
       Runnable sseClientRunnable = () -> {
          try {
-            restTemplate.execute("/mcp/Petstore+API/1.0.0/sse", HttpMethod.GET, request -> {}, response -> {
+            executeSse("/mcp/Petstore+API/1.0.0/sse", response -> {
                String line;
-               try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody()));) {
+               try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response));) {
                   while ((line = bufferedReader.readLine()) != null) {
                      parseAndStoreMcpSseFrame(line, sseFrames);
                   }
                } catch (IOException e) {
                   System.err.println("Caught exception while reading SSE response: " + e.getMessage());
                }
-               return response;
+               return;
             });
          } catch (Exception e) {
             System.err.println("Caught exception while executing SSE client: " + e.getMessage());
@@ -128,7 +128,7 @@ class McpControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
 
-      ResponseEntity<String> response = restTemplate.postForEntity(messageEndpoint,
+      ResponseEntity<String> response = postForEntity(messageEndpoint,
             new HttpEntity<>(initializeRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
@@ -162,7 +162,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -200,7 +200,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -234,18 +234,17 @@ class McpControllerIT extends AbstractBaseIT {
       // Define the runnable for the SSE client.
       Runnable sseClientRunnable = () -> {
          try {
-            restTemplate.execute("/mcp/org.acme.petstore.v1.PetstoreService/v1/sse", HttpMethod.GET, request -> {},
-                  response -> {
+            executeSse("/mcp/org.acme.petstore.v1.PetstoreService/v1/sse", response -> {
                      String line;
                      try (BufferedReader bufferedReader = new BufferedReader(
-                           new InputStreamReader(response.getBody()));) {
+                           new InputStreamReader(response));) {
                         while ((line = bufferedReader.readLine()) != null) {
                            parseAndStoreMcpSseFrame(line, sseFrames);
                         }
                      } catch (IOException e) {
                         System.err.println("Caught exception while reading SSE response: " + e.getMessage());
                      }
-                     return response;
+                     return;
                   });
          } catch (Exception e) {
             System.err.println("Caught exception while executing SSE client: " + e.getMessage());
@@ -294,7 +293,7 @@ class McpControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
 
-      ResponseEntity<String> response = restTemplate.postForEntity(messageEndpoint,
+      ResponseEntity<String> response = postForEntity(messageEndpoint,
             new HttpEntity<>(initializeRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
@@ -328,7 +327,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -366,7 +365,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -402,16 +401,16 @@ class McpControllerIT extends AbstractBaseIT {
       // Define the runnable for the SSE client.
       Runnable sseClientRunnable = () -> {
          try {
-            restTemplate.execute("/mcp/Petstore+Graph+API/1.0/sse", HttpMethod.GET, request -> {}, response -> {
+            executeSse("/mcp/Petstore+Graph+API/1.0/sse", response -> {
                String line;
-               try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody()));) {
+               try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response));) {
                   while ((line = bufferedReader.readLine()) != null) {
                      parseAndStoreMcpSseFrame(line, sseFrames);
                   }
                } catch (IOException e) {
                   System.err.println("Caught exception while reading SSE response: " + e.getMessage());
                }
-               return response;
+               return;
             });
          } catch (Exception e) {
             System.err.println("Caught exception while executing SSE client: " + e.getMessage());
@@ -460,7 +459,7 @@ class McpControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
 
-      ResponseEntity<String> response = restTemplate.postForEntity(messageEndpoint,
+      ResponseEntity<String> response = postForEntity(messageEndpoint,
             new HttpEntity<>(initializeRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
@@ -491,7 +490,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsListRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -532,7 +531,7 @@ class McpControllerIT extends AbstractBaseIT {
             }
             """;
 
-      response = restTemplate.postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
+      response = postForEntity(messageEndpoint, new HttpEntity<>(toolsCallRequest, headers), String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);

--- a/webapp/src/test/java/io/github/microcks/web/McpControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/McpControllerIT.java
@@ -128,8 +128,8 @@ class McpControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
 
-      ResponseEntity<String> response = postForEntity(messageEndpoint,
-            new HttpEntity<>(initializeRequest, headers), String.class);
+      ResponseEntity<String> response = postForEntity(messageEndpoint, new HttpEntity<>(initializeRequest, headers),
+            String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -235,17 +235,16 @@ class McpControllerIT extends AbstractBaseIT {
       Runnable sseClientRunnable = () -> {
          try {
             executeSse("/mcp/org.acme.petstore.v1.PetstoreService/v1/sse", response -> {
-                     String line;
-                     try (BufferedReader bufferedReader = new BufferedReader(
-                           new InputStreamReader(response));) {
-                        while ((line = bufferedReader.readLine()) != null) {
-                           parseAndStoreMcpSseFrame(line, sseFrames);
-                        }
-                     } catch (IOException e) {
-                        System.err.println("Caught exception while reading SSE response: " + e.getMessage());
-                     }
-                     return;
-                  });
+               String line;
+               try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response));) {
+                  while ((line = bufferedReader.readLine()) != null) {
+                     parseAndStoreMcpSseFrame(line, sseFrames);
+                  }
+               } catch (IOException e) {
+                  System.err.println("Caught exception while reading SSE response: " + e.getMessage());
+               }
+               return;
+            });
          } catch (Exception e) {
             System.err.println("Caught exception while executing SSE client: " + e.getMessage());
          }
@@ -293,8 +292,8 @@ class McpControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
 
-      ResponseEntity<String> response = postForEntity(messageEndpoint,
-            new HttpEntity<>(initializeRequest, headers), String.class);
+      ResponseEntity<String> response = postForEntity(messageEndpoint, new HttpEntity<>(initializeRequest, headers),
+            String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);
@@ -459,8 +458,8 @@ class McpControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       headers.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM));
 
-      ResponseEntity<String> response = postForEntity(messageEndpoint,
-            new HttpEntity<>(initializeRequest, headers), String.class);
+      ResponseEntity<String> response = postForEntity(messageEndpoint, new HttpEntity<>(initializeRequest, headers),
+            String.class);
 
       // SSE emitter is async so wait a few millis before checking.
       Thread.sleep(200);

--- a/webapp/src/test/java/io/github/microcks/web/RestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/RestControllerIT.java
@@ -102,8 +102,8 @@ class RestControllerIT extends AbstractBaseIT {
       // Check its validation endpoint with invalid payload
       patchedPastry = "{\"price\":\"2.6\"}";
       requestEntity = new HttpEntity<>(patchedPastry, headers);
-      response = exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe", HttpMethod.PATCH,
-            requestEntity, String.class);
+      response = exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe", HttpMethod.PATCH, requestEntity,
+            String.class);
       assertEquals(400, response.getStatusCode().value());
       assertEquals("[string found, number expected]", response.getBody());
    }
@@ -115,8 +115,7 @@ class RestControllerIT extends AbstractBaseIT {
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/beer-catalog-api-collection.json", false);
 
       // Check its different mocked operations.
-      ResponseEntity<String> response = getForEntity("/rest/Beer+Catalog+API/0.9/beer?page=0",
-            String.class);
+      ResponseEntity<String> response = getForEntity("/rest/Beer+Catalog+API/0.9/beer?page=0", String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("[3]", response.getBody(), new ArraySizeComparator(JSONCompareMode.LENIENT));
@@ -183,8 +182,8 @@ class RestControllerIT extends AbstractBaseIT {
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/simple-oidc-redirect-openapi.yaml", true);
 
       ResponseEntity<String> response = getForEntityWithoutRedirects("/rest/Simple+OIDC/1.0/login/oauth/authorize?"
-                  + "response_type=code&client_id=GHCLIENT&scope=openid+user:email&redirect_uri=http://localhost:8080/Login/githubLoginSuccess&state=e956e017-5e13-4c9d-b83b-6dd6337a6a86",
-                  String.class);
+            + "response_type=code&client_id=GHCLIENT&scope=openid+user:email&redirect_uri=http://localhost:8080/Login/githubLoginSuccess&state=e956e017-5e13-4c9d-b83b-6dd6337a6a86",
+            String.class);
       assertEquals(302, response.getStatusCode().value());
 
       String content = response.getBody();
@@ -211,8 +210,7 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // If we have the mock, we should get the response from the mock.
-      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut",
-            String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut", String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("{\"name\":\"Mocked One\"}", response.getBody(), JSONCompareMode.LENIENT);
@@ -246,8 +244,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       // If we have the mock, we should get the response from the mock.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut",
-            String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut", String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
       assertEquals(200, response.getStatusCode().value());
       try {
@@ -321,8 +318,7 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // Check that we don't fall into infinite loop and that we can't locally handle the call (error 400)
-      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
-            String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut", String.class);
       assertEquals(400, response.getStatusCode().value());
       verify(restController, times(1)).execute(any(), any(), any(), any(), any(), any(), any(), any());
    }
@@ -342,8 +338,7 @@ class RestControllerIT extends AbstractBaseIT {
             .replaceFirst("pastry-real", "not-found"));
       serviceRepository.save(service);
 
-      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
-            String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut", String.class);
       assertEquals(404, response.getStatusCode().value());
    }
 
@@ -361,8 +356,7 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // Event if `donut` is defined on our mock, we should always have the response coming for real backend.
-      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry/donut",
-            String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry/donut", String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("{\"name\":\"Real One\"}", response.getBody(), JSONCompareMode.LENIENT);
@@ -402,8 +396,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       // Check a delayed mocked operations.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = getForEntity("/rest/PetStore+API/1.0.0/pets?delay=200",
-            String.class);
+      ResponseEntity<String> response = getForEntity("/rest/PetStore+API/1.0.0/pets?delay=200", String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTime >= 200, "mocked response time delayed: " + mockedResponseTime + "ms");
@@ -415,8 +408,7 @@ class RestControllerIT extends AbstractBaseIT {
       HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
 
       startTime = System.currentTimeMillis();
-      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200", HttpMethod.GET, requestEntity,
-            String.class);
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200", HttpMethod.GET, requestEntity, String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTime >= 400, "mocked response time delayed: " + mockedResponseTime + "ms");
@@ -446,8 +438,8 @@ class RestControllerIT extends AbstractBaseIT {
 
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set random here).
-      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=random", HttpMethod.GET,
-            requestEntity, String.class);
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=random", HttpMethod.GET, requestEntity,
+            String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTime >= 400, "mocked response time delayed: " + mockedResponseTime + "ms");
@@ -479,8 +471,8 @@ class RestControllerIT extends AbstractBaseIT {
 
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set fixed here).
-      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET,
-            requestEntity, String.class);
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET, requestEntity,
+            String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is between 0 and the delay.
       // Note: we can't be sure that the delay is <= 400 because of JVM scheduling but it's very likely.
@@ -512,8 +504,8 @@ class RestControllerIT extends AbstractBaseIT {
       HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set fixed here).
-      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET,
-            requestEntity, String.class);
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET, requestEntity,
+            String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is between 320 and 480 (400 + or - 20%).
       // Note: we can't be sure that the delay is <= 480 because of JVM scheduling but it's very likely.

--- a/webapp/src/test/java/io/github/microcks/web/RestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/RestControllerIT.java
@@ -24,7 +24,6 @@ import io.github.microcks.domain.Service;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.skyscreamer.jsonassert.comparator.ArraySizeComparator;
-import org.springframework.boot.http.client.HttpRedirects;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -56,7 +55,7 @@ class RestControllerIT extends AbstractBaseIT {
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/petstore-openapi.json", true);
 
       // Check its different mocked operations.
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/PetStore+API/1.0.0/pets", String.class);
+      ResponseEntity<String> response = getForEntity("/rest/PetStore+API/1.0.0/pets", String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("[4]", response.getBody(), new ArraySizeComparator(JSONCompareMode.LENIENT));
@@ -67,7 +66,7 @@ class RestControllerIT extends AbstractBaseIT {
          fail("No Exception should be thrown here");
       }
 
-      response = restTemplate.getForEntity("/rest/PetStore+API/1.0.0/pets/1", String.class);
+      response = getForEntity("/rest/PetStore+API/1.0.0/pets/1", String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("{\"id\":1,\"name\":\"Zaza\",\"tag\":\"cat\"}", response.getBody(),
@@ -89,7 +88,7 @@ class RestControllerIT extends AbstractBaseIT {
       // Check its validation endpoint with correct payload
       String patchedPastry = "{\"price\":2.6}";
       HttpEntity<String> requestEntity = new HttpEntity<>(patchedPastry, headers);
-      ResponseEntity<String> response = restTemplate.exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe",
+      ResponseEntity<String> response = exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe",
             HttpMethod.PATCH, requestEntity, String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
@@ -103,7 +102,7 @@ class RestControllerIT extends AbstractBaseIT {
       // Check its validation endpoint with invalid payload
       patchedPastry = "{\"price\":\"2.6\"}";
       requestEntity = new HttpEntity<>(patchedPastry, headers);
-      response = restTemplate.exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe", HttpMethod.PATCH,
+      response = exchange("/rest-valid/pastry-details/1.0.0/pastry/Eclair+Cafe", HttpMethod.PATCH,
             requestEntity, String.class);
       assertEquals(400, response.getStatusCode().value());
       assertEquals("[string found, number expected]", response.getBody());
@@ -116,7 +115,7 @@ class RestControllerIT extends AbstractBaseIT {
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/beer-catalog-api-collection.json", false);
 
       // Check its different mocked operations.
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/Beer+Catalog+API/0.9/beer?page=0",
+      ResponseEntity<String> response = getForEntity("/rest/Beer+Catalog+API/0.9/beer?page=0",
             String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
@@ -125,7 +124,7 @@ class RestControllerIT extends AbstractBaseIT {
          fail("No Exception should be thrown here");
       }
 
-      response = restTemplate.getForEntity("/rest/Beer+Catalog+API/0.9/beer/Weissbier", String.class);
+      response = getForEntity("/rest/Beer+Catalog+API/0.9/beer/Weissbier", String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("{\n" + "    \"name\": \"Weissbier\",\n" + "    \"country\": \"Germany\",\n"
@@ -157,7 +156,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       // Check operation with an undefined defined mock (name: 'Dummy'), should now return a 400 error as
       // per issue #819 and #1132 to have a consistent behaviour, allow proxying support and this kind of stuff.
-      response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry/Dummy/details", String.class);
+      response = getForEntity("/rest/pastry-details/1.0.0/pastry/Dummy/details", String.class);
       assertEquals(400, response.getStatusCode().value());
    }
 
@@ -166,14 +165,14 @@ class RestControllerIT extends AbstractBaseIT {
       // Upload modified pastry-with-headers-openapi spec
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/pastry-with-headers-openapi.yaml", true);
 
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-headers/1.0.0/pastry", String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-headers/1.0.0/pastry", String.class);
       assertEquals(200, response.getStatusCode().value());
       assertEquals("some-static-header", response.getHeaders().getFirst("x-some-static-header"));
 
       String someGenericHeader = response.getHeaders().getFirst("x-some-generic-header");
       assertDoesNotThrow(() -> UUID.fromString(someGenericHeader));
 
-      response = restTemplate.getForEntity("/rest/pastry-headers/1.0.0/pastry?size=XL", String.class);
+      response = getForEntity("/rest/pastry-headers/1.0.0/pastry?size=XL", String.class);
       String requestBasedHeader = response.getHeaders().getFirst("x-request-based-header");
       assertEquals("XL size", requestBasedHeader);
    }
@@ -183,8 +182,7 @@ class RestControllerIT extends AbstractBaseIT {
       // Upload simple-oidc-redirect-openapi spec
       uploadArtifactFile("target/test-classes/io/github/microcks/util/openapi/simple-oidc-redirect-openapi.yaml", true);
 
-      ResponseEntity<String> response = restTemplate.withRedirects(HttpRedirects.DONT_FOLLOW)
-            .getForEntity("/rest/Simple+OIDC/1.0/login/oauth/authorize?"
+      ResponseEntity<String> response = getForEntityWithoutRedirects("/rest/Simple+OIDC/1.0/login/oauth/authorize?"
                   + "response_type=code&client_id=GHCLIENT&scope=openid+user:email&redirect_uri=http://localhost:8080/Login/githubLoginSuccess&state=e956e017-5e13-4c9d-b83b-6dd6337a6a86",
                   String.class);
       assertEquals(302, response.getStatusCode().value());
@@ -213,7 +211,7 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // If we have the mock, we should get the response from the mock.
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut",
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut",
             String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
@@ -223,7 +221,7 @@ class RestControllerIT extends AbstractBaseIT {
       }
 
       // If we don't have the mock, we should get the response from real backend.
-      response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
+      response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
          JSONAssert.assertEquals("{\"name\":\"Croissant from Real One\"}", response.getBody(), JSONCompareMode.LENIENT);
@@ -248,7 +246,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       // If we have the mock, we should get the response from the mock.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut",
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut",
             String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
       assertEquals(200, response.getStatusCode().value());
@@ -260,7 +258,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       // If we don't have the mock, we should get the response from real backend.
       startTime = System.currentTimeMillis();
-      response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
+      response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
       long realResponseTime = System.currentTimeMillis() - startTime;
       assertEquals(200, response.getStatusCode().value());
       try {
@@ -277,7 +275,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       // If we have the mock, we should get the response from the mock.
       startTime = System.currentTimeMillis();
-      response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut", String.class);
+      response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=donut", String.class);
       long mockedResponseTimeDelayed = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(mockedResponseTimeDelayed >= delay,
@@ -293,7 +291,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       // If we don't have the mock, we should get the response from real backend.
       startTime = System.currentTimeMillis();
-      response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
+      response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=croissant", String.class);
       long realResponseTimeDelayed = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
       assertTrue(realResponseTimeDelayed >= delay, "real response time delayed: " + realResponseTimeDelayed + "ms");
@@ -323,7 +321,7 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // Check that we don't fall into infinite loop and that we can't locally handle the call (error 400)
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
             String.class);
       assertEquals(400, response.getStatusCode().value());
       verify(restController, times(1)).execute(any(), any(), any(), any(), any(), any(), any(), any());
@@ -344,7 +342,7 @@ class RestControllerIT extends AbstractBaseIT {
             .replaceFirst("pastry-real", "not-found"));
       serviceRepository.save(service);
 
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry?name=realDonut",
             String.class);
       assertEquals(404, response.getStatusCode().value());
    }
@@ -363,7 +361,7 @@ class RestControllerIT extends AbstractBaseIT {
       serviceRepository.save(service);
 
       // Event if `donut` is defined on our mock, we should always have the response coming for real backend.
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-proxy/1.0.0/pastry/donut",
+      ResponseEntity<String> response = getForEntity("/rest/pastry-proxy/1.0.0/pastry/donut",
             String.class);
       assertEquals(200, response.getStatusCode().value());
       try {
@@ -381,18 +379,18 @@ class RestControllerIT extends AbstractBaseIT {
       ObjectMapper mapper = new ObjectMapper();
 
       // Check operation with a defined mock (name: 'Eclair Cafe')
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-script/1.0.0/pastry/Eclair Cafe/taste",
+      ResponseEntity<String> response = getForEntity("/rest/pastry-script/1.0.0/pastry/Eclair Cafe/taste",
             String.class);
       assertEquals(200, response.getStatusCode().value());
       assertEquals("Delicious", response.getBody());
 
       // Check operation with a defined mock (name: 'Millefeuille')
-      response = restTemplate.getForEntity("/rest/pastry-script/1.0.0/pastry/Millefeuille/taste", String.class);
+      response = getForEntity("/rest/pastry-script/1.0.0/pastry/Millefeuille/taste", String.class);
       assertEquals(200, response.getStatusCode().value());
       assertEquals("Awesome", response.getBody());
 
       // Check operation with an undefined mock (name: 'Dummy')
-      response = restTemplate.getForEntity("/rest/pastry-script/1.0.0/pastry/Dummy/taste", String.class);
+      response = getForEntity("/rest/pastry-script/1.0.0/pastry/Dummy/taste", String.class);
       assertEquals(200, response.getStatusCode().value());
       assertEquals("Ok", response.getBody());
    }
@@ -404,7 +402,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       // Check a delayed mocked operations.
       long startTime = System.currentTimeMillis();
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/PetStore+API/1.0.0/pets?delay=200",
+      ResponseEntity<String> response = getForEntity("/rest/PetStore+API/1.0.0/pets?delay=200",
             String.class);
       long mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
@@ -417,7 +415,7 @@ class RestControllerIT extends AbstractBaseIT {
       HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
 
       startTime = System.currentTimeMillis();
-      response = restTemplate.exchange("/rest/PetStore+API/1.0.0/pets?delay=200", HttpMethod.GET, requestEntity,
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200", HttpMethod.GET, requestEntity,
             String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
@@ -448,7 +446,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set random here).
-      response = restTemplate.exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=random", HttpMethod.GET,
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=random", HttpMethod.GET,
             requestEntity, String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is greater than the delay and greater that .
@@ -481,7 +479,7 @@ class RestControllerIT extends AbstractBaseIT {
 
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set fixed here).
-      response = restTemplate.exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET,
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET,
             requestEntity, String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is between 0 and the delay.
@@ -514,7 +512,7 @@ class RestControllerIT extends AbstractBaseIT {
       HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
       startTime = System.currentTimeMillis();
       // delay and delayStrategy query params should be ignored in favour of headers. (It's a reason why we set fixed here).
-      response = restTemplate.exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET,
+      response = exchange("/rest/PetStore+API/1.0.0/pets?delay=200&delayStrategy=fixed", HttpMethod.GET,
             requestEntity, String.class);
       mockedResponseTime = System.currentTimeMillis() - startTime;
       // Assert that the response time is between 320 and 480 (400 + or - 20%).

--- a/webapp/src/test/java/io/github/microcks/web/SoapControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/SoapControllerIT.java
@@ -147,8 +147,7 @@ class SoapControllerIT extends AbstractBaseIT {
 
       // Execute and assert.
       for (int i = 0; i < 10; ++i) {
-         ResponseEntity<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity,
-               String.class);
+         ResponseEntity<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
          switch (response.getStatusCode().value()) {
             case 200:
                assertTrue(okResponses.contains(response.getBody()));

--- a/webapp/src/test/java/io/github/microcks/web/SoapControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/SoapControllerIT.java
@@ -52,7 +52,7 @@ class SoapControllerIT extends AbstractBaseIT {
       HttpEntity<String> entity = new HttpEntity<>(request, headers);
 
       // Execute and assert.
-      ResponseEntity<String> response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      ResponseEntity<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertEquals(200, response.getStatusCode().value());
       assertEquals(
             "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hel=\"http://www.example.com/hello\">\n"
@@ -74,7 +74,7 @@ class SoapControllerIT extends AbstractBaseIT {
       entity = new HttpEntity<>(request, headers);
 
       // Execute and assert, content-type is different for SOAP 1.1.
-      response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertEquals(200, response.getStatusCode().value());
       assertEquals(
             "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hel=\"http://www.example.com/hello\">\n"
@@ -92,7 +92,7 @@ class SoapControllerIT extends AbstractBaseIT {
       entity = new HttpEntity<>(request, headers);
 
       // Execute and assert.
-      response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertEquals(500, response.getStatusCode().value());
       assertEquals(
             "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\" xmlns:hel=\"http://www.example.com/hello\">\n"
@@ -147,7 +147,7 @@ class SoapControllerIT extends AbstractBaseIT {
 
       // Execute and assert.
       for (int i = 0; i < 10; ++i) {
-         ResponseEntity<String> response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity,
+         ResponseEntity<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity,
                String.class);
          switch (response.getStatusCode().value()) {
             case 200:
@@ -181,7 +181,7 @@ class SoapControllerIT extends AbstractBaseIT {
       HttpEntity<String> entity = createBaseEntityForName("Andrew");
 
       // Execute and assert.
-      ResponseEntity<String> response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      ResponseEntity<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertResponseIsOkAndContains(response, "<sayHello>Hello Real Andrew !</sayHello>");
    }
 
@@ -207,14 +207,14 @@ class SoapControllerIT extends AbstractBaseIT {
       HttpEntity<String> entity = createBaseEntityForName("Andrew");
 
       // Execute and assert that it wasn't proxy.
-      ResponseEntity<String> response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      ResponseEntity<String> response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertResponseIsOkAndContains(response, "<sayHello>Hello Andrew !</sayHello>");
 
       // Build the request that doesn't match QUERY_MATCH.
       entity = createBaseEntityForName("Garry");
 
       // Execute and assert that it was proxy.
-      response = restTemplate.postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
+      response = postForEntity("/soap/HelloService+Mock/0.9", entity, String.class);
       assertResponseIsOkAndContains(response, "<sayHello>Hello Real Garry !</sayHello>");
    }
 

--- a/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
@@ -319,8 +319,7 @@ class TestControllerIT extends AbstractBaseIT {
    private void waitForTestCompletion(TestResult testResult, int seconds) {
       await().atMost(seconds, TimeUnit.SECONDS).pollDelay(500, TimeUnit.MILLISECONDS)
             .pollInterval(250, TimeUnit.MILLISECONDS).until(() -> {
-               ResponseEntity<TestResult> resp = getForEntity("/api/tests/" + testResult.getId(),
-                     TestResult.class);
+               ResponseEntity<TestResult> resp = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
                if (resp.getStatusCode().value() == 200) {
                   TestResult tr = resp.getBody();
                   return tr != null && !tr.isInProgress();

--- a/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TestControllerIT.java
@@ -97,7 +97,7 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
+      ResponseEntity<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
       assertEquals(201, response.getStatusCode().value());
 
       TestResult testResult = response.getBody();
@@ -109,7 +109,7 @@ class TestControllerIT extends AbstractBaseIT {
       // Wait till timeout and re-fetch the result.
       waitForTestCompletion(testResult, 3);
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
       assertEquals(200, response.getStatusCode().value());
 
       testResult = response.getBody();
@@ -144,7 +144,7 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
+      ResponseEntity<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
       assertEquals(201, response.getStatusCode().value());
 
       TestResult testResult = response.getBody();
@@ -161,7 +161,7 @@ class TestControllerIT extends AbstractBaseIT {
          System.err.println(postmanRunner.getLogs());
       }
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
       assertEquals(200, response.getStatusCode().value());
 
       testResult = response.getBody();
@@ -186,7 +186,7 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
+      ResponseEntity<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
       assertEquals(201, response.getStatusCode().value());
 
       TestResult testResult = response.getBody();
@@ -198,7 +198,7 @@ class TestControllerIT extends AbstractBaseIT {
       // Wait till timeout and re-fetch the result.
       waitForTestCompletion(testResult, 3);
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
       assertEquals(200, response.getStatusCode().value());
 
       testResult = response.getBody();
@@ -248,7 +248,7 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
+      ResponseEntity<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
       assertEquals(201, response.getStatusCode().value());
 
       TestResult testResult = response.getBody();
@@ -260,7 +260,7 @@ class TestControllerIT extends AbstractBaseIT {
       // Wait till timeout and re-fetch the result.
       waitForTestCompletion(testResult, 3);
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
       assertEquals(200, response.getStatusCode().value());
 
       testResult = response.getBody();
@@ -296,7 +296,7 @@ class TestControllerIT extends AbstractBaseIT {
       headers.setContentType(MediaType.APPLICATION_JSON);
       HttpEntity<String> entity = new HttpEntity<>(testRequest.toString(), headers);
 
-      ResponseEntity<TestResult> response = restTemplate.postForEntity("/api/tests", entity, TestResult.class);
+      ResponseEntity<TestResult> response = postForEntity("/api/tests", entity, TestResult.class);
       assertEquals(201, response.getStatusCode().value());
 
       TestResult testResult = response.getBody();
@@ -308,7 +308,7 @@ class TestControllerIT extends AbstractBaseIT {
       // Wait till timeout and re-fetch the result.
       waitForTestCompletion(testResult, 3);
 
-      response = restTemplate.getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
+      response = getForEntity("/api/tests/" + testResult.getId(), TestResult.class);
       assertEquals(200, response.getStatusCode().value());
       testResult = response.getBody();
       assertNotNull(testResult);
@@ -319,7 +319,7 @@ class TestControllerIT extends AbstractBaseIT {
    private void waitForTestCompletion(TestResult testResult, int seconds) {
       await().atMost(seconds, TimeUnit.SECONDS).pollDelay(500, TimeUnit.MILLISECONDS)
             .pollInterval(250, TimeUnit.MILLISECONDS).until(() -> {
-               ResponseEntity<TestResult> resp = restTemplate.getForEntity("/api/tests/" + testResult.getId(),
+               ResponseEntity<TestResult> resp = getForEntity("/api/tests/" + testResult.getId(),
                      TestResult.class);
                if (resp.getStatusCode().value() == 200) {
                   TestResult tr = resp.getBody();

--- a/webapp/src/test/java/io/github/microcks/web/TracingControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TracingControllerIT.java
@@ -85,11 +85,11 @@ class TracingControllerIT extends AbstractBaseIT {
    @DisplayName("Should retrieve spans for a specific trace ID")
    void shouldRetrieveSpansForTraceId() {
       // Given - Call GET /rest/pastry-details/1.0.0/pastry to generate traces
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
       // Get all trace IDs GET /api/traces that returns a List<String>
-      ResponseEntity<Set<String>> traceIdsResponse = restTemplate.exchange("/api/traces", HttpMethod.GET, null,
+      ResponseEntity<Set<String>> traceIdsResponse = exchange("/api/traces", HttpMethod.GET, null,
             new ParameterizedTypeReference<>() {
             });
 
@@ -97,7 +97,7 @@ class TracingControllerIT extends AbstractBaseIT {
       if (traceIdsResponse.getBody() != null && !traceIdsResponse.getBody().isEmpty()) {
          // Get spans for the first trace ID
          String firstTraceId = traceIdsResponse.getBody().iterator().next();
-         ResponseEntity<List<Object>> spansResponse = restTemplate.exchange("/api/traces/" + firstTraceId + "/spans",
+         ResponseEntity<List<Object>> spansResponse = exchange("/api/traces/" + firstTraceId + "/spans",
                HttpMethod.GET, null, new ParameterizedTypeReference<>() {
                });
 
@@ -119,7 +119,7 @@ class TracingControllerIT extends AbstractBaseIT {
    @DisplayName("Should return 404 for non-existent trace ID")
    void shouldReturn404ForNonExistentTraceId() {
       // When
-      ResponseEntity<List<SpanData>> response = restTemplate.exchange("/api/traces/non-existent-trace-id/spans",
+      ResponseEntity<List<SpanData>> response = exchange("/api/traces/non-existent-trace-id/spans",
             HttpMethod.GET, null, new ParameterizedTypeReference<>() {
             });
 
@@ -131,12 +131,12 @@ class TracingControllerIT extends AbstractBaseIT {
    @DisplayName("Should retrieve spans by operation name")
    void shouldRetrieveSpansByOperation() {
       // Given - Call GET /rest/pastry-details/1.0.0/pastry to generate traces
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
 
       // Try to query spans by operation (this may return empty if no specific operation traces exist)
-      ResponseEntity<List<List<Object>>> operationSpansResponse = restTemplate.exchange(
+      ResponseEntity<List<List<Object>>> operationSpansResponse = exchange(
             "/api/traces/operations?serviceName=pastry-details&operationName=GET /pastry", HttpMethod.GET, null,
             new ParameterizedTypeReference<>() {
             });
@@ -149,15 +149,15 @@ class TracingControllerIT extends AbstractBaseIT {
    @DisplayName("Should clear all traces")
    void shouldClearAllTraces() {
       // Given - Call GET /rest/pastry-details/1.0.0/pastry to generate traces
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
       // Check if traces exist (but don't fail if they don't)
-      restTemplate.exchange("/api/traces", HttpMethod.GET, null, new ParameterizedTypeReference<Set<String>>() {
+      exchange("/api/traces", HttpMethod.GET, null, new ParameterizedTypeReference<Set<String>>() {
       });
 
       // When - Clear all traces
-      ResponseEntity<String> clearResponse = restTemplate.exchange("/api/traces", HttpMethod.DELETE, null,
+      ResponseEntity<String> clearResponse = exchange("/api/traces", HttpMethod.DELETE, null,
             String.class);
 
       // Then
@@ -165,7 +165,7 @@ class TracingControllerIT extends AbstractBaseIT {
       assertThat(clearResponse.getBody()).contains("All traces and spans have been cleared");
 
       // Verify traces are cleared
-      ResponseEntity<Set<String>> tracesAfterClear = restTemplate.exchange("/api/traces", HttpMethod.GET, null,
+      ResponseEntity<Set<String>> tracesAfterClear = exchange("/api/traces", HttpMethod.GET, null,
             new ParameterizedTypeReference<>() {
             });
 
@@ -178,19 +178,19 @@ class TracingControllerIT extends AbstractBaseIT {
    void shouldStreamTracesViaSseEndpoint() throws Exception {
       // Define the runnable for the SSE client to listen to the stream
       Runnable sseClientRunnable = () -> {
-         restTemplate.execute(
+         executeSse(
                "/api/traces/operations/stream?serviceName=pastry-details&operationName=GET /pastry&clientAddress=.*",
-               HttpMethod.GET, request -> {}, response -> {
+               response -> {
 
                   String line;
-                  try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response.getBody()));) {
+                  try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response));) {
                      while ((line = bufferedReader.readLine()) != null) {
                         parseAndStoreSseFrame(line, sseFrames);
                      }
                   } catch (IOException e) {
                      System.err.println("Caught exception while reading SSE response: " + e.getMessage());
                   }
-                  return response;
+                  return;
                });
       };
 
@@ -201,7 +201,7 @@ class TracingControllerIT extends AbstractBaseIT {
       Thread.sleep(100);
 
       // Generate traces by calling the REST endpoint
-      ResponseEntity<String> response = restTemplate.getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
+      ResponseEntity<String> response = getForEntity("/rest/pastry-details/1.0.0/pastry", String.class);
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
       // Wait for SSE events to be received

--- a/webapp/src/test/java/io/github/microcks/web/TracingControllerIT.java
+++ b/webapp/src/test/java/io/github/microcks/web/TracingControllerIT.java
@@ -97,8 +97,8 @@ class TracingControllerIT extends AbstractBaseIT {
       if (traceIdsResponse.getBody() != null && !traceIdsResponse.getBody().isEmpty()) {
          // Get spans for the first trace ID
          String firstTraceId = traceIdsResponse.getBody().iterator().next();
-         ResponseEntity<List<Object>> spansResponse = exchange("/api/traces/" + firstTraceId + "/spans",
-               HttpMethod.GET, null, new ParameterizedTypeReference<>() {
+         ResponseEntity<List<Object>> spansResponse = exchange("/api/traces/" + firstTraceId + "/spans", HttpMethod.GET,
+               null, new ParameterizedTypeReference<>() {
                });
 
          // Then
@@ -119,8 +119,8 @@ class TracingControllerIT extends AbstractBaseIT {
    @DisplayName("Should return 404 for non-existent trace ID")
    void shouldReturn404ForNonExistentTraceId() {
       // When
-      ResponseEntity<List<SpanData>> response = exchange("/api/traces/non-existent-trace-id/spans",
-            HttpMethod.GET, null, new ParameterizedTypeReference<>() {
+      ResponseEntity<List<SpanData>> response = exchange("/api/traces/non-existent-trace-id/spans", HttpMethod.GET,
+            null, new ParameterizedTypeReference<>() {
             });
 
       // Then
@@ -157,8 +157,7 @@ class TracingControllerIT extends AbstractBaseIT {
       });
 
       // When - Clear all traces
-      ResponseEntity<String> clearResponse = exchange("/api/traces", HttpMethod.DELETE, null,
-            String.class);
+      ResponseEntity<String> clearResponse = exchange("/api/traces", HttpMethod.DELETE, null, String.class);
 
       // Then
       assertThat(clearResponse.getStatusCode()).isEqualTo(HttpStatus.OK);


### PR DESCRIPTION
## Description

Migrate Microcks webapp integration tests from `TestRestTemplate` to `RestTestClient` for Spring Boot 4.0.7 compatibility.

### Changes

- Replace `TestRestTemplate` with `RestTestClient` in webapp integration tests.
- Preserve existing request/response assertions and generic response handling.
- Migrate multipart artifact upload tests.
- Migrate SSE/streaming test handling while preserving asynchronous behavior and assertions.
- Preserve the no-redirect test behavior using `HttpClient.Redirect.NEVER`.
- Keep `spring-boot-resttestclient` for `@AutoConfigureRestTestClient`.

### Validation

- `git diff --check` passes.
- Spotless formatting checks pass.
- Full Maven compilation/tests could not be completed because Maven Central was unreachable from the development environment.