### PR TITLE
fix(webapp): align httpcore5 version with httpclient5 5.6.3

### DIFF
--- a/minions/async/pom.xml
+++ b/minions/async/pom.xml
@@ -25,6 +25,7 @@
     <quarkus-plugin.version>3.31.4</quarkus-plugin.version>
 
     <apache-httpclient.version>5.6.3</apache-httpclient.version>
+    <apache-httpcore.version>5.4.3</apache-httpcore.version>
     <eclipse-paho.version>1.2.5</eclipse-paho.version>
     <nats.version>2.25.3</nats.version>
     <rabbitmq.version>5.33.1</rabbitmq.version>
@@ -108,6 +109,16 @@
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
       <version>${apache-httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <version>${apache-httpcore.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5-h2</artifactId>
+      <version>${apache-httpcore.version}</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.paho</groupId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -20,6 +20,7 @@
     <snakeyaml.version>2.5</snakeyaml.version>
     <mongo-java-server.version>1.47.0</mongo-java-server.version>
     <apache-httpclient.version>5.6.3</apache-httpclient.version>
+    <apache-httpcore.version>5.4.3</apache-httpcore.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <commons-io.version>2.22.0</commons-io.version>
     <commons-codec.version>1.22.0</commons-codec.version>
@@ -166,6 +167,16 @@
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
       <version>${apache-httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <version>${apache-httpcore.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5-h2</artifactId>
+      <version>${apache-httpcore.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary

- Pin `httpcore5` and `httpcore5-h2` to 5.4.3 in `webapp/pom.xml` and `minions/async/pom.xml`
- Fixes `integration-tests` CI failures introduced after #2270/#2271 bumped `httpclient5` to 5.6.3

Fixes #2295

## Problem

Spring Boot 4.0.7 BOM pins `httpcore5` to 5.3.6, but `httpclient5` 5.6.3 requires `httpcore5` 5.4.3+ (`org.apache.hc.core5.io.IOFunction` is missing in 5.3.6).

## Test plan

- [x] `mvn dependency:tree` shows `httpcore5:5.4.3` (no longer downgraded to 5.3.6)
- [x] `TestControllerIT#testOpenAPITesting` passes locally
- [x] `integration-tests` CI job passes

## AI disclosure

This pull request was prepared with assistance from an AI coding assistant (Cursor). The human author is responsible for reviewing, testing, and understanding the changes.