### PR TITLE
fix(async-minion): support amqps:// for Amazon MQ TLS connectionsFix/async minion amqps amazon mq

### DIFF
--- a/install/kubernetes/README.md
+++ b/install/kubernetes/README.md
@@ -308,7 +308,7 @@ Here are below the configuration properties of the AMQP support feature:
 
 | Section               | Property   | Description                                                                                                                              |
 | --------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `features.async.amqp` | `url`      | **Optional**. The URL of AMQP broker (eg: `my-amqp-broker.example.com:5672`). Default is undefined which means that feature is disabled. |
+| `features.async.amqp` | `url`      | **Optional**. The URL of AMQP broker. Supports `host:5672` (plain AMQP), `host:5671` (auto `amqps://` for TLS), or explicit `amqps://host:5671` (e.g. Amazon MQ). Default is undefined which means that feature is disabled. |
 | `features.async.amqp` | `username` | **Optional**. The username to use for connecting to secured AMQP broker. Default to `microcks`.                                          |
 | `features.async.amqp` | `password` | **Optional**. The password to use for connecting to secured AMQP broker. Default to `microcks`.                                          |
 

--- a/install/kubernetes/microcks/README.md
+++ b/install/kubernetes/microcks/README.md
@@ -308,7 +308,7 @@ Here are below the configuration properties of the AMQP support feature:
 
 | Section               | Property   | Description                                                                                                                              |
 | --------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `features.async.amqp` | `url`      | **Optional**. The URL of AMQP broker (eg: `my-amqp-broker.example.com:5672`). Default is undefined which means that feature is disabled. |
+| `features.async.amqp` | `url`      | **Optional**. The URL of AMQP broker. Supports `host:5672` (plain AMQP), `host:5671` (auto `amqps://` for TLS), or explicit `amqps://host:5671` (e.g. Amazon MQ). Default is undefined which means that feature is disabled. |
 | `features.async.amqp` | `username` | **Optional**. The username to use for connecting to secured AMQP broker. Default to `microcks`.                                          |
 | `features.async.amqp` | `password` | **Optional**. The password to use for connecting to secured AMQP broker. Default to `microcks`.                                          |
 

--- a/install/kubernetes/microcks/values.yaml
+++ b/install/kubernetes/microcks/values.yaml
@@ -349,7 +349,12 @@ features:
 
     # Uncomment the amqp.url and put a valid endpoint address below to enable AMQP support.
     amqp:
+      # Plain AMQP (dev/local):
       #url: rabbitmq:5672
+      # Amazon MQ for RabbitMQ (TLS on port 5671):
+      #url: amqps://xxxx.mq.eu-west-3.amazonaws.com:5671
+      # Or host:port form (amqps:// auto-detected for :5671):
+      #url: xxxx.mq.eu-west-3.amazonaws.com:5671
       username: microcks
       password: microcks
 

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
@@ -86,8 +86,6 @@ public class AMQPProducerManager {
    protected Connection createConnection() throws Exception {
       ConnectionFactory factory = new ConnectionFactory();
       factory.setUri(buildAmqpUri());
-      factory.setConnectionTimeout(15000);
-      factory.setHandshakeTimeout(15000);
 
       if (amqpUsername != null && !amqpUsername.isEmpty() && amqpPassword != null && !amqpPassword.isEmpty()) {
          logger.infof("Connecting to AMQP broker with user '%s'", amqpUsername);
@@ -99,19 +97,29 @@ public class AMQPProducerManager {
    }
 
    /**
-    * Build the AMQP connection URI from configured server address. Honors explicit {@code amqp://} or {@code amqps://}
-    * schemes; auto-detects TLS for port 5671.
+    * Build the AMQP connection URI from configured server address.
     *
     * @return The connection URI for the RabbitMQ Java client
     */
-   String buildAmqpUri() {
-      if (amqpServer.contains("://")) {
-         return amqpServer;
+   private String buildAmqpUri() {
+      return resolveAmqpUri(amqpServer);
+   }
+
+   /**
+    * Resolve the AMQP connection URI from a server address. Honors explicit {@code amqp://} or {@code amqps://}
+    * schemes; auto-detects TLS for port 5671.
+    *
+    * @param server The configured AMQP server address
+    * @return The connection URI for the RabbitMQ Java client
+    */
+   static String resolveAmqpUri(String server) {
+      if (server.contains("://")) {
+         return server;
       }
-      if (amqpServer.contains(":5671")) {
-         return "amqps://" + amqpServer;
+      if (server.contains(":5671")) {
+         return "amqps://" + server;
       }
-      return "amqp://" + amqpServer;
+      return "amqp://" + server;
    }
 
    /**

--- a/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
+++ b/minions/async/src/main/java/io/github/microcks/minion/async/producer/AMQPProducerManager.java
@@ -85,7 +85,9 @@ public class AMQPProducerManager {
     */
    protected Connection createConnection() throws Exception {
       ConnectionFactory factory = new ConnectionFactory();
-      factory.setUri("amqp://" + amqpServer);
+      factory.setUri(buildAmqpUri());
+      factory.setConnectionTimeout(15000);
+      factory.setHandshakeTimeout(15000);
 
       if (amqpUsername != null && !amqpUsername.isEmpty() && amqpPassword != null && !amqpPassword.isEmpty()) {
          logger.infof("Connecting to AMQP broker with user '%s'", amqpUsername);
@@ -94,6 +96,22 @@ public class AMQPProducerManager {
       }
       factory.setAutomaticRecoveryEnabled(true);
       return factory.newConnection(amqpClientId);
+   }
+
+   /**
+    * Build the AMQP connection URI from configured server address. Honors explicit {@code amqp://} or {@code amqps://}
+    * schemes; auto-detects TLS for port 5671.
+    *
+    * @return The connection URI for the RabbitMQ Java client
+    */
+   String buildAmqpUri() {
+      if (amqpServer.contains("://")) {
+         return amqpServer;
+      }
+      if (amqpServer.contains(":5671")) {
+         return "amqps://" + amqpServer;
+      }
+      return "amqp://" + amqpServer;
    }
 
    /**

--- a/minions/async/src/main/resources/application.properties
+++ b/minions/async/src/main/resources/application.properties
@@ -64,6 +64,10 @@ mqtt.password=microcks
 amqp.server=localhost:5672
 amqp.username=microcks
 amqp.password=microcks
+# Amazon MQ for RabbitMQ (TLS on port 5671), e.g. via ECS/SSM env override:
+#amqp.server=amqps://xxxx.mq.eu-west-3.amazonaws.com:5671
+# Or host:port form (amqps:// auto-detected for :5671):
+#amqp.server=xxxx.mq.eu-west-3.amazonaws.com:5671
 
 # Access to Google PubSub.
 googlepubsub.project=my-project

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/AMQPProducerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/AMQPProducerManagerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright The Microcks Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.microcks.minion.async.producer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link AMQPProducerManager}.
+ */
+class AMQPProducerManagerTest {
+
+   @Test
+   void shouldBuildDefaultAmqpUri() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "rabbitmq";
+
+      assertEquals("amqp://rabbitmq", manager.buildAmqpUri());
+   }
+
+   @Test
+   void shouldBuildAmqpUriForStandardPort() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "rabbitmq:5672";
+
+      assertEquals("amqp://rabbitmq:5672", manager.buildAmqpUri());
+   }
+
+   @Test
+   void shouldBuildAmqpsUriForTlsPort() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "broker.example.com:5671";
+
+      assertEquals("amqps://broker.example.com:5671", manager.buildAmqpUri());
+   }
+
+   @Test
+   void shouldKeepExplicitAmqpUri() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "amqp://rabbitmq:5672";
+
+      assertEquals("amqp://rabbitmq:5672", manager.buildAmqpUri());
+   }
+
+   @Test
+   void shouldKeepExplicitAmqpsUri() {
+      AMQPProducerManager manager = new AMQPProducerManager();
+      manager.amqpServer = "amqps://broker.example.com:5671";
+
+      assertEquals("amqps://broker.example.com:5671", manager.buildAmqpUri());
+   }
+}

--- a/minions/async/src/test/java/io/github/microcks/minion/async/producer/AMQPProducerManagerTest.java
+++ b/minions/async/src/test/java/io/github/microcks/minion/async/producer/AMQPProducerManagerTest.java
@@ -26,41 +26,27 @@ class AMQPProducerManagerTest {
 
    @Test
    void shouldBuildDefaultAmqpUri() {
-      AMQPProducerManager manager = new AMQPProducerManager();
-      manager.amqpServer = "rabbitmq";
-
-      assertEquals("amqp://rabbitmq", manager.buildAmqpUri());
+      assertEquals("amqp://rabbitmq", AMQPProducerManager.resolveAmqpUri("rabbitmq"));
    }
 
    @Test
    void shouldBuildAmqpUriForStandardPort() {
-      AMQPProducerManager manager = new AMQPProducerManager();
-      manager.amqpServer = "rabbitmq:5672";
-
-      assertEquals("amqp://rabbitmq:5672", manager.buildAmqpUri());
+      assertEquals("amqp://rabbitmq:5672", AMQPProducerManager.resolveAmqpUri("rabbitmq:5672"));
    }
 
    @Test
    void shouldBuildAmqpsUriForTlsPort() {
-      AMQPProducerManager manager = new AMQPProducerManager();
-      manager.amqpServer = "broker.example.com:5671";
-
-      assertEquals("amqps://broker.example.com:5671", manager.buildAmqpUri());
+      assertEquals("amqps://broker.example.com:5671", AMQPProducerManager.resolveAmqpUri("broker.example.com:5671"));
    }
 
    @Test
    void shouldKeepExplicitAmqpUri() {
-      AMQPProducerManager manager = new AMQPProducerManager();
-      manager.amqpServer = "amqp://rabbitmq:5672";
-
-      assertEquals("amqp://rabbitmq:5672", manager.buildAmqpUri());
+      assertEquals("amqp://rabbitmq:5672", AMQPProducerManager.resolveAmqpUri("amqp://rabbitmq:5672"));
    }
 
    @Test
    void shouldKeepExplicitAmqpsUri() {
-      AMQPProducerManager manager = new AMQPProducerManager();
-      manager.amqpServer = "amqps://broker.example.com:5671";
-
-      assertEquals("amqps://broker.example.com:5671", manager.buildAmqpUri());
+      assertEquals("amqps://broker.example.com:5671",
+            AMQPProducerManager.resolveAmqpUri("amqps://broker.example.com:5671"));
    }
 }


### PR DESCRIPTION
## Summary
- Auto-detect `amqps://` for port 5671 and honor explicit `amqp://` / `amqps://` schemes in `AMQPProducerManager`
- Required for Amazon MQ for RabbitMQ (TLS on port 5671)
- Document Helm and ECS configuration paths for `features.async.amqp.url` / `amqp.server`
- Keep fail-fast `@PostConstruct` behavior per maintainer feedback on #2247
Fixes #2233
## Problem
`AMQPProducerManager.createConnection()` hardcoded `amqp://`, preventing TLS connections to Amazon MQ on port 5671.
## Configuration
**Helm (Kubernetes):**
```yaml
features:
  async:
    amqp:
      url: xxxx.mq.eu-west-3.amazonaws.com:5671
      # or: amqps://xxxx.mq.eu-west-3.amazonaws.com:5671
