### PR TITLE
fix(webapp): keep already encoded characters in proxied URLs

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/MockControllerCommons.java
+++ b/webapp/src/main/java/io/github/microcks/web/MockControllerCommons.java
@@ -132,8 +132,8 @@ public class MockControllerCommons {
          externalUrl = externalUrl.replaceFirst("/$", "") + resourcePath;
          if (!externalUrl.contentEquals(request.getRequestURL())) {
             try {
-               return Optional.of(
-                     UriComponentsBuilder.fromUriString(externalUrl).query(request.getQueryString()).build().toUri());
+               return Optional.of(UriComponentsBuilder.fromUriString(externalUrl).query(request.getQueryString())
+                     .build(true).toUri());
             } catch (IllegalArgumentException ex) {
                log.warn("Invalid external URL in the dispatcher - {}", externalUrl);
             }

--- a/webapp/src/test/java/io/github/microcks/web/MockControllerCommonsTest.java
+++ b/webapp/src/test/java/io/github/microcks/web/MockControllerCommonsTest.java
@@ -15,11 +15,23 @@
  */
 package io.github.microcks.web;
 
+import io.github.microcks.domain.Response;
+import io.github.microcks.util.DispatchStyles;
 import io.github.microcks.util.delay.DelaySpec;
+import io.github.microcks.util.dispatcher.JsonMappingException;
+import io.github.microcks.util.dispatcher.ProxyFallbackSpecification;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 
+import java.net.URI;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * This is a test case for the MockControllerCommons class.
@@ -60,5 +72,109 @@ class MockControllerCommonsTest {
       assertNotNull(spec);
       assertEquals(100L, spec.baseValue());
       assertEquals("random", spec.strategyName());
+   }
+
+   @Nested
+   @DisplayName("Proxy URL computation")
+   class ProxyUrlTests {
+
+      private static final String ENCODED_PROXY_URL = "https://backend.example.com/resources/urn%3Aorg%3Aexample%3Aservice%2Fitem-ABC123";
+      private static final String ENCODED_PROXY_PATH = "/resources/urn%3Aorg%3Aexample%3Aservice%2Fitem-ABC123";
+
+      private HttpServletRequest mockRequest(String requestUrl, String queryString) {
+         HttpServletRequest request = mock(HttpServletRequest.class);
+         when(request.getRequestURL()).thenReturn(new StringBuffer(requestUrl));
+         when(request.getQueryString()).thenReturn(queryString);
+         return request;
+      }
+
+      @Test
+      @DisplayName("should keep already encoded characters of a PROXY url")
+      void shouldKeepEncodedCharactersOfProxyUrl() {
+         HttpServletRequest request = mockRequest("http://localhost:8080/rest/encoded-api/1.0.0/resources", null);
+
+         Optional<URI> uri = MockControllerCommons.getProxyUrlIfProxyIsNeeded(DispatchStyles.PROXY, ENCODED_PROXY_URL,
+               "", null, request, null);
+
+         assertTrue(uri.isPresent());
+         assertEquals(ENCODED_PROXY_PATH, uri.get().getRawPath());
+         assertFalse(uri.get().toString().contains("%25"));
+      }
+
+      @Test
+      @DisplayName("should append resource path to PROXY url without encoding it twice")
+      void shouldAppendResourcePathToProxyUrl() {
+         HttpServletRequest request = mockRequest("http://localhost:8080/rest/encoded-api/1.0.0/resources", null);
+
+         Optional<URI> uri = MockControllerCommons.getProxyUrlIfProxyIsNeeded(DispatchStyles.PROXY,
+               "https://backend.example.com/resources/", "/urn%3Aorg%3Aitem-ABC123", null, request, null);
+
+         assertTrue(uri.isPresent());
+         assertEquals("/resources/urn%3Aorg%3Aitem-ABC123", uri.get().getRawPath());
+      }
+
+      @Test
+      @DisplayName("should keep already encoded characters of the query string")
+      void shouldKeepEncodedCharactersOfQueryString() {
+         HttpServletRequest request = mockRequest("http://localhost:8080/rest/encoded-api/1.0.0/invocations",
+               "qualifier=DEFAULT&name=a%20b");
+
+         Optional<URI> uri = MockControllerCommons.getProxyUrlIfProxyIsNeeded(DispatchStyles.PROXY,
+               "https://backend.example.com/invocations", "", null, request, null);
+
+         assertTrue(uri.isPresent());
+         assertEquals("qualifier=DEFAULT&name=a%20b", uri.get().getRawQuery());
+      }
+
+      @Test
+      @DisplayName("should keep already encoded characters of a PROXY_FALLBACK url")
+      void shouldKeepEncodedCharactersOfProxyFallbackUrl() throws JsonMappingException {
+         HttpServletRequest request = mockRequest("http://localhost:8080/rest/encoded-api/1.0.0/resources", null);
+         ProxyFallbackSpecification proxyFallback = ProxyFallbackSpecification
+               .buildFromJsonString("{\"dispatcher\": \"URI_PARTS\", \"dispatcherRules\": \"name\", \"proxyUrl\": \""
+                     + ENCODED_PROXY_URL + "\"}");
+
+         Optional<URI> uri = MockControllerCommons.getProxyUrlIfProxyIsNeeded(DispatchStyles.PROXY_FALLBACK, "name", "",
+               proxyFallback, request, null);
+
+         assertTrue(uri.isPresent());
+         assertEquals(ENCODED_PROXY_PATH, uri.get().getRawPath());
+      }
+
+      @Test
+      @DisplayName("should not proxy when a response was found with PROXY_FALLBACK")
+      void shouldNotProxyWhenResponseFoundWithProxyFallback() throws JsonMappingException {
+         HttpServletRequest request = mockRequest("http://localhost:8080/rest/encoded-api/1.0.0/resources", null);
+         ProxyFallbackSpecification proxyFallback = ProxyFallbackSpecification
+               .buildFromJsonString("{\"dispatcher\": \"URI_PARTS\", \"dispatcherRules\": \"name\", \"proxyUrl\": \""
+                     + ENCODED_PROXY_URL + "\"}");
+
+         Optional<URI> uri = MockControllerCommons.getProxyUrlIfProxyIsNeeded(DispatchStyles.PROXY_FALLBACK, "name", "",
+               proxyFallback, request, new Response());
+
+         assertTrue(uri.isEmpty());
+      }
+
+      @Test
+      @DisplayName("should not proxy when dispatcher is not a proxy one")
+      void shouldNotProxyWhenNoProxyDispatcher() {
+         HttpServletRequest request = mockRequest("http://localhost:8080/rest/encoded-api/1.0.0/resources", null);
+
+         Optional<URI> uri = MockControllerCommons.getProxyUrlIfProxyIsNeeded(DispatchStyles.URI_PARTS, "name", "",
+               null, request, null);
+
+         assertTrue(uri.isEmpty());
+      }
+
+      @Test
+      @DisplayName("should not proxy when external url equals incoming request url")
+      void shouldNotProxyWhenExternalUrlEqualsRequestUrl() {
+         HttpServletRequest request = mockRequest(ENCODED_PROXY_URL, null);
+
+         Optional<URI> uri = MockControllerCommons.getProxyUrlIfProxyIsNeeded(DispatchStyles.PROXY, ENCODED_PROXY_URL,
+               "", null, request, null);
+
+         assertTrue(uri.isEmpty());
+      }
    }
 }

--- a/webapp/src/test/java/io/github/microcks/web/RestInvocationProcessorTest.java
+++ b/webapp/src/test/java/io/github/microcks/web/RestInvocationProcessorTest.java
@@ -30,12 +30,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.net.URI;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -249,6 +251,32 @@ class RestInvocationProcessorTest {
          assertEquals(HttpStatus.OK, result.status());
          assertArrayEquals("from proxy".getBytes(), result.content());
          verify(proxyService).callExternal(any(), eq(HttpMethod.GET), any(), isNull());
+      }
+
+      @Test
+      @DisplayName("should forward an already encoded proxy url as-is")
+      void shouldProxyRequestWithEncodedProxyUrl() {
+         // Arrange
+         var context = createMockContext("GET /invocations", "GET", "/invocations");
+         context.operation().setDispatcher("PROXY");
+         context.operation().setDispatcherRules(
+               "https://backend.example.com/runtimes/urn%3Aorg%3Aexample%3Aservice%2Fruntime%2Fexample-ABC123");
+
+         var proxyResponse = new ResponseEntity<>("from proxy".getBytes(), HttpStatus.OK);
+         when(request.getRequestURL()).thenReturn(new StringBuffer("http://localhost/invocations"));
+         when(request.getQueryString()).thenReturn("qualifier=DEFAULT");
+         when(proxyService.callExternal(any(), eq(HttpMethod.GET), any(), isNull())).thenReturn(proxyResponse);
+
+         // Act
+         var result = processor.processInvocation(context, System.currentTimeMillis(), null, null, Map.of(), request);
+
+         // Assert
+         assertEquals(HttpStatus.OK, result.status());
+         var forwardedUri = ArgumentCaptor.forClass(URI.class);
+         verify(proxyService).callExternal(forwardedUri.capture(), eq(HttpMethod.GET), any(), isNull());
+         assertEquals("/runtimes/urn%3Aorg%3Aexample%3Aservice%2Fruntime%2Fexample-ABC123/invocations",
+               forwardedUri.getValue().getRawPath());
+         assertEquals("qualifier=DEFAULT", forwardedUri.getValue().getRawQuery());
       }
    }
 }


### PR DESCRIPTION
## Description

Fixes #2291

With the `PROXY` or `PROXY_FALLBACK` dispatcher, a `proxyUrl` that already contains percent-encoded characters was
encoded a second time on the outbound request: `%3A` became `%253A`, `%2F` became `%252F`, and the query string had the same problem. Backends whose resource identifier must stay encoded inside a single path segment then resolve a
non-existent resource and return `404`.

`MockControllerCommons.getProxyUrlIfProxyIsNeeded()` built the URI with `UriComponentsBuilder.build()`, which marks the components as *not* encoded, so `toUri()` uses the multi-args `java.net.URI` constructor that quotes `%` again.

## Changes

- `MockControllerCommons.java`: build with `build(true)` the `proxyUrl`, the incoming resource path and the query string are already URI encoded, so they are assembled as-is. 

Fixes `PROXY` and `PROXY_FALLBACK` for the REST, SOAP and GraphQL invocation processors at once. Proxy URLs that are not valid URI syntax now hit the existing `Invalid external URL in the dispatcher` branch instead of being silently encoded.

## Tests

- `MockControllerCommonsTest.ProxyUrlTests` (7 tests): encoded `PROXY` url, resource path appending, encoded query
  string, encoded `PROXY_FALLBACK` url and the three no-proxy cases (response found, no proxy dispatcher, external url
  equal to the incoming one).
- `RestInvocationProcessorTest.shouldProxyRequestWithEncodedProxyUrl`: asserts the `URI` handed to
  `ProxyService.callExternal()` keeps its raw path and raw query.

```bash
mvn -pl webapp -am -Dtest=MockControllerCommonsTest,RestInvocationProcessorTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Prepared with the assistance of an AI coding agent. Reviewed, tested and owned by the human author.
