### PR TITLE
fix(async-minion): propagate sasl.client.callback.handler.class for SASL_SSL Kafka producers

### DIFF
--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -277,6 +277,7 @@ Here are below the configuration properties of the Kafka support feature:
 | `features.async.kafka.authentication` | `saslMechanism`                 | **Optional**. For SASL authentication, you'll have to specify an additional authentication mechanism such as `SCRAM-SHA-512` or `OAUTHBEARER`                                                                          |
 | `features.async.kafka.authentication` | `saslJaasConfig`                | **Optional**. For SASL authentication, you'll have to specify a JAAS configuration line with login module, username and password.                                                                                      |
 | `features.async.kafka.authentication` | `saslLoginCallbackHandlerClass` | **Optional**. For SASL authentication, you may want to provide a Login Callback Handler implementations. This implementation may be provided by extending the main and `async-minion` images and adding your own libs. |
+| `features.async.kafka.authentication` | `saslClientCallbackHandlerClass` | **Optional**. For SASL authentication, you may want to provide a Client Callback Handler implementation (required for Amazon MSK IAM with `AWS_MSK_IAM`). This implementation may be provided by extending the main and `async-minion` images and adding your own libs. |
 
 #### MQTT feature details
 

--- a/install/kubernetes/microcks/README.md
+++ b/install/kubernetes/microcks/README.md
@@ -277,6 +277,7 @@ Here are below the configuration properties of the Kafka support feature:
 | `features.async.kafka.authentication` | `saslMechanism`                 | **Optional**. For SASL authentication, you'll have to specify an additional authentication mechanism such as `SCRAM-SHA-512` or `OAUTHBEARER`                                                                          |
 | `features.async.kafka.authentication` | `saslJaasConfig`                | **Optional**. For SASL authentication, you'll have to specify a JAAS configuration line with login module, username and password.                                                                                      |
 | `features.async.kafka.authentication` | `saslLoginCallbackHandlerClass` | **Optional**. For SASL authentication, you may want to provide a Login Callback Handler implementations. This implementation may be provided by extending the main and `async-minion` images and adding your own libs. |
+| `features.async.kafka.authentication` | `saslClientCallbackHandlerClass` | **Optional**. For SASL authentication, you may want to provide a Client Callback Handler implementation (required for Amazon MSK IAM with `AWS_MSK_IAM`). This implementation may be provided by extending the main and `async-minion` images and adding your own libs. |
 
 #### MQTT feature details
 

--- a/install/kubernetes/microcks/templates/configmap.yaml
+++ b/install/kubernetes/microcks/templates/configmap.yaml
@@ -137,6 +137,10 @@ data:
     kafka.producers.service-changes.properties.sasl.login.callback.handler.class={{ .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
     kafka.producers.asyncapi-triggers.properties.sasl.login.callback.handler.class={{ .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
         {{- end }}
+        {{- if .Values.features.async.kafka.authentication.saslClientCallbackHandlerClass }}
+    kafka.producers.service-changes.properties.sasl.client.callback.handler.class={{ .Values.features.async.kafka.authentication.saslClientCallbackHandlerClass }}
+    kafka.producers.asyncapi-triggers.properties.sasl.client.callback.handler.class={{ .Values.features.async.kafka.authentication.saslClientCallbackHandlerClass }}
+        {{- end }}
       {{- end }}
     {{- end }}
 
@@ -555,6 +559,9 @@ data:
         {{- if .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
     %kube.kafka.sasl.login.callback.handler.class={{ .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
         {{- end }}
+        {{- if .Values.features.async.kafka.authentication.saslClientCallbackHandlerClass }}
+    %kube.kafka.sasl.client.callback.handler.class={{ .Values.features.async.kafka.authentication.saslClientCallbackHandlerClass }}
+        {{- end }}
     
     %kube.mp.messaging.incoming.microcks-services-updates.security.protocol=SASL_SSL
     %kube.mp.messaging.incoming.microcks-asyncapi-triggers.security.protocol=SASL_SSL
@@ -573,6 +580,10 @@ data:
         {{- if .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
     %kube.mp.messaging.incoming.microcks-services-updates.sasl.login.callback.handler.class={{ .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
     %kube.mp.messaging.incoming.microcks-asyncapi-triggers.sasl.login.callback.handler.class={{ .Values.features.async.kafka.authentication.saslLoginCallbackHandlerClass }}
+        {{- end }}
+        {{- if .Values.features.async.kafka.authentication.saslClientCallbackHandlerClass }}
+    %kube.mp.messaging.incoming.microcks-services-updates.sasl.client.callback.handler.class={{ .Values.features.async.kafka.authentication.saslClientCallbackHandlerClass }}
+    %kube.mp.messaging.incoming.microcks-asyncapi-triggers.sasl.client.callback.handler.class={{ .Values.features.async.kafka.authentication.saslClientCallbackHandlerClass }}
         {{- end }}
       {{- end }}
     {{ end }}

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -338,6 +338,8 @@ features:
         #saslMechanism: OAUTHBEARER
         #saslJaasConfig: org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
         #saslLoginCallbackHandlerClass: io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
+        # For Amazon MSK IAM authentication (AWS_MSK_IAM), you'll also need a Client Callback Handler.
+        #saslClientCallbackHandlerClass: software.amazon.msk.auth.iam.IAMClientCallbackHandler
 
     # Uncomment the mqtt.url and put a valid endpoint address below to enable MQTT support.
     mqtt:

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/KafkaProducerManager.java
@@ -323,6 +323,10 @@ public class KafkaProducerManager {
                   props.put(SaslConfigs.SASL_LOGIN_CALLBACK_HANDLER_CLASS,
                         config.getValue("kafka.sasl.login.callback.handler.class", String.class));
                }
+               if (config.getOptionalValue("kafka.sasl.client.callback.handler.class", String.class).isPresent()) {
+                  props.put(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS,
+                        config.getValue("kafka.sasl.client.callback.handler.class", String.class));
+               }
                break;
             case "SSL":
                logger.debug("Adding SSL specific connection properties");

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/KafkaProducerManagerTest.java
@@ -20,12 +20,23 @@ import io.github.microcks.domain.Operation;
 import io.github.microcks.domain.Service;
 import io.github.microcks.minion.async.AsyncMockDefinition;
 
+import org.apache.kafka.common.config.SaslConfigs;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigValue;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.Converter;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -88,5 +99,87 @@ class KafkaProducerManagerTest {
       assertEquals(
             "StreetlightsAPI-0.1.0-smartylighting.streetlights.1.0.event.da059782-3ad0-4e45-88ce-ef3392bc7797.lighting.measured",
             topicName);
+   }
+
+   @Test
+   void testCompletePropertiesWithSecurityConfigSaslSslIncludesClientCallbackHandler() throws Exception {
+      String clientCallbackHandler = "software.amazon.msk.auth.iam.IAMClientCallbackHandler";
+      Map<String, String> configValues = Map.of("kafka.security.protocol", "SASL_SSL", "kafka.sasl.mechanism",
+            "AWS_MSK_IAM", "kafka.sasl.jaas.config", "software.amazon.msk.auth.iam.IAMLoginModule required;",
+            "kafka.sasl.client.callback.handler.class", clientCallbackHandler);
+
+      Properties props = invokeCompletePropertiesWithSecurityConfig(configValues);
+
+      assertEquals("SASL_SSL", props.get("security.protocol"));
+      assertEquals("AWS_MSK_IAM", props.get(SaslConfigs.SASL_MECHANISM));
+      assertEquals("software.amazon.msk.auth.iam.IAMLoginModule required;", props.get(SaslConfigs.SASL_JAAS_CONFIG));
+      assertEquals(clientCallbackHandler, props.get(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS));
+   }
+
+   @Test
+   void testCompletePropertiesWithSecurityConfigSaslSslWithoutClientCallbackHandler() throws Exception {
+      Map<String, String> configValues = Map.of("kafka.security.protocol", "SASL_SSL", "kafka.sasl.mechanism",
+            "AWS_MSK_IAM", "kafka.sasl.jaas.config", "software.amazon.msk.auth.iam.IAMLoginModule required;");
+
+      Properties props = invokeCompletePropertiesWithSecurityConfig(configValues);
+
+      assertNull(props.get(SaslConfigs.SASL_CLIENT_CALLBACK_HANDLER_CLASS));
+   }
+
+   private Properties invokeCompletePropertiesWithSecurityConfig(Map<String, String> configValues) throws Exception {
+      KafkaProducerManager producerManager = new KafkaProducerManager();
+      Properties props = new Properties();
+      Method method = KafkaProducerManager.class.getDeclaredMethod("completePropertiesWithSecurityConfig",
+            Properties.class, Config.class);
+      method.setAccessible(true);
+      method.invoke(producerManager, props, new MapConfig(configValues));
+      return props;
+   }
+
+   private static class MapConfig implements Config {
+      private final Map<String, String> values;
+
+      private MapConfig(Map<String, String> values) {
+         this.values = new HashMap<>(values);
+      }
+
+      @Override
+      public <T> T getValue(String propertyName, Class<T> propertyType) {
+         String value = values.get(propertyName);
+         if (value == null) {
+            throw new IllegalArgumentException("Missing config property: " + propertyName);
+         }
+         return propertyType.cast(value);
+      }
+
+      @Override
+      public ConfigValue getConfigValue(String propertyName) {
+         return null;
+      }
+
+      @Override
+      public <T> Optional<T> getOptionalValue(String propertyName, Class<T> propertyType) {
+         return Optional.ofNullable(values.get(propertyName)).map(propertyType::cast);
+      }
+
+      @Override
+      public Iterable<String> getPropertyNames() {
+         return values.keySet();
+      }
+
+      @Override
+      public Iterable<ConfigSource> getConfigSources() {
+         return null;
+      }
+
+      @Override
+      public <T> Optional<Converter<T>> getConverter(Class<T> forType) {
+         return Optional.empty();
+      }
+
+      @Override
+      public <T> T unwrap(Class<T> type) {
+         return null;
+      }
    }
 }


### PR DESCRIPTION
## Summary

- Propagate `kafka.sasl.client.callback.handler.class` to native Kafka producers in `KafkaProducerManager`
- Required for Amazon MSK IAM (`AWS_MSK_IAM`) — SmallRye consumers already honor this property via `application.properties`
- Add unit tests covering SASL_SSL security property mapping with and without the client callback handler

Fixes #2232

## Problem

MSK IAM requires `sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler`.
Producers created by `KafkaProducerManager` fail authentication with `UnsupportedCallbackException: Unrecognized SASL ClientCallback` because only `sasl.login.callback.handler.class` was mapped in the `SASL_SSL` branch of `completePropertiesWithSecurityConfig()`.

## AI disclosure

This pull request was prepared with assistance from an AI coding assistant (Cursor). The human author is responsible for reviewing, testing, and understanding the changes.

## Test plan

- [x] Unit tests `KafkaProducerManagerTest` pass
- [x] `mvn spotless:check` passes (pre-commit hook)
- [ ] Manual: async-minion against MSK Serverless :9098 publishes mock messages without SASL errors